### PR TITLE
Add option to trim .\ prefix from directory and filename completions

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -90,6 +90,11 @@ namespace PSConsoleUtilities
         public const bool DefaultShowToolTips = false;
 
         /// <summary>
+        /// Trim "./" prefix when auto completing directories or files.
+        /// </summary>
+        public const bool DefaultTrimDotSlash = false;
+
+        /// <summary>
         /// When ringing the bell, what frequency do we use?
         /// </summary>
         public const int DefaultDingTone = 1221;
@@ -124,6 +129,7 @@ namespace PSConsoleUtilities
             MaximumKillRingCount = DefaultMaximumKillRingCount;
             HistorySearchCursorMovesToEnd = DefaultHistorySearchCursorMovesToEnd;
             ShowToolTips = DefaultShowToolTips;
+            TrimDotSlash = DefaultTrimDotSlash;
             DingDuration = DefaultDingDuration;
             DingTone = DefaultDingTone;
             BellStyle = DefaultBellStyle;
@@ -201,6 +207,7 @@ namespace PSConsoleUtilities
         public int MaximumKillRingCount { get; set; }
         public bool HistorySearchCursorMovesToEnd { get; set; }
         public bool ShowToolTips { get; set; }
+        public bool TrimDotSlash { get; set; }
         public int DingTone { get; set; }
         public int CompletionQueryItems { get; set; }
         public string WordDelimiters { get; set; }
@@ -466,6 +473,14 @@ namespace PSConsoleUtilities
             set { _showToolTips = value; }
         }
         internal SwitchParameter? _showToolTips;
+
+        [Parameter(ParameterSetName = "OptionsSet")]
+        public SwitchParameter TrimDotSlash
+        {
+            get { return _trimDotSlash.GetValueOrDefault(); }
+            set { _trimDotSlash = value; }
+        }
+        internal SwitchParameter? _trimDotSlash;
 
         [Parameter(ParameterSetName = "OptionsSet")]
         public int ExtraPromptLineCount

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Text;
+using System.Text.RegularExpressions;
 using PSConsoleUtilities.Internal;
 
 namespace PSConsoleUtilities
@@ -244,10 +245,18 @@ namespace PSConsoleUtilities
             _tabCommandCount += 1;
         }
 
+        private static Regex dotSlash = new Regex(@"\.\\(.*)$", RegexOptions.Compiled);
+
         private void DoReplacementForCompletion(CompletionResult completionResult, CommandCompletion completions)
         {
             var replacementText = completionResult.CompletionText;
             int cursorAdjustment = 0;
+
+            if ((completionResult.ResultType == CompletionResultType.ProviderContainer || completionResult.ResultType == CompletionResultType.ProviderItem)
+                && _singleton._options.TrimDotSlash && !dotSlash.IsMatch(_buffer.ToString()))
+            {
+                replacementText = dotSlash.Replace(replacementText, "$1");
+            }
             if (completionResult.ResultType == CompletionResultType.ProviderContainer)
             {
                 replacementText = GetReplacementTextForDirectory(replacementText, ref cursorAdjustment);

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -109,6 +109,10 @@ namespace PSConsoleUtilities
             {
                 Options.ShowToolTips = options.ShowToolTips;
             }
+            if (options._trimDotSlash.HasValue)
+            {
+                Options.TrimDotSlash = options.TrimDotSlash;
+            }
             if (options._extraPromptLineCount.HasValue)
             {
                 Options.ExtraPromptLineCount = options.ExtraPromptLineCount;


### PR DESCRIPTION
".\" being prepended to directory and file names was causing trouble for a lot of the msys utils that I use from powershell. I should wrap them all with scripts that use cygpath but for the majority that just take a single file or directory name this option to trim the ".\" from completion was more convenient.

It only trims if you didn't explicitly type .\, e.g:
![trimdotslash](https://cloud.githubusercontent.com/assets/1146032/6933955/38fb09b8-d7e2-11e4-901d-26cb25c206ef.gif)
