### PR TITLE
removed reference to PSReadline.dll-help.xml in csproj file

### DIFF
--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -113,9 +113,6 @@
     <None Include="en-US\about_PSReadline.help.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="en-US\PSReadline.dll-help.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="Changes.txt">


### PR DESCRIPTION
enables building without error in VS
