### PR TITLE
Add help output for the module as PSReadLine.txt artifact

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,9 @@ before_build:
       nuget install platyPS -source https://www.powershellgallery.com/api/v2 -outputDirectory . -ExcludeVersion
       Import-Module .\platyPS
       .\MakeRelease.ps1
+      # Store help output for the module as PSReadline.txt artifact
+      Get-PlatyPSTextHelpFromMaml .\PSReadline\en-US\PSReadline.dll-help.xml -TextOutputPath PSReadline.txt
 
 artifacts:
   - path: PSReadline.zip
+  - path: PSReadline.txt


### PR DESCRIPTION
I published platyPS v 0.3.0 which should fix Update-Help interactive problem https://ci.appveyor.com/project/lzybkr/psreadline/build/1.0.14
