### PR TITLE
SamplePSReadlineProfile::SmartInsertQuote: don't put double quotes wh…

### DIFF
--- a/PSReadLine/SamplePSReadlineProfile.ps1
+++ b/PSReadLine/SamplePSReadlineProfile.ps1
@@ -127,7 +127,12 @@ Set-PSReadlineKeyHandler -Key '"',"'" `
     $cursor = $null
     [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
 
-    if ($line[$cursor] -eq $key.KeyChar) {
+    $quoteNumber = Select-String -InputObject $line -Pattern $key.KeyChar -AllMatches
+    if ($quoteNumber.Matches.Count % 2 -eq 1) {
+        # Oneven amount of quotes, put just one quote
+        [PSConsoleUtilities.PSConsoleReadline]::Insert($key.KeyChar)
+    }
+    elseif ($line[$cursor] -eq $key.KeyChar) {
         # Just move the cursor
         [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($cursor + 1)
     }


### PR DESCRIPTION
…en there is an oneven amount of them on the current line

I always found this annoying... not sure if it is the case for most peoples workflow...
