### PR TITLE
Personal/danthom/screen capture usability

### DIFF
--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -537,6 +537,11 @@ namespace Microsoft.PowerShell
 
         public void WriteBufferLines(CHAR_INFO[] buffer, ref int top)
         {
+            WriteBufferLines(buffer, ref top, true);
+        }
+
+        public void WriteBufferLines(CHAR_INFO[] buffer, ref int top, bool ensureBottomLineVisible)
+        {
             var handle = NativeMethods.GetStdHandle((uint) StandardHandleId.Output);
 
             int bufferWidth = Console.BufferWidth;
@@ -565,7 +570,8 @@ namespace Microsoft.PowerShell
                                              bufferSize, bufferCoord, ref writeRegion);
 
             // Now make sure the bottom line is visible
-            if (bottom >= (Console.WindowTop + Console.WindowHeight))
+            if (ensureBottomLineVisible &&
+                (bottom >= (Console.WindowTop + Console.WindowHeight)))
             {
                 Console.CursorTop = bottom;
             }

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -47,6 +47,7 @@ namespace Microsoft.PowerShell
             void WriteLine(string s);
             void Write(string s);
             void WriteBufferLines(CHAR_INFO[] buffer, ref int top);
+            void WriteBufferLines(CHAR_INFO[] buffer, ref int top, bool ensureBottomLineVisible);
             void ScrollBuffer(int lines);
             CHAR_INFO[] ReadBufferLines(int top, int count);
         }

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -975,6 +975,19 @@ namespace Microsoft.PowerShell
             var console = _singleton._console;
             var newTop = coordinates.Y - console.WindowHeight + 1;
 
+            // If the cursor is already visible, and we're on the first
+            // page-worth of the buffer, then just scroll to the top (we can't
+            // scroll to before the beginning of the buffer).
+            //
+            // Note that we don't want to just return, because the window may
+            // have been scrolled way past the end of the content, so we really
+            // do need to set the new window top to 0 to bring it back into
+            // view.
+            if (newTop < 0)
+            {
+                newTop = 0;
+            }
+
             // But if the cursor won't be visible, make sure it is.
             if (newTop > console.CursorTop)
             {

--- a/UnitTestPSReadLine/UnitTestReadLine.cs
+++ b/UnitTestPSReadLine/UnitTestReadLine.cs
@@ -192,6 +192,11 @@ namespace UnitTestPSReadLine
 
         public void WriteBufferLines(CHAR_INFO[] bufferToWrite, ref int top)
         {
+            WriteBufferLines(bufferToWrite, ref top, true);
+        }
+
+        public void WriteBufferLines(CHAR_INFO[] bufferToWrite, ref int top, bool ensureBottomLineVisible)
+        {
             var startPos = top * BufferWidth;
             for (int i = 0; i < bufferToWrite.Length; i++)
             {


### PR DESCRIPTION
This change improves the usability of the CaptureScreen function, especially when selecting more than a page-worth of text, by scrolling the buffer to keep the selection head on the screen. Also fixes a minor ScrollDisplayToCursor bug.