### PR TITLE
Addressing Feedback

### DIFF
--- a/PSReadLine/Completion.vi.cs
+++ b/PSReadLine/Completion.vi.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿/********************************************************************++
+Copyright (c) Microsoft Corporation.  All rights reserved.
+--********************************************************************/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿/********************************************************************++
+Copyright (c) Microsoft Corporation.  All rights reserved.
+--********************************************************************/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -36,7 +40,6 @@ namespace Microsoft.PowerShell
         }
 
         private int _normalCursorSize = 10;
-        private ConsoleColor _normalBackground = ConsoleColor.Black;
 
         private static KeyHandler MakeViKeyHandler(Action<ConsoleKeyInfo?, object> action, string briefDescription, string longDescription = null)
         {
@@ -196,7 +199,7 @@ namespace Microsoft.PowerShell
                 { Keys.Pipe,            MakeViKeyHandler(GotoColumn,           "GotoColumn") },
                 { Keys.Uphat,           MakeViKeyHandler(GotoFirstNonBlankOfLine, "GotoFirstNonBlankOfLine") },
                 { Keys.Tilde,           MakeViKeyHandler(InvertCase,           "InvertCase") },
-                { Keys.Slash,           MakeViKeyHandler(SearchBackward,       "SearchBackward") },
+                { Keys.Slash,           MakeViKeyHandler(ViSearchHistoryBackward,       "SearchBackward") },
                 { Keys.CtrlR,           MakeViKeyHandler(SearchCharBackward,   "SearchCharBackward") },
                 { Keys.Question,        MakeViKeyHandler(SearchForward,        "SearchForward") },
                 { Keys.CtrlS,           MakeViKeyHandler(SearchForward,        "SearchForward") },
@@ -286,7 +289,6 @@ namespace Microsoft.PowerShell
             _viCmdChordTable[Keys.Y] = _viChordYTable;
 
             _normalCursorSize = _console.CursorSize;
-            _normalBackground = _console.BackgroundColor;
         }
     }
 }

--- a/PSReadLine/Movement.vi.cs
+++ b/PSReadLine/Movement.vi.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿/********************************************************************++
+Copyright (c) Microsoft Corporation.  All rights reserved.
+--********************************************************************/
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -990,15 +990,6 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Starts a new seach backward in the history..
-        /// </summary>
-        internal static string SearchBackwardDescription {
-            get {
-                return ResourceManager.GetString("SearchBackwardDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Move to the previous occurance of the specified character..
         /// </summary>
         internal static string SearchCharBackwardDescription {
@@ -1635,6 +1626,15 @@ namespace Microsoft.PowerShell {
         internal static string ViReplaceWordDescription {
             get {
                 return ResourceManager.GetString("ViReplaceWordDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Starts a new seach backward in the history..
+        /// </summary>
+        internal static string ViSearchHistoryBackwardDescription {
+            get {
+                return ResourceManager.GetString("ViSearchHistoryBackwardDescription", resourceCulture);
             }
         }
         

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -546,7 +546,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
   <data name="InsertCharacterDescription" xml:space="preserve">
     <value>Delete the current character and insert the next character.</value>
   </data>
-  <data name="SearchBackwardDescription" xml:space="preserve">
+  <data name="ViSearchHistoryBackwardDescription" xml:space="preserve">
     <value>Starts a new seach backward in the history.</value>
   </data>
   <data name="ViTransposeCharsDescription" xml:space="preserve">

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿/********************************************************************++
+Copyright (c) Microsoft Corporation.  All rights reserved.
+--********************************************************************/
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -231,15 +235,6 @@ namespace Microsoft.PowerShell
         public static void ViExit(ConsoleKeyInfo? key = null, object arg = null)
         {
             throw new ExitException();
-        }
-
-        /// <summary>
-        /// Insert the next key entered.
-        /// </summary>
-        private static void InsertCharacter(object arg = null)
-        {
-            ConsoleKeyInfo secondKey = ReadKey();
-            _singleton.ProcessOneKey(secondKey, _viInsKeyMap, ignoreIfNoAction: false, arg: arg);
         }
 
         /// <summary>
@@ -840,7 +835,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Prompts for a search string and initiates search upon AcceptLine.
         /// </summary>
-        public static void SearchBackward(ConsoleKeyInfo? key = null, object arg = null)
+        public static void ViSearchHistoryBackward(ConsoleKeyInfo? key = null, object arg = null)
         {
             if (!key.HasValue || char.IsControl(key.Value.KeyChar))
             {

--- a/PSReadLine/Replace.vi.cs
+++ b/PSReadLine/Replace.vi.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿/********************************************************************++
+Copyright (c) Microsoft Corporation.  All rights reserved.
+--********************************************************************/
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/PSReadLine/UndoRedo.vi.cs
+++ b/PSReadLine/UndoRedo.vi.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿/********************************************************************++
+Copyright (c) Microsoft Corporation.  All rights reserved.
+--********************************************************************/
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/PSReadLine/VisualEditing.vi.cs
+++ b/PSReadLine/VisualEditing.vi.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿/********************************************************************++
+Copyright (c) Microsoft Corporation.  All rights reserved.
+--********************************************************************/
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/PSReadLine/Words.vi.cs
+++ b/PSReadLine/Words.vi.cs
@@ -1,3 +1,7 @@
+/********************************************************************++
+Copyright (c) Microsoft Corporation.  All rights reserved.
+--********************************************************************/
+
 using System.Collections.Generic;
 using System.Management.Automation.Language;
 

--- a/PSReadLine/YankPaste.vi.cs
+++ b/PSReadLine/YankPaste.vi.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿/********************************************************************++
+Copyright (c) Microsoft Corporation.  All rights reserved.
+--********************************************************************/
+
+using System;
 using System.Collections.Generic;
 using System.Management.Automation.Language;
 using System.Windows;


### PR DESCRIPTION
Addressed this feedback:
1  _normalBackground (keybindings.vi.cs) unused
2  copyright notice in *.vi.cs files?
3  ReadLine.vi.cs - InsertCharacter unreferenced
4  SearchBackward - change fn name to ViSearchHistoryBackward?

Please let me know which editor you use to edit PSReadline.dll-help.xml.  The editor I choose (PS Cmdlet Help Editor - https://pscmdlethelpeditor.codeplex.com/) does not appear to be the same as what  you are using.
