### PR TITLE
Import PowerShell changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ x64/
 *.vspscc
 *.vssscc
 .builds
+project.lock.json
 
 # Visual C++ cache files
 ipch/

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="powershell-core" value="https://powershell.myget.org/F/powershell-core/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -523,7 +523,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void InsertLineAbove(ConsoleKeyInfo? key = null, object arg = null)
         {
-            // Move the current postion to the beginning of the current line and only the current line.
+            // Move the current position to the beginning of the current line and only the current line.
             if (_singleton.LineIsMultiLine())
             {
                 int i = Math.Max(0, _singleton._current - 1);
@@ -554,7 +554,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void InsertLineBelow(ConsoleKeyInfo? key = null, object arg = null)
         {
-            // Move the current postion to the end of the current line and only the current line.
+            // Move the current position to the end of the current line and only the current line.
             if (_singleton.LineIsMultiLine())
             {
                 int i = _singleton._current;

--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -428,8 +428,8 @@ namespace Microsoft.PowerShell
                 {
                 // The following are debugger commands that should be accepted if we're debugging
                 // because the console host will interpret these commands directly.
-                case 's': case 'v': case 'o': case 'c': case 'q': case'k': case 'l':
-                case 'S': case 'V': case 'O': case 'C': case 'Q': case'K': case 'L':
+                case 's': case 'v': case 'o': case 'c': case 'q': case 'k': case 'l':
+                case 'S': case 'V': case 'O': case 'C': case 'Q': case 'K': case 'L':
                 case '?': case 'h': case 'H':
                     // Ideally we would check $PSDebugContext, but it is set at function
                     // scope, and because we're in a module, we can't find that variable

--- a/PSReadLine/Changes.txt
+++ b/PSReadLine/Changes.txt
@@ -154,7 +154,7 @@ New features:
 * SamplePSReadlineProfile.ps1 added with examples of custom key bindings
 * Word movement takes DigitArgument
 * HistoryNoDuplicates now works a little differently
-    - Dupicates are saved (it was a dubious memory optimization anyway)
+    - Duplicates are saved (it was a dubious memory optimization anyway)
     - Recall will recall the most recently executed item instead of the first
 * When at the last word, NextWord/ForwardWord now move to the end of line instead
   of the last character of the word.
@@ -227,7 +227,7 @@ Bugs fixed:
 * Ctrl+R with long search lines no longer causes big problems
 
 Behavior change:
-* Word functions now use delimiters.  The previous behavior is availble 
+* Word functions now use delimiters.  The previous behavior is available 
   via a Shell*Word function, e.g. instead of KillWord, use ShellKillWord.
 
 ### Version 1.0.0.4

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -169,40 +169,39 @@ namespace Microsoft.PowerShell
             WordDelimiters = DefaultWordDelimiters;
             HistorySearchCaseSensitive = DefaultHistorySearchCaseSensitive;
             HistorySaveStyle = DefaultHistorySaveStyle;
+
+            string historyFileName = hostName + "_history.txt";
 #if CORECLR
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))   // MS Windows
             {
                 HistorySavePath = System.IO.Path.Combine(Environment.GetEnvironmentVariable("APPDATA"),
                                                          @"Microsoft\Windows\PowerShell\PSReadline\",
-                                                         hostName + "_history.txt");
+                                                         historyFileName);
             }
-
             else
             {
-                //PSReadline does not have access to Utils.CorePSPlatform. Must set PSReadline path seperately                
-                string historypath = System.Environment.GetEnvironmentVariable("XDG_DATA_HOME");
-                    
-                if (!String.IsNullOrEmpty(historypath))
-                {
-                    historypath = System.IO.Path.Combine(historypath, "powershell", "PSReadLine", hostName + "_history.txt");
-                    HistorySavePath = historypath; 
-                }
+                // PSReadline does not have access to Utils.CorePSPlatform. Must set PSReadline path separately
+                string historyPath = System.Environment.GetEnvironmentVariable("XDG_DATA_HOME");
 
+                if (!String.IsNullOrEmpty(historyPath))
+                {
+                    historyPath = System.IO.Path.Combine(historyPath, "powershell", "PSReadLine", historyFileName);
+                    HistorySavePath = historyPath;
+                }
                 else
                 {
-                    //While a module, history save path goes into the larger .local/share/powershell folder
-                    HistorySavePath = System.IO.Path.Combine(
-                                                             Environment.GetEnvironmentVariable("HOME"), 
+                    // History is data, so it goes into .local/share/powershell folder
+                    HistorySavePath = System.IO.Path.Combine(Environment.GetEnvironmentVariable("HOME"),
                                                              ".local",
                                                              "share",
-                                                             "powershell",  
+                                                             "powershell",
                                                              "PSReadLine",
-                                                             hostName + "_history.txt");
+                                                             historyFileName);
                 }
             }
 #else
-                HistorySavePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
-                + @"\Microsoft\Windows\PowerShell\PSReadline\" + hostName + "_history.txt";
+            HistorySavePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+                + @"\Microsoft\Windows\PowerShell\PSReadline\" + historyFileName;
 #endif
             CommandValidationHandler = null;
             CommandsToValidateScriptBlockArguments = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -221,7 +220,7 @@ namespace Microsoft.PowerShell
                 "Where-Object", "?", "where",
             };
         }
-        
+
         public EditMode EditMode { get; set; }
 
         public string ContinuationPrompt { get; set; }

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -190,11 +190,12 @@ namespace Microsoft.PowerShell
 
                 else
                 {
+                    //While a module, history save path goes into the larger .local/share/powershell folder
                     HistorySavePath = System.IO.Path.Combine(
                                                              Environment.GetEnvironmentVariable("HOME"), 
-                                                             ".cache",
-                                                             "powershell",
-                                                             "PSReadLine",
+                                                             ".local",
+                                                             "share",
+                                                             "powershell",                                                             
                                                              hostName + "_history.txt");
                 }
             }

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -176,6 +176,7 @@ namespace Microsoft.PowerShell
                                                          @"\Microsoft\Windows\PowerShell\PSReadline\",
                                                          hostName + "_history.txt");
             }
+
             else
             {
                 //PSReadline does not have access to Utils.CorePSPlatform. Must set PSReadline path seperately                
@@ -186,13 +187,20 @@ namespace Microsoft.PowerShell
                         modulepath = System.IO.Path.Combine(
                                                              Environment.GetEnvironmentVariable("HOME"), 
                                                              ".config/powershell/modules");
-                }
                         
-                HistorySavePath = System.IO.Path.Combine(
+                        HistorySavePath = System.IO.Path.Combine(
                                                          Environment.GetEnvironmentVariable("HOME"), 
                                                          modulepath,
                                                          "PSReadLine",
                                                          hostName + "_history.txt");
+                }
+                 
+                else {
+                    
+                    HistorySavePath = modulepath; 
+                   
+                }
+
                             
                 }
     #else

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -178,14 +178,25 @@ namespace Microsoft.PowerShell
             }
             else
             {
+                //PSReadline does not have access to Utils.CorePSPlatform. Must set PSReadline path seperately                
+                string modulepath = System.Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+               
+                if (String.IsNullOrEmpty(modulepath))
+                {
+                        modulepath = System.IO.Path.Combine(
+                                                             Environment.GetEnvironmentVariable("HOME"), 
+                                                             ".config/powershell/modules");
+                }
+                        
                 HistorySavePath = System.IO.Path.Combine(
                                                          Environment.GetEnvironmentVariable("HOME"), 
-                                                         ".powershell",
+                                                         modulepath,
                                                          "PSReadLine",
                                                          hostName + "_history.txt");
-            }
-#else
-            HistorySavePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+                            
+                }
+    #else
+                HistorySavePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
                 + @"\Microsoft\Windows\PowerShell\PSReadline\" + hostName + "_history.txt";
 #endif
             CommandValidationHandler = null;
@@ -205,7 +216,7 @@ namespace Microsoft.PowerShell
                 "Where-Object", "?", "where",
             };
         }
-
+        
         public EditMode EditMode { get; set; }
 
         public string ContinuationPrompt { get; set; }

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -180,23 +180,23 @@ namespace Microsoft.PowerShell
             else
             {
                 //PSReadline does not have access to Utils.CorePSPlatform. Must set PSReadline path seperately                
-                string modulepath = System.Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+                string historypath = System.Environment.GetEnvironmentVariable("XDG_DATA_HOME");
                     
-                if (!String.IsNullOrEmpty(modulepath))
+                if (!String.IsNullOrEmpty(historypath))
                 {
-                    modulepath = System.IO.Path.Combine(modulepath, "powershell");
-                    HistorySavePath = modulepath; 
+                    historypath = System.IO.Path.Combine(historypath, "powershell");
+                    HistorySavePath = historypath; 
                 }
 
                 else
                 {
-                    modulepath = System.IO.Path.Combine(
+                    historypath = System.IO.Path.Combine(
                                                         Environment.GetEnvironmentVariable("HOME"), 
-                                                        ".config/powershell/modules");
+                                                        ".local/share/powershell/modules");
                         
                     HistorySavePath = System.IO.Path.Combine(
                                                              Environment.GetEnvironmentVariable("HOME"), 
-                                                             modulepath,
+                                                             historypath,
                                                              "PSReadLine",
                                                              hostName + "_history.txt");
                 }

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -10,6 +10,9 @@ using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Reflection;
 using System.Linq;
+#if CORECLR
+using System.Runtime.InteropServices;
+#endif
 
 namespace Microsoft.PowerShell
 {
@@ -82,6 +85,7 @@ namespace Microsoft.PowerShell
         public const ConsoleColor DefaultEmphasisForegroundColor  = ConsoleColor.Cyan;
         public const ConsoleColor DefaultErrorForegroundColor     = ConsoleColor.Red;
 
+
         public const EditMode DefaultEditMode = EditMode.Windows;
 
         public const string DefaultContinuationPrompt = ">> ";
@@ -151,8 +155,24 @@ namespace Microsoft.PowerShell
             WordDelimiters = DefaultWordDelimiters;
             HistorySearchCaseSensitive = DefaultHistorySearchCaseSensitive;
             HistorySaveStyle = DefaultHistorySaveStyle;
+#if CORECLR
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))   // MS Windows
+            {
+                HistorySavePath = System.IO.Path.Combine(Environment.ExpandEnvironmentVariables("%AppData%"),
+                                                         @"\Microsoft\Windows\PowerShell\PSReadline\",
+                                                         hostName + "_history.txt");
+            }
+            else
+            {
+                HistorySavePath = System.IO.Path.Combine(
+                                                         Environment.GetEnvironmentVariable("HOME"), 
+                                                         ".psreadline", 
+                                                         hostName + "_history.txt");
+            }
+#else
             HistorySavePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
                 + @"\Microsoft\Windows\PowerShell\PSReadline\" + hostName + "_history.txt";
+#endif
             CommandValidationHandler = null;
             CommandsToValidateScriptBlockArguments = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -346,7 +366,9 @@ namespace Microsoft.PowerShell
     [OutputType(typeof(PSConsoleReadlineOptions))]
     public class GetPSReadlineOption : PSCmdlet
     {
+#if !CORECLR
         [ExcludeFromCodeCoverage]
+#endif
         protected override void EndProcessing()
         {
             WriteObject(PSConsoleReadLine.GetOptions());
@@ -589,7 +611,9 @@ namespace Microsoft.PowerShell
         }
         internal ConsoleColor? _backgroundColor;
 
+#if !CORECLR
         [ExcludeFromCodeCoverage]
+#endif
         protected override void EndProcessing()
         {
             PSConsoleReadLine.SetOptions(this);
@@ -607,7 +631,9 @@ namespace Microsoft.PowerShell
         [Parameter]
         public ViMode ViMode { get; set; }
 
+#if !CORECLR
         [ExcludeFromCodeCoverage]
+#endif
         protected IDisposable UseRequestedDispatchTables()
         {
             bool inViMode = PSConsoleReadLine.GetOptions().EditMode == EditMode.Vi;
@@ -650,7 +676,9 @@ namespace Microsoft.PowerShell
         private const string FunctionParameter = "Function";
         private const string FunctionParameterSet = "Function";
 
+#if !CORECLR
         [ExcludeFromCodeCoverage]
+#endif
         protected override void EndProcessing()
         {
             using (UseRequestedDispatchTables())
@@ -658,9 +686,16 @@ namespace Microsoft.PowerShell
                 if (ParameterSetName.Equals(FunctionParameterSet))
                 {
                     var function = (string)_dynamicParameters.Value[FunctionParameter].Value;
+#if CORECLR
+                    MethodInfo mi = typeof (PSConsoleReadLine).GetMethod(function);
+                    var keyHandler = (Action<ConsoleKeyInfo?, object>)
+                        mi.CreateDelegate(typeof (Action<ConsoleKeyInfo?, object>));
+                            
+#else
                     var keyHandler = (Action<ConsoleKeyInfo?, object>)
                         Delegate.CreateDelegate(typeof (Action<ConsoleKeyInfo?, object>),
                             typeof (PSConsoleReadLine).GetMethod(function));
+#endif
                     BriefDescription = function;
                     PSConsoleReadLine.SetKeyHandler(Chord, keyHandler, BriefDescription, Description);
                 }
@@ -728,7 +763,9 @@ namespace Microsoft.PowerShell
         }
         private SwitchParameter? _unbound;
 
+#if !CORECLR
         [ExcludeFromCodeCoverage]
+#endif
         protected override void EndProcessing()
         {
             bool bound = true;
@@ -755,7 +792,9 @@ namespace Microsoft.PowerShell
     [Cmdlet("Remove", "PSReadlineKeyHandler", HelpUri = "http://go.microsoft.com/fwlink/?LinkId=528809")]
     public class RemoveKeyHandlerCommand : ChangePSReadlineKeyHandlerCommandBase
     {
+#if !CORECLR
         [ExcludeFromCodeCoverage]
+#endif
         protected override void EndProcessing()
         {
             using (UseRequestedDispatchTables())

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -180,7 +180,8 @@ namespace Microsoft.PowerShell
             {
                 HistorySavePath = System.IO.Path.Combine(
                                                          Environment.GetEnvironmentVariable("HOME"), 
-                                                         ".psreadline", 
+                                                         ".powershell",
+                                                         "PSReadLine",
                                                          hostName + "_history.txt");
             }
 #else

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -172,8 +172,8 @@ namespace Microsoft.PowerShell
 #if CORECLR
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))   // MS Windows
             {
-                HistorySavePath = System.IO.Path.Combine(Environment.ExpandEnvironmentVariables("%AppData%"),
-                                                         @"\Microsoft\Windows\PowerShell\PSReadline\",
+                HistorySavePath = System.IO.Path.Combine(Environment.GetEnvironmentVariable("APPDATA"),
+                                                         @"Microsoft\Windows\PowerShell\PSReadline\",
                                                          hostName + "_history.txt");
             }
 

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -180,23 +180,20 @@ namespace Microsoft.PowerShell
             else
             {
                 //PSReadline does not have access to Utils.CorePSPlatform. Must set PSReadline path seperately                
-                string historypath = System.Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+                string historypath = System.Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
                     
                 if (!String.IsNullOrEmpty(historypath))
                 {
-                    historypath = System.IO.Path.Combine(historypath, "powershell");
+                    historypath = System.IO.Path.Combine(historypath, "powershell", "PSReadLine", hostName + "_history.txt");
                     HistorySavePath = historypath; 
                 }
 
                 else
                 {
-                    historypath = System.IO.Path.Combine(
-                                                        Environment.GetEnvironmentVariable("HOME"), 
-                                                        ".local/share/powershell/modules");
-                        
                     HistorySavePath = System.IO.Path.Combine(
                                                              Environment.GetEnvironmentVariable("HOME"), 
-                                                             historypath,
+                                                             ".cache",
+                                                             "powershell",
                                                              "PSReadLine",
                                                              hostName + "_history.txt");
                 }

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -180,7 +180,7 @@ namespace Microsoft.PowerShell
             else
             {
                 //PSReadline does not have access to Utils.CorePSPlatform. Must set PSReadline path seperately                
-                string historypath = System.Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+                string historypath = System.Environment.GetEnvironmentVariable("XDG_DATA_HOME");
                     
                 if (!String.IsNullOrEmpty(historypath))
                 {
@@ -195,7 +195,8 @@ namespace Microsoft.PowerShell
                                                              Environment.GetEnvironmentVariable("HOME"), 
                                                              ".local",
                                                              "share",
-                                                             "powershell",                                                             
+                                                             "powershell",  
+                                                             "PSReadLine",
                                                              hostName + "_history.txt");
                 }
             }

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -72,6 +72,20 @@ namespace Microsoft.PowerShell
 
     public class PSConsoleReadlineOptions
     {
+#if CORECLR
+        public const ConsoleColor DefaultCommentForegroundColor   = ConsoleColor.Magenta;
+        public const ConsoleColor DefaultKeywordForegroundColor   = ConsoleColor.Green;
+        public const ConsoleColor DefaultStringForegroundColor    = ConsoleColor.DarkCyan;
+        public const ConsoleColor DefaultOperatorForegroundColor  = ConsoleColor.Gray;
+        public const ConsoleColor DefaultVariableForegroundColor  = ConsoleColor.Green;
+        public const ConsoleColor DefaultCommandForegroundColor   = ConsoleColor.Yellow;
+        public const ConsoleColor DefaultParameterForegroundColor = ConsoleColor.Green;
+        public const ConsoleColor DefaultTypeForegroundColor      = ConsoleColor.Gray;
+        public const ConsoleColor DefaultNumberForegroundColor    = ConsoleColor.White;
+        public const ConsoleColor DefaultMemberForegroundColor    = ConsoleColor.Gray;
+        public const ConsoleColor DefaultEmphasisForegroundColor  = ConsoleColor.Cyan;
+        public const ConsoleColor DefaultErrorForegroundColor     = ConsoleColor.Red;
+#else
         public const ConsoleColor DefaultCommentForegroundColor   = ConsoleColor.DarkGreen;
         public const ConsoleColor DefaultKeywordForegroundColor   = ConsoleColor.Green;
         public const ConsoleColor DefaultStringForegroundColor    = ConsoleColor.DarkCyan;
@@ -84,7 +98,7 @@ namespace Microsoft.PowerShell
         public const ConsoleColor DefaultMemberForegroundColor    = ConsoleColor.Gray;
         public const ConsoleColor DefaultEmphasisForegroundColor  = ConsoleColor.Cyan;
         public const ConsoleColor DefaultErrorForegroundColor     = ConsoleColor.Red;
-
+#endif
 
         public const EditMode DefaultEditMode = EditMode.Windows;
 

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -181,29 +181,27 @@ namespace Microsoft.PowerShell
             {
                 //PSReadline does not have access to Utils.CorePSPlatform. Must set PSReadline path seperately                
                 string modulepath = System.Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
-               
-                if (String.IsNullOrEmpty(modulepath))
-                {
-                        modulepath = System.IO.Path.Combine(
-                                                             Environment.GetEnvironmentVariable("HOME"), 
-                                                             ".config/powershell/modules");
-                        
-                        HistorySavePath = System.IO.Path.Combine(
-                                                         Environment.GetEnvironmentVariable("HOME"), 
-                                                         modulepath,
-                                                         "PSReadLine",
-                                                         hostName + "_history.txt");
-                }
-                 
-                else {
                     
+                if (!String.IsNullOrEmpty(modulepath))
+                {
+                    modulepath = System.IO.Path.Combine(modulepath, "powershell");
                     HistorySavePath = modulepath; 
-                   
                 }
 
-                            
+                else
+                {
+                    modulepath = System.IO.Path.Combine(
+                                                        Environment.GetEnvironmentVariable("HOME"), 
+                                                        ".config/powershell/modules");
+                        
+                    HistorySavePath = System.IO.Path.Combine(
+                                                             Environment.GetEnvironmentVariable("HOME"), 
+                                                             modulepath,
+                                                             "PSReadLine",
+                                                             hostName + "_history.txt");
                 }
-    #else
+            }
+#else
                 HistorySavePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
                 + @"\Microsoft\Windows\PowerShell\PSReadline\" + hostName + "_history.txt";
 #endif

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -690,7 +690,6 @@ namespace Microsoft.PowerShell
                     MethodInfo mi = typeof (PSConsoleReadLine).GetMethod(function);
                     var keyHandler = (Action<ConsoleKeyInfo?, object>)
                         mi.CreateDelegate(typeof (Action<ConsoleKeyInfo?, object>));
-                            
 #else
                     var keyHandler = (Action<ConsoleKeyInfo?, object>)
                         Delegate.CreateDelegate(typeof (Action<ConsoleKeyInfo?, object>),

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -92,7 +92,12 @@ namespace Microsoft.PowerShell
         public const ConsoleColor DefaultEmphasisForegroundColor  = ConsoleColor.Cyan;
         public const ConsoleColor DefaultErrorForegroundColor     = ConsoleColor.Red;
 
-        public const EditMode DefaultEditMode = EditMode.Windows;
+        public const EditMode DefaultEditMode =
+#if LINUX
+            EditMode.Emacs;
+#else
+            EditMode.Windows;
+#endif
 
         public const string DefaultContinuationPrompt = ">> ";
 

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell
 
         /// <summary>
         /// When displaying possible completions, either display
-        /// tooltips or dipslay just the completions.
+        /// tooltips or display just the completions.
         /// </summary>
         public const bool DefaultShowToolTips = false;
 

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -381,7 +381,7 @@ namespace Microsoft.PowerShell
         }
     }
 
-    [Cmdlet("Get", "PSReadlineOption", HelpUri = "http://go.microsoft.com/fwlink/?LinkId=528808")]
+    [Cmdlet("Get", "PSReadlineOption", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=528808")]
     [OutputType(typeof(PSConsoleReadlineOptions))]
     public class GetPSReadlineOption : PSCmdlet
     {
@@ -392,7 +392,7 @@ namespace Microsoft.PowerShell
         }
     }
 
-    [Cmdlet("Set", "PSReadlineOption", HelpUri = "http://go.microsoft.com/fwlink/?LinkId=528811")]
+    [Cmdlet("Set", "PSReadlineOption", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=528811")]
     public class SetPSReadlineOption : PSCmdlet
     {
         [Parameter(ParameterSetName = "OptionsSet")]
@@ -672,7 +672,7 @@ namespace Microsoft.PowerShell
         }
     }
 
-    [Cmdlet("Set", "PSReadlineKeyHandler", HelpUri = "http://go.microsoft.com/fwlink/?LinkId=528810")]
+    [Cmdlet("Set", "PSReadlineKeyHandler", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=528810")]
     public class SetPSReadlineKeyHandlerCommand : ChangePSReadlineKeyHandlerCommandBase, IDynamicParameters
     {
         [Parameter(Position = 1, Mandatory = true, ParameterSetName = "ScriptBlock")]
@@ -747,7 +747,7 @@ namespace Microsoft.PowerShell
         }
     }
 
-    [Cmdlet("Get", "PSReadlineKeyHandler", HelpUri = "http://go.microsoft.com/fwlink/?LinkId=528807")]
+    [Cmdlet("Get", "PSReadlineKeyHandler", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=528807")]
     [OutputType(typeof(KeyHandler))]
     public class GetKeyHandlerCommand : PSCmdlet
     {
@@ -791,7 +791,7 @@ namespace Microsoft.PowerShell
         }
     }
 
-    [Cmdlet("Remove", "PSReadlineKeyHandler", HelpUri = "http://go.microsoft.com/fwlink/?LinkId=528809")]
+    [Cmdlet("Remove", "PSReadlineKeyHandler", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=528809")]
     public class RemoveKeyHandlerCommand : ChangePSReadlineKeyHandlerCommandBase
     {
         [ExcludeFromCodeCoverage]

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell
 
     public class PSConsoleReadlineOptions
     {
-#if LINUX // TODO: why different schemes for LINUX?
+#if UNIX // TODO: why different schemes for LINUX?
         public const ConsoleColor DefaultCommentForegroundColor   = ConsoleColor.Magenta;
         public const ConsoleColor DefaultOperatorForegroundColor  = ConsoleColor.Gray;
         public const ConsoleColor DefaultParameterForegroundColor = ConsoleColor.Green;
@@ -93,7 +93,7 @@ namespace Microsoft.PowerShell
         public const ConsoleColor DefaultErrorForegroundColor     = ConsoleColor.Red;
 
         public const EditMode DefaultEditMode =
-#if LINUX
+#if UNIX
             EditMode.Emacs;
 #else
             EditMode.Windows;
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell
             HistorySaveStyle = DefaultHistorySaveStyle;
 
             string historyFileName = hostName + "_history.txt";
-#if LINUX
+#if UNIX
             // PSReadline does not have access to Utils.CorePSPlatform. Must set PSReadline path separately
             string historyPath = System.Environment.GetEnvironmentVariable("XDG_DATA_HOME");
 

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -24,7 +24,9 @@ namespace Microsoft.PowerShell
         private Runspace _runspace;
 
         // Stub helper method so completion can be mocked
+#if !CORECLR
         [ExcludeFromCodeCoverage]
+#endif
         CommandCompletion IPSConsoleReadLineMockableMethods.CompleteInput(string input, int cursorIndex, Hashtable options, System.Management.Automation.PowerShell powershell)
         {
             return CalloutUsingDefaultConsoleMode(

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -303,8 +303,16 @@ namespace Microsoft.PowerShell
             for (int i = 0; i < menuColumnWidth; i++)
             {
                 int j = i + start;
+#if CORECLR                
+                ConsoleColor tempColor = (int)buffer[j].ForegroundColor == -1 
+                    ? ConsoleColor.White : buffer[j].ForegroundColor;
+                buffer[j].ForegroundColor = (int)buffer[j].BackgroundColor == -1 
+                    ? ConsoleColor.Black : buffer[j].BackgroundColor;
+                buffer[j].BackgroundColor = tempColor;
+#else
                 buffer[j].ForegroundColor = (ConsoleColor)((int)buffer[j].ForegroundColor ^ 7);
                 buffer[j].BackgroundColor = (ConsoleColor)((int)buffer[j].BackgroundColor ^ 7);
+#endif
             }
         }
 

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -23,6 +23,9 @@ namespace Microsoft.PowerShell
         private CommandCompletion _tabCompletions;
         private Runspace _runspace;
 
+        // String helper for directory paths
+        private static string DirectorySeparatorString = System.IO.Path.DirectorySeparatorChar.ToString();
+
         // Stub helper method so completion can be mocked
 #if !CORECLR
         [ExcludeFromCodeCoverage]
@@ -275,21 +278,23 @@ namespace Microsoft.PowerShell
 
         private static string GetReplacementTextForDirectory(string replacementText, ref int cursorAdjustment)
         {
-            if (!replacementText.EndsWith("\\", StringComparison.Ordinal))
+            if (!replacementText.EndsWith(DirectorySeparatorString , StringComparison.Ordinal))
             {
-                if (replacementText.EndsWith("\\'", StringComparison.Ordinal) || replacementText.EndsWith("\\\"", StringComparison.Ordinal))
+                if (replacementText.EndsWith(String.Format("{0}\'", DirectorySeparatorString), StringComparison.Ordinal) ||
+                    replacementText.EndsWith(String.Format("{0}\"", DirectorySeparatorString), StringComparison.Ordinal))
                 {
                     cursorAdjustment = -1;
                 }
-                else if (replacementText.EndsWith("'", StringComparison.Ordinal) || replacementText.EndsWith("\"", StringComparison.Ordinal))
+                else if (replacementText.EndsWith("'", StringComparison.Ordinal) ||
+                         replacementText.EndsWith("\"", StringComparison.Ordinal))
                 {
                     var len = replacementText.Length;
-                    replacementText = replacementText.Substring(0, len - 1) + '\\' + replacementText[len - 1];
+                    replacementText = replacementText.Substring(0, len - 1) + System.IO.Path.DirectorySeparatorChar + replacementText[len - 1];
                     cursorAdjustment = -1;
                 }
                 else
                 {
-                    replacementText = replacementText + '\\';
+                    replacementText = replacementText + System.IO.Path.DirectorySeparatorChar;
                 }
             }
             return replacementText;

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -27,9 +27,7 @@ namespace Microsoft.PowerShell
         private static string DirectorySeparatorString = System.IO.Path.DirectorySeparatorChar.ToString();
 
         // Stub helper method so completion can be mocked
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         CommandCompletion IPSConsoleReadLineMockableMethods.CompleteInput(string input, int cursorIndex, Hashtable options, System.Management.Automation.PowerShell powershell)
         {
             return CalloutUsingDefaultConsoleMode(
@@ -308,7 +306,7 @@ namespace Microsoft.PowerShell
             for (int i = 0; i < menuColumnWidth; i++)
             {
                 int j = i + start;
-#if CORECLR                
+#if LINUX // TODO: use real inverse
                 ConsoleColor tempColor = (int)buffer[j].ForegroundColor == -1 
                     ? ConsoleColor.White : buffer[j].ForegroundColor;
                 buffer[j].ForegroundColor = (int)buffer[j].BackgroundColor == -1 

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -307,9 +307,9 @@ namespace Microsoft.PowerShell
             {
                 int j = i + start;
 #if LINUX // TODO: use real inverse
-                ConsoleColor tempColor = (int)buffer[j].ForegroundColor == -1 
+                ConsoleColor tempColor = buffer[j].ForegroundColor == UnknownColor
                     ? ConsoleColor.White : buffer[j].ForegroundColor;
-                buffer[j].ForegroundColor = (int)buffer[j].BackgroundColor == -1 
+                buffer[j].ForegroundColor = buffer[j].BackgroundColor == UnknownColor
                     ? ConsoleColor.Black : buffer[j].BackgroundColor;
                 buffer[j].BackgroundColor = tempColor;
 #else

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -298,24 +298,14 @@ namespace Microsoft.PowerShell
             return replacementText;
         }
 
-        private static void InvertSelectedCompletion(CHAR_INFO[] buffer, int selectedItem, int menuColumnWidth, int menuRows)
+        private static void InvertSelectedCompletion(BufferChar[] buffer, int selectedItem, int menuColumnWidth, int menuRows)
         {
             var selectedX = selectedItem / menuRows;
             var selectedY = selectedItem - (selectedX * menuRows);
             var start = selectedY * _singleton._console.BufferWidth + selectedX * menuColumnWidth;
             for (int i = 0; i < menuColumnWidth; i++)
             {
-                int j = i + start;
-#if LINUX // TODO: use real inverse
-                ConsoleColor tempColor = buffer[j].ForegroundColor == UnknownColor
-                    ? ConsoleColor.White : buffer[j].ForegroundColor;
-                buffer[j].ForegroundColor = buffer[j].BackgroundColor == UnknownColor
-                    ? ConsoleColor.Black : buffer[j].BackgroundColor;
-                buffer[j].BackgroundColor = tempColor;
-#else
-                buffer[j].ForegroundColor = (ConsoleColor)((int)buffer[j].ForegroundColor ^ 7);
-                buffer[j].BackgroundColor = (ConsoleColor)((int)buffer[j].BackgroundColor ^ 7);
-#endif
+                buffer[i + start].Inverse = true;
             }
         }
 

--- a/PSReadLine/ConsoleBufferBuilder.cs
+++ b/PSReadLine/ConsoleBufferBuilder.cs
@@ -10,18 +10,18 @@ namespace Microsoft.PowerShell
 {
     internal class ConsoleBufferBuilder
     {
-        private List<CHAR_INFO> buffer;
+        private List<BufferChar> buffer;
         private IConsole _console;
 
         public ConsoleBufferBuilder(int capacity, IConsole console)
         {
-            buffer = new List<CHAR_INFO>(capacity);
+            buffer = new List<BufferChar>(capacity);
             _console = console;
         }
 
-        CHAR_INFO NewCharInfo(char c)
+        BufferChar NewCharInfo(char c)
         {
-            return new CHAR_INFO
+            return new BufferChar
             {
                 UnicodeChar = c,
                 BackgroundColor = _console.BackgroundColor,
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell
             }
         }
 
-        public CHAR_INFO[] ToArray()
+        public BufferChar[] ToArray()
         {
             return buffer.ToArray();
         }

--- a/PSReadLine/ConsoleKeyChordConverter.cs
+++ b/PSReadLine/ConsoleKeyChordConverter.cs
@@ -321,12 +321,12 @@ namespace Microsoft.PowerShell
             // get corresponding scan code
             uint scanCode = NativeMethods.MapVirtualKey(virtualKey, NativeMethods.MAPVK_VK_TO_VSC);
 
-            // get corresponding character  - maybe be 0, 1 or 2 in length (diacriticals)
+            // get corresponding character  - maybe be 0, 1 or 2 in length (diacritics)
             var chars = new char[2];
             int charCount = NativeMethods.ToUnicode(
                 virtualKey, scanCode, state, chars, chars.Length, NativeMethods.MENU_IS_INACTIVE);
 
-            // TODO: support diacriticals (charCount == 2)
+            // TODO: support diacritics (charCount == 2)
             if (charCount == 1)
             {
                 keyChar = chars[0];

--- a/PSReadLine/ConsoleKeyChordConverter.cs
+++ b/PSReadLine/ConsoleKeyChordConverter.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if CORECLR
+#if LINUX
 using System.Reflection;
 #endif
 using System.Runtime.InteropServices;
@@ -214,7 +214,7 @@ namespace Microsoft.PowerShell
         {
             // default for unprintables and unhandled
             char keyChar = '\u0000';
-#if CORECLR
+#if LINUX
             Type keyType = typeof (Keys);
             FieldInfo[] keyFields = keyType.GetFields();
             

--- a/PSReadLine/ConsoleKeyChordConverter.cs
+++ b/PSReadLine/ConsoleKeyChordConverter.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if LINUX
+#if UNIX
 using System.Reflection;
 #endif
 using System.Runtime.InteropServices;
@@ -214,7 +214,7 @@ namespace Microsoft.PowerShell
         {
             // default for unprintables and unhandled
             char keyChar = '\u0000';
-#if LINUX
+#if UNIX
             Type keyType = typeof (Keys);
             FieldInfo[] keyFields = keyType.GetFields();
             

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -315,6 +315,18 @@ namespace Microsoft.PowerShell.Internal
 
     public struct CHAR_INFO
     {
+#if CORECLR
+        public char UnicodeChar;
+        public ConsoleColor ForegroundColor;
+        public ConsoleColor BackgroundColor;
+
+        public CHAR_INFO(char c, ConsoleColor foreground, ConsoleColor background)
+        {
+            UnicodeChar = c;
+            ForegroundColor = foreground;
+            BackgroundColor = background;
+        }
+#else
         public ushort UnicodeChar;
         public ushort Attributes;
 
@@ -324,27 +336,21 @@ namespace Microsoft.PowerShell.Internal
             Attributes = (ushort)(((int)background << 4) | (int)foreground);
         }
 
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         public ConsoleColor ForegroundColor
         {
             get { return (ConsoleColor)(Attributes & 0xf); }
             set { Attributes = (ushort)((Attributes & 0xfff0) | ((int)value & 0xf)); }
         }
 
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         public ConsoleColor BackgroundColor
         {
             get { return (ConsoleColor)((Attributes & 0xf0) >> 4); }
             set { Attributes = (ushort)((Attributes & 0xff0f) | (((int)value & 0xf) << 4)); }
         }
 
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         public override string ToString()
         {
             var sb = new StringBuilder();
@@ -356,9 +362,7 @@ namespace Microsoft.PowerShell.Internal
             return sb.ToString();
         }
 
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         public override bool Equals(object obj)
         {
             if (!(obj is CHAR_INFO))
@@ -370,14 +374,12 @@ namespace Microsoft.PowerShell.Internal
             return this.UnicodeChar == other.UnicodeChar && this.Attributes == other.Attributes;
         }
 
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         public override int GetHashCode()
         {
             return UnicodeChar.GetHashCode() + Attributes.GetHashCode();
         }
-
+#endif
     }
 
     internal static class ConsoleKeyInfoExtension 
@@ -626,20 +628,9 @@ namespace Microsoft.PowerShell.Internal
 
             for (int i = 0; i < buffer.Length; ++i)
             {
-                /* For some reasons, the default color comes out white on white */
-                /*
-                if (buffer[i].ForegroundColor == ConsoleColor.White
-                    && buffer[i].BackgroundColor == ConsoleColor.White)
-                {
-                    Console.ForegroundColor =  foregroundColor;
-                    Console.BackgroundColor =  backgroundColor;
-                }
-                else
-                {
-                    Console.ForegroundColor =  buffer[i].ForegroundColor;
-                    Console.BackgroundColor = backgroundColor;
-                }
-                */
+                Console.ForegroundColor =  buffer[i].ForegroundColor;
+                Console.BackgroundColor =  buffer[i].BackgroundColor;
+
                 Console.Write((char)buffer[i].UnicodeChar);
             }
 
@@ -675,8 +666,6 @@ namespace Microsoft.PowerShell.Internal
         public void ScrollBuffer(int lines)
         {
 #if CORECLR
-//            Console.MoveBufferArea(lines, 0, Console.BufferWidth, Console.BufferHeight - lines, 0, 0, ' ', 
-//                                   Console.ForegroundColor, Console.BackgroundColor);
             for (int i=0; i<lines; ++i)
             {
                 Console.SetCursorPosition(Console.BufferWidth, Console.BufferHeight - 1);

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -908,6 +908,13 @@ namespace Microsoft.PowerShell.Internal
                 NativeMethods.ReleaseDC(_hwnd, _hDC);
             }
         }
+
+#if CORECLR
+        public void Clear()
+        {
+            Console.Clear();
+        }
+#endif
     }
 
 #pragma warning restore 1591

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -713,10 +713,10 @@ namespace Microsoft.PowerShell.Internal
         internal static bool IsAnyDBCSCharSet(uint charSet)
         {
             const uint SHIFTJIS_CHARSET = 128;
-            const uint HANGEUL_CHARSET = 129;
+            const uint HANGUL_CHARSET = 129;
             const uint CHINESEBIG5_CHARSET = 136;
             const uint GB2312_CHARSET = 134;
-            return charSet == SHIFTJIS_CHARSET || charSet == HANGEUL_CHARSET ||
+            return charSet == SHIFTJIS_CHARSET || charSet == HANGUL_CHARSET ||
                    charSet == CHINESEBIG5_CHARSET || charSet == GB2312_CHARSET;
         }
 
@@ -798,7 +798,7 @@ namespace Microsoft.PowerShell.Internal
                      (0xffd2 <= c && c <= 0xffd7) ||
                      (0xffda <= c && c <= 0xffdc))
             {
-                /* Halfwidth Hangule variants */
+                /* Halfwidth Hangul variants */
                 return 1;
             }
             else if (0xffe0 <= c && c <= 0xffe6)

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -386,24 +386,6 @@ namespace Microsoft.PowerShell.Internal
                 sb.Append("Alt");
             }
 
-#if UNIX
-            if (sb.Length > 0)
-                sb.Append("+");
-            // TODO: find better way to map these characters to something more friendly
-            if ((key.Key >= ConsoleKey.D0 && key.Key <= ConsoleKey.D9)
-                || (key.Key >= ConsoleKey.Oem1 && key.Key <= ConsoleKey.Oem8))
-            {
-                sb.Append(key.KeyChar);
-            }
-            else
-            {
-                if (key.Modifiers.HasFlag(ConsoleModifiers.Shift))
-                {
-                    sb.Append("Shift+");
-                }
-                sb.Append(key.Key);
-            }
-#else
             char c = key.KeyChar;
             if (char.IsControl(c) || char.IsWhiteSpace(c))
             {
@@ -423,7 +405,6 @@ namespace Microsoft.PowerShell.Internal
                     sb.Append("+");
                 sb.Append(c);
             }
-#endif
             return sb.ToString();
         }
     }

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -314,13 +314,13 @@ namespace Microsoft.PowerShell.Internal
         public char UnicodeChar;
         public ConsoleColor ForegroundColor;
         public ConsoleColor BackgroundColor;
-#if !LINUX
+#if !UNIX
         public bool IsLeadByte;
         public bool IsTrailByte;
 #endif
         public bool Inverse;
 
-#if !LINUX
+#if !UNIX
         public CHAR_INFO ToCharInfo()
         {
             int fg = (int) ForegroundColor;
@@ -386,7 +386,7 @@ namespace Microsoft.PowerShell.Internal
                 sb.Append("Alt");
             }
 
-#if LINUX
+#if UNIX
             if (sb.Length > 0)
                 sb.Append("+");
             // TODO: find better way to map these characters to something more friendly
@@ -429,7 +429,7 @@ namespace Microsoft.PowerShell.Internal
         }
     }
 
-#if !LINUX
+#if !UNIX
     internal class ConhostConsole : IConsole
     {
         [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -404,8 +404,7 @@ namespace Microsoft.PowerShell.Internal
                 sb.Append(key.Key);
             }
 #else
-            char c = ConsoleKeyChordConverter.GetCharFromConsoleKey(key.Key,
-                (mods & ConsoleModifiers.Shift) != 0 ? ConsoleModifiers.Shift : 0);
+            char c = key.KeyChar;
             if (char.IsControl(c) || char.IsWhiteSpace(c))
             {
                 if (key.Modifiers.HasFlag(ConsoleModifiers.Shift))

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -317,7 +317,7 @@ namespace Microsoft.PowerShell.Internal
         public CHAR_INFO(char c, ConsoleColor foreground, ConsoleColor background)
         {
             UnicodeChar = c;
-            Attributes = (ushort)(((int)background << 4) | (int)foreground);
+            Attributes = (ushort)((((int)background << 4) & 0xf) | ((int)foreground & 0xf));
         }
 
         [ExcludeFromCodeCoverage]
@@ -330,7 +330,7 @@ namespace Microsoft.PowerShell.Internal
         [ExcludeFromCodeCoverage]
         public ConsoleColor BackgroundColor
         {
-            get { return (ConsoleColor)((Attributes & 0xf0) >> 4); }
+            get { return (ConsoleColor)((Attributes & 0x00f0) >> 4); }
             set { Attributes = (ushort)((Attributes & 0xff0f) | (((int)value & 0xf) << 4)); }
         }
 
@@ -426,6 +426,7 @@ namespace Microsoft.PowerShell.Internal
         }
     }
 
+#if !LINUX
     internal class ConhostConsole : IConsole
     {
         [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
@@ -482,18 +483,42 @@ namespace Microsoft.PowerShell.Internal
             return new SafeFileHandle(handle, true);
         });
 
-        public uint GetConsoleInputMode()
+        public object GetConsoleInputMode()
         {
+            uint mode;
             var handle = _inputHandle.Value.DangerousGetHandle();
-            uint result;
-            NativeMethods.GetConsoleMode(handle, out result);
-            return result;
+            NativeMethods.GetConsoleMode(handle, out mode);
+            return mode;
         }
 
-        public void SetConsoleInputMode(uint mode)
+        public void SetConsoleInputMode(object modeObj)
         {
-            var handle = _inputHandle.Value.DangerousGetHandle();
-            NativeMethods.SetConsoleMode(handle, mode);
+            if (modeObj is uint)
+            {
+                // Clear a couple flags so we can actually receive certain keys:
+                //     ENABLE_PROCESSED_INPUT - enables Ctrl+C
+                //     ENABLE_LINE_INPUT - enables Ctrl+S
+                // Also clear a couple flags so we don't mask the input that we ignore:
+                //     ENABLE_MOUSE_INPUT - mouse events
+                //     ENABLE_WINDOW_INPUT - window resize events
+                var mode = (uint)modeObj &
+                           ~(NativeMethods.ENABLE_PROCESSED_INPUT |
+                             NativeMethods.ENABLE_LINE_INPUT |
+                             NativeMethods.ENABLE_WINDOW_INPUT |
+                             NativeMethods.ENABLE_MOUSE_INPUT);
+
+                var handle = _inputHandle.Value.DangerousGetHandle();
+                NativeMethods.SetConsoleMode(handle, mode);
+            }
+        }
+
+        public void RestoreConsoleInputMode(object modeObj)
+        {
+            if (modeObj is uint)
+            {
+                var handle = _inputHandle.Value.DangerousGetHandle();
+                NativeMethods.SetConsoleMode(handle, (uint)modeObj);
+            }
         }
 
         public ConsoleKeyInfo ReadKey()
@@ -601,24 +626,7 @@ namespace Microsoft.PowerShell.Internal
                 ScrollBuffer(scrollCount);
                 top -= scrollCount;
             }
-#if LINUX
-            ConsoleColor foregroundColor = Console.ForegroundColor;
-            ConsoleColor backgroundColor = Console.BackgroundColor;
 
-            Console.SetCursorPosition(0, (top>=0) ? top : 0);
-
-            for (int i = 0; i < buffer.Length; ++i)
-            {
-                // TODO: use escape sequences for better perf
-                Console.ForegroundColor =  buffer[i].ForegroundColor;
-                Console.BackgroundColor =  buffer[i].BackgroundColor;
-
-                Console.Write((char)buffer[i].UnicodeChar);
-            }
-
-            Console.BackgroundColor = backgroundColor;
-            Console.ForegroundColor = foregroundColor;
-#else
             var handle = NativeMethods.GetStdHandle((uint) StandardHandleId.Output);
             var bufferSize = new COORD
             {
@@ -643,18 +651,10 @@ namespace Microsoft.PowerShell.Internal
             {
                 Console.CursorTop = bottom;
             }
-#endif
         }
 
         public void ScrollBuffer(int lines)
         {
-#if LINUX
-            for (int i=0; i<lines; ++i)
-            {
-                Console.SetCursorPosition(Console.BufferWidth, Console.BufferHeight - 1);
-                Console.WriteLine();
-            }
-#else
             var handle = NativeMethods.GetStdHandle((uint) StandardHandleId.Output);
 
             var scrollRectangle = new SMALL_RECT
@@ -667,20 +667,11 @@ namespace Microsoft.PowerShell.Internal
             var destinationOrigin = new COORD {X = 0, Y = 0};
             var fillChar = new CHAR_INFO(' ', Console.ForegroundColor, Console.BackgroundColor);
             NativeMethods.ScrollConsoleScreenBuffer(handle, ref scrollRectangle, IntPtr.Zero, destinationOrigin, ref fillChar);
-#endif
         }
 
         public CHAR_INFO[] ReadBufferLines(int top, int count)
         {
             var result = new CHAR_INFO[BufferWidth * count];
-#if LINUX
-            for (int i=0; i<BufferWidth*count; ++i)
-            {
-                result[i].UnicodeChar = ' ';
-                result[i].ForegroundColor = Console.ForegroundColor;
-                result[i].BackgroundColor = Console.BackgroundColor;
-            }
-#else
             var handle = NativeMethods.GetStdHandle((uint) StandardHandleId.Output);
 
             var readBufferSize = new COORD {
@@ -696,7 +687,7 @@ namespace Microsoft.PowerShell.Internal
             };
             NativeMethods.ReadConsoleOutput(handle, result,
                 readBufferSize, readBufferCoord, ref readRegion);
-#endif
+
             return result;
         }
 
@@ -891,14 +882,196 @@ namespace Microsoft.PowerShell.Internal
                 NativeMethods.ReleaseDC(_hwnd, _hDC);
             }
         }
+    }
 
-#if LINUX // TODO: this is not correct, PSReadline never clears the screen, it should only scroll
+#else
+
+    internal class TTYConsole : IConsole
+    {
+        public object GetConsoleInputMode()
+        {
+            return Console.TreatControlCAsInput;
+        }
+
+        public void SetConsoleInputMode(object modeObj)
+        {
+            Console.TreatControlCAsInput = true;
+        }
+
+        public void RestoreConsoleInputMode(object modeObj)
+        {
+            if (modeObj is bool)
+            {
+                Console.TreatControlCAsInput = (bool)modeObj;
+            }
+        }
+
+        public ConsoleKeyInfo ReadKey()
+        {
+            return Console.ReadKey(true);
+        }
+
+        public bool KeyAvailable
+        {
+            get { return Console.KeyAvailable; }
+        }
+
+        public int CursorLeft
+        {
+            get { return Console.CursorLeft; }
+            set { Console.CursorLeft = value; }
+        }
+
+        public int CursorTop
+        {
+            get { return Console.CursorTop; }
+            set { Console.CursorTop = value; }
+        }
+
+        public int CursorSize
+        {
+            get { return Console.CursorSize; }
+            set { Console.CursorSize = value; }
+        }
+
+        public int BufferWidth
+        {
+            get { return Console.BufferWidth; }
+            set { Console.BufferWidth = value; }
+        }
+
+        public int BufferHeight
+        {
+            get { return Console.BufferHeight; }
+            set { Console.BufferHeight = value; }
+        }
+
+        public int WindowWidth
+        {
+            get { return Console.WindowWidth; }
+            set { Console.WindowWidth = value; }
+        }
+
+        public int WindowHeight
+        {
+            get { return Console.WindowHeight; }
+            set { Console.WindowHeight = value; }
+        }
+
+        public int WindowTop
+        {
+            get { return Console.WindowTop; }
+            set { Console.WindowTop = value; }
+        }
+
+        public ConsoleColor BackgroundColor
+        {
+            get { return Console.BackgroundColor; }
+            set { Console.BackgroundColor = value; }
+        }
+
+        public ConsoleColor ForegroundColor
+        {
+            get { return Console.ForegroundColor; }
+            set { Console.ForegroundColor = value; }
+        }
+
+        public void SetWindowPosition(int left, int top)
+        {
+            Console.SetWindowPosition(left, top);
+        }
+
+        public void SetCursorPosition(int left, int top)
+        {
+            Console.SetCursorPosition(left, top);
+        }
+
+        public void Write(string value)
+        {
+            Console.Write(value);
+        }
+
+        public void WriteLine(string value)
+        {
+            Console.WriteLine(value);
+        }
+
+        public void WriteBufferLines(CHAR_INFO[] buffer, ref int top)
+        {
+            WriteBufferLines(buffer, ref top, true);
+        }
+
+        public void WriteBufferLines(CHAR_INFO[] buffer, ref int top, bool ensureBottomLineVisible)
+        {
+            int bufferWidth = Console.BufferWidth;
+            int bufferLineCount = buffer.Length / bufferWidth;
+            if ((top + bufferLineCount) > Console.BufferHeight)
+            {
+                var scrollCount = (top + bufferLineCount) - Console.BufferHeight;
+                ScrollBuffer(scrollCount);
+                top -= scrollCount;
+            }
+
+            ConsoleColor foregroundColor = Console.ForegroundColor;
+            ConsoleColor backgroundColor = Console.BackgroundColor;
+
+            Console.SetCursorPosition(0, (top>=0) ? top : 0);
+
+            for (int i = 0; i < buffer.Length; ++i)
+            {
+                // TODO: use escape sequences for better perf
+                Console.ForegroundColor =  buffer[i].ForegroundColor;
+                Console.BackgroundColor =  buffer[i].BackgroundColor;
+
+                Console.Write((char)buffer[i].UnicodeChar);
+            }
+
+            Console.BackgroundColor = backgroundColor;
+            Console.ForegroundColor = foregroundColor;
+        }
+
+        public void ScrollBuffer(int lines)
+        {
+            for (int i=0; i<lines; ++i)
+            {
+                Console.SetCursorPosition(Console.BufferWidth, Console.BufferHeight - 1);
+                Console.WriteLine();
+            }
+        }
+
+        public CHAR_INFO[] ReadBufferLines(int top, int count)
+        {
+            var result = new CHAR_INFO[BufferWidth * count];
+            for (int i=0; i<BufferWidth*count; ++i)
+            {
+                result[i].UnicodeChar = ' ';
+                result[i].ForegroundColor = Console.ForegroundColor;
+                result[i].BackgroundColor = Console.BackgroundColor;
+            }
+            return result;
+        }
+
+        public int LengthInBufferCells(char c)
+        {
+            return 1;
+        }
+
+
+        public void StartRender()
+        {
+        }
+
+        public void EndRender()
+        {
+        }
+
+        // TODO: this is not correct, PSReadline never clears the screen, it should only scroll
         public void Clear()
         {
             Console.Clear();
         }
-#endif
     }
+#endif
 
 #if CORECLR // TODO: remove if CORECLR adds this attribute back
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event)]

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -443,7 +443,7 @@ namespace Microsoft.PowerShell.Internal
             {
                 int err = Marshal.GetLastWin32Error();
                 Win32Exception innerException = new Win32Exception(err);
-                throw new Exception("Failed to retreive the input console handle.", innerException);
+                throw new Exception("Failed to retrieve the input console handle.", innerException);
             }
 
             return new SafeFileHandle(handle, true);
@@ -466,7 +466,7 @@ namespace Microsoft.PowerShell.Internal
             {
                 int err = Marshal.GetLastWin32Error();
                 Win32Exception innerException = new Win32Exception(err);
-                throw new Exception("Failed to retreive the input console handle.", innerException);
+                throw new Exception("Failed to retrieve the input console handle.", innerException);
             }
 
             return new SafeFileHandle(handle, true);

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -386,7 +386,13 @@ namespace Microsoft.PowerShell.Internal
                 sb.Append("Alt");
             }
 
+#if UNIX
             char c = key.KeyChar;
+#else
+            // Windows cannot use KeyChar as some chords (like Ctrl+[) show up as control characters.
+            char c = ConsoleKeyChordConverter.GetCharFromConsoleKey(key.Key,
+                (mods & ConsoleModifiers.Shift) != 0 ? ConsoleModifiers.Shift : 0);
+#endif
             if (char.IsControl(c) || char.IsWhiteSpace(c))
             {
                 if (key.Modifiers.HasFlag(ConsoleModifiers.Shift))

--- a/PSReadLine/HistoryQueue.cs
+++ b/PSReadLine/HistoryQueue.cs
@@ -9,7 +9,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.PowerShell
 {
-    [ExcludeFromCodeCoverage]
+#if !CORECLR
+        [ExcludeFromCodeCoverage]
+#endif
     internal sealed class QueueDebugView<T>
     {
         private readonly HistoryQueue<T> _queue;
@@ -114,7 +116,9 @@ namespace Microsoft.PowerShell
             return result;
         }
 
+#if !CORECLR
         [ExcludeFromCodeCoverage]
+#endif
         public T this[int index]
         {
             get

--- a/PSReadLine/HistoryQueue.cs
+++ b/PSReadLine/HistoryQueue.cs
@@ -6,12 +6,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+#if CORECLR
+using Microsoft.PowerShell.Internal;
+#endif
 
 namespace Microsoft.PowerShell
 {
-#if !CORECLR
-        [ExcludeFromCodeCoverage]
-#endif
+    [ExcludeFromCodeCoverage]
     internal sealed class QueueDebugView<T>
     {
         private readonly HistoryQueue<T> _queue;
@@ -116,9 +117,7 @@ namespace Microsoft.PowerShell
             return result;
         }
 
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         public T this[int index]
         {
             get

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -82,12 +82,21 @@ namespace Microsoft.PowerShell
         {
             public bool Equals(ConsoleKeyInfo x, ConsoleKeyInfo y)
             {
-                return x.Key == y.Key && x.KeyChar == y.KeyChar && x.Modifiers == y.Modifiers;
+                // We *must not* compare the KeyChar field as its value is platform-dependent.
+                // We compare exactly the ConsoleKey enum field (which is platform-agnostic)
+                // and the modifiers.
+
+                return x.Key == y.Key && x.Modifiers == y.Modifiers;
             }
 
             public int GetHashCode(ConsoleKeyInfo obj)
             {
-                return obj.GetHashCode();
+                // Because a comparison of two ConsoleKeyInfo objects is a comparison of the
+                // combination of the ConsoleKey and Modifiers, we must combine their hashes.
+                // This is based on Tuple.GetHashCode
+                int h1 = obj.Key.GetHashCode();
+                int h2 = obj.Modifiers.GetHashCode();
+                return unchecked(((h1 << 5) + h1) ^ h2);
             }
         }
 

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -181,10 +181,12 @@ namespace Microsoft.PowerShell
                 { Keys.ShiftF3,                MakeKeyHandler(CharacterSearchBackward,   "CharacterSearchBackward") },
                 { Keys.F8,                     MakeKeyHandler(HistorySearchBackward,     "HistorySearchBackward") },
                 { Keys.ShiftF8,                MakeKeyHandler(HistorySearchForward,      "HistorySearchForward") },
+#if !CORECLR
                 { Keys.PageUp,                 MakeKeyHandler(ScrollDisplayUp,           "ScrollDisplayUp") },
                 { Keys.PageDown,               MakeKeyHandler(ScrollDisplayDown,         "ScrollDisplayDown") },
                 { Keys.CtrlPageUp,             MakeKeyHandler(ScrollDisplayUpLine,       "ScrollDisplayUpLine") },
                 { Keys.CtrlPageDown,           MakeKeyHandler(ScrollDisplayDownLine,     "ScrollDisplayDownLine") },
+#endif
             };
 
             _chordDispatchTable = new Dictionary<ConsoleKeyInfo, Dictionary<ConsoleKeyInfo, KeyHandler>>();
@@ -267,13 +269,13 @@ namespace Microsoft.PowerShell
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },
-#endif
                 { Keys.PageUp,          MakeKeyHandler(ScrollDisplayUp,      "ScrollDisplayUp") },
                 { Keys.CtrlPageUp,      MakeKeyHandler(ScrollDisplayUpLine,  "ScrollDisplayUpLine") },
                 { Keys.PageDown,        MakeKeyHandler(ScrollDisplayDown,    "ScrollDisplayDown") },
                 { Keys.CtrlPageDown,    MakeKeyHandler(ScrollDisplayDownLine,"ScrollDisplayDownLine") },
                 { Keys.CtrlHome,        MakeKeyHandler(ScrollDisplayTop,     "ScrollDisplayTop") },
                 { Keys.CtrlEnd,         MakeKeyHandler(ScrollDisplayToCursor,"ScrollDisplayToCursor") },
+#endif
             };
 
             _chordDispatchTable = new Dictionary<ConsoleKeyInfo, Dictionary<ConsoleKeyInfo, KeyHandler>>();

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -133,9 +133,11 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlSpace,              MakeKeyHandler(MenuComplete,              "MenuComplete") },
                 { Keys.Tab,                    MakeKeyHandler(TabCompleteNext,           "TabCompleteNext") },
                 { Keys.ShiftTab,               MakeKeyHandler(TabCompletePrevious,       "TabCompletePrevious") },
+#if !CORECLR
                 { Keys.VolumeDown,             MakeKeyHandler(Ignore,                    "Ignore") },
                 { Keys.VolumeUp,               MakeKeyHandler(Ignore,                    "Ignore") },
                 { Keys.VolumeMute,             MakeKeyHandler(Ignore,                    "Ignore") },
+#endif
                 { Keys.CtrlA,                  MakeKeyHandler(SelectAll,                 "SelectAll") },
                 { Keys.CtrlC,                  MakeKeyHandler(CopyOrCancelLine,          "CopyOrCancelLine") },
                 { Keys.CtrlShiftC,             MakeKeyHandler(Copy,                      "Copy") },
@@ -252,9 +254,11 @@ namespace Microsoft.PowerShell
                 { Keys.AltPeriod,       MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.AltUnderbar,     MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.AltCtrlY,        MakeKeyHandler(YankNthArg,           "YankNthArg") },
+#if !CORECLR
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },
+#endif
                 { Keys.PageUp,          MakeKeyHandler(ScrollDisplayUp,      "ScrollDisplayUp") },
                 { Keys.CtrlPageUp,      MakeKeyHandler(ScrollDisplayUpLine,  "ScrollDisplayUpLine") },
                 { Keys.PageDown,        MakeKeyHandler(ScrollDisplayDown,    "ScrollDisplayDown") },

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -93,9 +93,13 @@ namespace Microsoft.PowerShell
             {
                 // Because a comparison of two ConsoleKeyInfo objects is a comparison of the
                 // combination of the ConsoleKey and Modifiers, we must combine their hashes.
-                // This is based on Tuple.GetHashCode
-                int h1 = obj.Key.GetHashCode();
+                // Note that if the ConsoleKey is default, we must fall back to the KeyChar,
+                // otherwise every non-special key will compare as the same.
+                int h1 = obj.Key == default(ConsoleKey)
+                    ? obj.KeyChar.GetHashCode()
+                    : obj.Key.GetHashCode();
                 int h2 = obj.Modifiers.GetHashCode();
+                // This is based on Tuple.GetHashCode
                 return unchecked(((h1 << 5) + h1) ^ h2);
             }
         }

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell
             // should be included on all handlers that ignore their parameters so they
             // can be called from PowerShell without passing anything.
             //
-            // The first arugment is the key that caused the action to be called
+            // The first argument is the key that caused the action to be called
             // (the second key when it's a 2 key chord).  The default is null (it's nullable)
             // because PowerShell can't handle default(ConsoleKeyInfo) as a default.
             // Most actions will ignore this argument.

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlSpace,              MakeKeyHandler(MenuComplete,              "MenuComplete") },
                 { Keys.Tab,                    MakeKeyHandler(TabCompleteNext,           "TabCompleteNext") },
                 { Keys.ShiftTab,               MakeKeyHandler(TabCompletePrevious,       "TabCompletePrevious") },
-#if !CORECLR
+#if !LINUX
                 { Keys.VolumeDown,             MakeKeyHandler(Ignore,                    "Ignore") },
                 { Keys.VolumeUp,               MakeKeyHandler(Ignore,                    "Ignore") },
                 { Keys.VolumeMute,             MakeKeyHandler(Ignore,                    "Ignore") },
@@ -181,7 +181,7 @@ namespace Microsoft.PowerShell
                 { Keys.ShiftF3,                MakeKeyHandler(CharacterSearchBackward,   "CharacterSearchBackward") },
                 { Keys.F8,                     MakeKeyHandler(HistorySearchBackward,     "HistorySearchBackward") },
                 { Keys.ShiftF8,                MakeKeyHandler(HistorySearchForward,      "HistorySearchForward") },
-#if !CORECLR
+#if !LINUX
                 { Keys.PageUp,                 MakeKeyHandler(ScrollDisplayUp,           "ScrollDisplayUp") },
                 { Keys.PageDown,               MakeKeyHandler(ScrollDisplayDown,         "ScrollDisplayDown") },
                 { Keys.CtrlPageUp,             MakeKeyHandler(ScrollDisplayUpLine,       "ScrollDisplayUpLine") },
@@ -265,7 +265,7 @@ namespace Microsoft.PowerShell
                 { Keys.AltPeriod,       MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.AltUnderbar,     MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.AltCtrlY,        MakeKeyHandler(YankNthArg,           "YankNthArg") },
-#if !CORECLR
+#if !LINUX
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlSpace,              MakeKeyHandler(MenuComplete,              "MenuComplete") },
                 { Keys.Tab,                    MakeKeyHandler(TabCompleteNext,           "TabCompleteNext") },
                 { Keys.ShiftTab,               MakeKeyHandler(TabCompletePrevious,       "TabCompletePrevious") },
-#if !LINUX
+#if !UNIX
                 { Keys.VolumeDown,             MakeKeyHandler(Ignore,                    "Ignore") },
                 { Keys.VolumeUp,               MakeKeyHandler(Ignore,                    "Ignore") },
                 { Keys.VolumeMute,             MakeKeyHandler(Ignore,                    "Ignore") },
@@ -200,7 +200,7 @@ namespace Microsoft.PowerShell
                 { Keys.ShiftF3,                MakeKeyHandler(CharacterSearchBackward,   "CharacterSearchBackward") },
                 { Keys.F8,                     MakeKeyHandler(HistorySearchBackward,     "HistorySearchBackward") },
                 { Keys.ShiftF8,                MakeKeyHandler(HistorySearchForward,      "HistorySearchForward") },
-#if !LINUX
+#if !UNIX
                 { Keys.PageUp,                 MakeKeyHandler(ScrollDisplayUp,           "ScrollDisplayUp") },
                 { Keys.PageDown,               MakeKeyHandler(ScrollDisplayDown,         "ScrollDisplayDown") },
                 { Keys.CtrlPageUp,             MakeKeyHandler(ScrollDisplayUpLine,       "ScrollDisplayUpLine") },
@@ -284,7 +284,7 @@ namespace Microsoft.PowerShell
                 { Keys.AltPeriod,       MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.AltUnderbar,     MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.AltCtrlY,        MakeKeyHandler(YankNthArg,           "YankNthArg") },
-#if !LINUX
+#if !UNIX
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -114,6 +114,25 @@ namespace Microsoft.PowerShell
         private Dictionary<ConsoleKeyInfo, KeyHandler> _dispatchTable;
         private Dictionary<ConsoleKeyInfo, Dictionary<ConsoleKeyInfo, KeyHandler>> _chordDispatchTable; 
 
+        /// <summary>
+        /// Helper to set bindings based on EditMode
+        /// </summary>
+        void SetDefaultBindings(EditMode editMode)
+        {
+            switch (editMode)
+            {
+                case EditMode.Emacs:
+                    SetDefaultEmacsBindings();
+                    break;
+                case EditMode.Vi:
+                    SetDefaultViBindings();
+                    break;
+                case EditMode.Windows:
+                    SetDefaultWindowsBindings();
+                    break;
+            }
+        }
+
         void SetDefaultWindowsBindings()
         {
             _dispatchTable = new Dictionary<ConsoleKeyInfo, KeyHandler>(new ConsoleKeyInfoComparer())

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -70,9 +70,11 @@ namespace Microsoft.PowerShell
                 { Keys.Tab,             MakeKeyHandler(ViTabCompleteNext,      "ViTabCompleteNext") },
                 { Keys.ShiftTab,        MakeKeyHandler(ViTabCompletePrevious,  "ViTabCompletePrevious") },
                 { Keys.CtrlV,           MakeKeyHandler(Paste,                  "Paste") },
+#if !CORECLR
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,                 "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,                 "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,                 "Ignore") },
+#endif
                 { Keys.CtrlC,           MakeKeyHandler(CancelLine,             "CancelLine") },
                 { Keys.CtrlL,           MakeKeyHandler(ClearScreen,            "ClearScreen") },
                 { Keys.CtrlY,           MakeKeyHandler(Redo,                   "Redo") },
@@ -107,9 +109,11 @@ namespace Microsoft.PowerShell
                 { Keys.Tab,             MakeKeyHandler(TabCompleteNext,      "TabCompleteNext") },
                 { Keys.ShiftTab,        MakeKeyHandler(TabCompletePrevious,  "TabCompletePrevious") },
                 { Keys.CtrlV,           MakeKeyHandler(Paste,                "Paste") },
+#if !CORECLR
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },
+#endif
                 { Keys.CtrlC,           MakeKeyHandler(CancelLine,           "CancelLine") },
                 { Keys.CtrlL,           MakeKeyHandler(ClearScreen,          "ClearScreen") },
                 { Keys.CtrlT,           MakeKeyHandler(SwapCharacters,       "SwapCharacters") },

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell
                 { Keys.Tab,             MakeKeyHandler(ViTabCompleteNext,      "ViTabCompleteNext") },
                 { Keys.ShiftTab,        MakeKeyHandler(ViTabCompletePrevious,  "ViTabCompletePrevious") },
                 { Keys.CtrlV,           MakeKeyHandler(Paste,                  "Paste") },
-#if !CORECLR
+#if !LINUX
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,                 "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,                 "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,                 "Ignore") },
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell
                 { Keys.Tab,             MakeKeyHandler(TabCompleteNext,      "TabCompleteNext") },
                 { Keys.ShiftTab,        MakeKeyHandler(TabCompletePrevious,  "TabCompletePrevious") },
                 { Keys.CtrlV,           MakeKeyHandler(Paste,                "Paste") },
-#if !CORECLR
+#if !LINUX
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell
                 { Keys.Tab,             MakeKeyHandler(ViTabCompleteNext,      "ViTabCompleteNext") },
                 { Keys.ShiftTab,        MakeKeyHandler(ViTabCompletePrevious,  "ViTabCompletePrevious") },
                 { Keys.CtrlV,           MakeKeyHandler(Paste,                  "Paste") },
-#if !LINUX
+#if !UNIX
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,                 "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,                 "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,                 "Ignore") },
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell
                 { Keys.Tab,             MakeKeyHandler(TabCompleteNext,      "TabCompleteNext") },
                 { Keys.ShiftTab,        MakeKeyHandler(TabCompletePrevious,  "TabCompletePrevious") },
                 { Keys.CtrlV,           MakeKeyHandler(Paste,                "Paste") },
-#if !LINUX
+#if !UNIX
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -3,9 +3,6 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
 using System;
-#if CORECLR
-using System.Runtime.InteropServices;
-#endif
 
 namespace Microsoft.PowerShell
 {

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -105,7 +105,6 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo Minus       = new ConsoleKeyInfo('-', ConsoleKey.OemMinus, false, false, false);
         public static ConsoleKeyInfo AltMinus    = new ConsoleKeyInfo('-', ConsoleKey.OemMinus, false, true, false);
         public static ConsoleKeyInfo Plus        = new ConsoleKeyInfo('+', ConsoleKey.OemPlus, true, false, false);
-        new
         public static ConsoleKeyInfo Equals      = new ConsoleKeyInfo('=', ConsoleKey.OemPlus, false, false, false);
 
         public static ConsoleKeyInfo CtrlAt       = new ConsoleKeyInfo((char)0, ConsoleKey.D2, true, false, true);

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -3,11 +3,30 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
 using System;
+#if CORECLR
+using System.Runtime.InteropServices;
+#endif
 
 namespace Microsoft.PowerShell
 {
     internal static class Keys
     {
+        static Keys()
+        {
+#if CORECLR
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Enter = new ConsoleKeyInfo((char)10, ConsoleKey.Enter, false, false, false);
+            }
+            else
+            {
+                Enter = new ConsoleKeyInfo((char)13, ConsoleKey.Enter, false, false, false);
+            }
+#else
+            Enter = new ConsoleKeyInfo((char)13, ConsoleKey.Enter, false, false, false);
+#endif
+        }
+
         public static ConsoleKeyInfo A = new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false);
         public static ConsoleKeyInfo B = new ConsoleKeyInfo('b', ConsoleKey.B, false, false, false);
         public static ConsoleKeyInfo C = new ConsoleKeyInfo('c', ConsoleKey.C, false, false, false);
@@ -205,7 +224,7 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo End          = new ConsoleKeyInfo((char)0, ConsoleKey.End, false, false, false);
         public static ConsoleKeyInfo CtrlEnd      = new ConsoleKeyInfo((char)0, ConsoleKey.End, false, false, true);
         public static ConsoleKeyInfo ShiftEnd     = new ConsoleKeyInfo((char)0, ConsoleKey.End, true, false, false);
-        public static ConsoleKeyInfo Enter        = new ConsoleKeyInfo((char)13, ConsoleKey.Enter, false, false, false);
+        public static ConsoleKeyInfo Enter; 
         public static ConsoleKeyInfo Escape       = new ConsoleKeyInfo((char)27, ConsoleKey.Escape, false, false, false);
         public static ConsoleKeyInfo Home         = new ConsoleKeyInfo((char)0, ConsoleKey.Home, false, false, false);
         public static ConsoleKeyInfo CtrlHome     = new ConsoleKeyInfo((char)0, ConsoleKey.Home, false, false, true);
@@ -290,8 +309,10 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo ShiftF8 = new ConsoleKeyInfo((char)0, ConsoleKey.F8, true, false, false);
 
         // Keys to ignore 
+#if !CORECLR
         public static ConsoleKeyInfo VolumeUp   = new ConsoleKeyInfo((char)0, ConsoleKey.VolumeUp, false, false, false);
         public static ConsoleKeyInfo VolumeDown = new ConsoleKeyInfo((char)0, ConsoleKey.VolumeDown, false, false, false);
         public static ConsoleKeyInfo VolumeMute = new ConsoleKeyInfo((char)0, ConsoleKey.VolumeMute, false, false, false);
+#endif
     }
 }

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -11,22 +11,6 @@ namespace Microsoft.PowerShell
 {
     internal static class Keys
     {
-        static Keys()
-        {
-#if CORECLR
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Enter = new ConsoleKeyInfo((char)10, ConsoleKey.Enter, false, false, false);
-            }
-            else
-            {
-                Enter = new ConsoleKeyInfo((char)13, ConsoleKey.Enter, false, false, false);
-            }
-#else
-            Enter = new ConsoleKeyInfo((char)13, ConsoleKey.Enter, false, false, false);
-#endif
-        }
-
         public static ConsoleKeyInfo A = new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false);
         public static ConsoleKeyInfo B = new ConsoleKeyInfo('b', ConsoleKey.B, false, false, false);
         public static ConsoleKeyInfo C = new ConsoleKeyInfo('c', ConsoleKey.C, false, false, false);
@@ -224,7 +208,7 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo End          = new ConsoleKeyInfo((char)0, ConsoleKey.End, false, false, false);
         public static ConsoleKeyInfo CtrlEnd      = new ConsoleKeyInfo((char)0, ConsoleKey.End, false, false, true);
         public static ConsoleKeyInfo ShiftEnd     = new ConsoleKeyInfo((char)0, ConsoleKey.End, true, false, false);
-        public static ConsoleKeyInfo Enter; 
+        public static ConsoleKeyInfo Enter        = new ConsoleKeyInfo((char)13, ConsoleKey.Enter, false, false, false);
         public static ConsoleKeyInfo Escape       = new ConsoleKeyInfo((char)27, ConsoleKey.Escape, false, false, false);
         public static ConsoleKeyInfo Home         = new ConsoleKeyInfo((char)0, ConsoleKey.Home, false, false, false);
         public static ConsoleKeyInfo CtrlHome     = new ConsoleKeyInfo((char)0, ConsoleKey.Home, false, false, true);

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -105,6 +105,7 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo Minus       = new ConsoleKeyInfo('-', ConsoleKey.OemMinus, false, false, false);
         public static ConsoleKeyInfo AltMinus    = new ConsoleKeyInfo('-', ConsoleKey.OemMinus, false, true, false);
         public static ConsoleKeyInfo Plus        = new ConsoleKeyInfo('+', ConsoleKey.OemPlus, true, false, false);
+        new
         public static ConsoleKeyInfo Equals      = new ConsoleKeyInfo('=', ConsoleKey.OemPlus, false, false, false);
 
         public static ConsoleKeyInfo CtrlAt       = new ConsoleKeyInfo((char)0, ConsoleKey.D2, true, false, true);

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -290,7 +290,7 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo ShiftF8 = new ConsoleKeyInfo((char)0, ConsoleKey.F8, true, false, false);
 
         // Keys to ignore 
-#if !LINUX
+#if !UNIX
         public static ConsoleKeyInfo VolumeUp   = new ConsoleKeyInfo((char)0, /*ConsoleKey.VolumeUp*/(ConsoleKey)175, false, false, false);
         public static ConsoleKeyInfo VolumeDown = new ConsoleKeyInfo((char)0, /*ConsoleKey.VolumeDown*/(ConsoleKey)174, false, false, false);
         public static ConsoleKeyInfo VolumeMute = new ConsoleKeyInfo((char)0, /*ConsoleKey.VolumeMute*/(ConsoleKey)173, false, false, false);

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -290,10 +290,10 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo ShiftF8 = new ConsoleKeyInfo((char)0, ConsoleKey.F8, true, false, false);
 
         // Keys to ignore 
-#if !CORECLR
-        public static ConsoleKeyInfo VolumeUp   = new ConsoleKeyInfo((char)0, ConsoleKey.VolumeUp, false, false, false);
-        public static ConsoleKeyInfo VolumeDown = new ConsoleKeyInfo((char)0, ConsoleKey.VolumeDown, false, false, false);
-        public static ConsoleKeyInfo VolumeMute = new ConsoleKeyInfo((char)0, ConsoleKey.VolumeMute, false, false, false);
+#if !LINUX
+        public static ConsoleKeyInfo VolumeUp   = new ConsoleKeyInfo((char)0, /*ConsoleKey.VolumeUp*/(ConsoleKey)175, false, false, false);
+        public static ConsoleKeyInfo VolumeDown = new ConsoleKeyInfo((char)0, /*ConsoleKey.VolumeDown*/(ConsoleKey)174, false, false, false);
+        public static ConsoleKeyInfo VolumeMute = new ConsoleKeyInfo((char)0, /*ConsoleKey.VolumeMute*/(ConsoleKey)173, false, false, false);
 #endif
     }
 }

--- a/PSReadLine/KillYank.cs
+++ b/PSReadLine/KillYank.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Language;
-using System.Windows.Forms;
+//using System.Windows.Forms;
 
 namespace Microsoft.PowerShell
 {
@@ -476,6 +476,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void Paste(ConsoleKeyInfo? key = null, object arg = null)
         {
+#if !CORECLR
             string textToPaste = null;
             ExecuteOnSTAThread(() => {
                 if (Clipboard.ContainsText())
@@ -498,6 +499,7 @@ namespace Microsoft.PowerShell
                     Insert(textToPaste);
                 }
             }
+#endif
         }
 
         /// <summary>
@@ -506,6 +508,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void Copy(ConsoleKeyInfo? key = null, object arg = null)
         {
+#if !CORECLR
             string textToSet;
             if (_singleton._visualSelectionCommandCount > 0)
             {
@@ -521,6 +524,7 @@ namespace Microsoft.PowerShell
             {
                 ExecuteOnSTAThread(() => Clipboard.SetText(textToSet));
             }
+#endif
         }
 
         /// <summary>
@@ -545,6 +549,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void Cut(ConsoleKeyInfo? key = null, object arg = null)
         {
+#if !CORECLR
             if (_singleton._visualSelectionCommandCount > 0)
             {
                 int start, length;
@@ -552,6 +557,7 @@ namespace Microsoft.PowerShell
                 ExecuteOnSTAThread(() => Clipboard.SetText(_singleton._buffer.ToString(start, length)));
                 Delete(start, length);
             }
+#endif
         }
     }
 }

--- a/PSReadLine/KillYank.cs
+++ b/PSReadLine/KillYank.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Language;
-//using System.Windows.Forms;
+#if !CORECLR
+using System.Windows.Forms;
+#endif
 
 namespace Microsoft.PowerShell
 {

--- a/PSReadLine/KillYank.cs
+++ b/PSReadLine/KillYank.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell
         private int _visualSelectionCommandCount;
 
         /// <summary>
-        /// Mark the current loction of the cursor for use in a subsequent editing command.
+        /// Mark the current location of the cursor for use in a subsequent editing command.
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void SetMark(ConsoleKeyInfo? key = null, object arg = null)

--- a/PSReadLine/KillYank.cs
+++ b/PSReadLine/KillYank.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Language;
-#if !CORECLR
+#if !CORECLR // TODO: clipboard
 using System.Windows.Forms;
 #endif
 
@@ -478,7 +478,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void Paste(ConsoleKeyInfo? key = null, object arg = null)
         {
-#if !CORECLR
+#if !CORECLR // TODO: clipboard
             string textToPaste = null;
             ExecuteOnSTAThread(() => {
                 if (Clipboard.ContainsText())
@@ -510,7 +510,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void Copy(ConsoleKeyInfo? key = null, object arg = null)
         {
-#if !CORECLR
+#if !CORECLR // TODO: clipboard
             string textToSet;
             if (_singleton._visualSelectionCommandCount > 0)
             {
@@ -551,15 +551,15 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void Cut(ConsoleKeyInfo? key = null, object arg = null)
         {
-#if !CORECLR
             if (_singleton._visualSelectionCommandCount > 0)
             {
                 int start, length;
                 _singleton.GetRegion(out start, out length);
+#if !CORECLR // TODO: clipboard
                 ExecuteOnSTAThread(() => Clipboard.SetText(_singleton._buffer.ToString(start, length)));
+#endif
                 Delete(start, length);
             }
-#endif
         }
     }
 }

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -434,6 +434,11 @@ namespace Microsoft.PowerShell
         public static void ClearScreen(ConsoleKeyInfo? key = null, object arg = null)
         {
             var console = _singleton._console;
+#if CORECLR
+            console.Clear();
+            _singleton._initialY = 0; 
+            _singleton.Render();
+#else
             if (_singleton._initialY + console.WindowHeight > console.BufferHeight)
             {
                 var scrollCount = _singleton._initialY - console.WindowTop;
@@ -445,6 +450,7 @@ namespace Microsoft.PowerShell
             {
                 console.SetWindowPosition(0, _singleton._initialY);
             }
+#endif                
         }
 
         // Try to convert the arg to a char, return 0 for failure

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -434,7 +434,7 @@ namespace Microsoft.PowerShell
         public static void ClearScreen(ConsoleKeyInfo? key = null, object arg = null)
         {
             var console = _singleton._console;
-#if LINUX // TODO: this is not correct, it should only scroll
+#if UNIX // TODO: this is not correct, it should only scroll
             console.Clear();
             _singleton._initialY = 0; 
             _singleton.Render();

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -434,7 +434,7 @@ namespace Microsoft.PowerShell
         public static void ClearScreen(ConsoleKeyInfo? key = null, object arg = null)
         {
             var console = _singleton._console;
-#if CORECLR
+#if LINUX // TODO: this is not correct, it should only scroll
             console.Clear();
             _singleton._initialY = 0; 
             _singleton.Render();

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -297,7 +297,7 @@ namespace Microsoft.PowerShell
         public static IEnumerable<Microsoft.PowerShell.KeyHandler> GetKeyHandlers(bool includeBound = true, bool includeUnbound = false)
         {
             var boundFunctions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
+            
             foreach (var entry in _singleton._dispatchTable)
             {
                 if (entry.Value.BriefDescription == "Ignore"

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -96,18 +96,7 @@ namespace Microsoft.PowerShell
                 // Switching/resetting modes - clear out chord dispatch table
                 _chordDispatchTable.Clear();
 
-                switch (options._editMode)
-                {
-                case EditMode.Emacs:
-                    SetDefaultEmacsBindings();
-                    break;
-                case EditMode.Vi:
-                    SetDefaultViBindings();
-                    break;
-                case EditMode.Windows:
-                    SetDefaultWindowsBindings();
-                    break;
-                }
+                SetDefaultBindings(Options.EditMode);
             }
             if (options._showToolTips.HasValue)
             {

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -34,6 +34,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'UNIX|AnyCPU'">
+    <OutputPath>bin\UNIX\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'CORECLR|AnyCPU'">
+    <OutputPath>bin\CORECLR\</OutputPath>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/PSReadLine/PSReadLine.psd1
+++ b/PSReadLine/PSReadLine.psd1
@@ -13,5 +13,5 @@ CLRVersion = '4.0'
 FunctionsToExport = 'PSConsoleHostReadline'
 CmdletsToExport = 'Get-PSReadlineKeyHandler','Set-PSReadlineKeyHandler','Remove-PSReadlineKeyHandler',
                   'Get-PSReadlineOption','Set-PSReadlineOption'
-HelpInfoURI = 'http://go.microsoft.com/fwlink/?LinkId=528806'
+HelpInfoURI = 'https://go.microsoft.com/fwlink/?LinkId=528806'
 }

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PSReadLine.PSReadLineResources", typeof(PSReadLineResources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.PowerShell.PSReadLine.PSReadLineResources", typeof(PSReadLineResources).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -10,7 +10,7 @@
 
 namespace Microsoft.PowerShell {
     using System;
-    
+    using System.Reflection;
     
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.PowerShell.PSReadLineResources", typeof(PSReadLineResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PSReadLine.PSReadLineResources", typeof(PSReadLineResources).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete the charcter before the cursor.
+        ///   Looks up a localized string similar to Delete the character before the cursor.
         /// </summary>
         internal static string BackwardDeleteCharDescription {
             get {
@@ -322,7 +322,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete the character under the cusor.
+        ///   Looks up a localized string similar to Delete the character under the cursor.
         /// </summary>
         internal static string DeleteCharDescription {
             get {
@@ -331,7 +331,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete the character under the cusor, or if the line is empty, exit the process..
+        ///   Looks up a localized string similar to Delete the character under the cursor, or if the line is empty, exit the process..
         /// </summary>
         internal static string DeleteCharOrExitDescription {
             get {
@@ -502,7 +502,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Moves the cursor to the perscribed column..
+        ///   Looks up a localized string similar to Moves the cursor to the prescribed column..
         /// </summary>
         internal static string GotoColumnDescription {
             get {
@@ -990,7 +990,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Searches backward for the perscribed character..
+        ///   Looks up a localized string similar to Searches backward for the prescribed character..
         /// </summary>
         internal static string SearchBackwardCharDescription {
             get {
@@ -999,7 +999,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move to the previous occurance of the specified character..
+        ///   Looks up a localized string similar to Move to the previous occurrence of the specified character..
         /// </summary>
         internal static string SearchCharBackwardDescription {
             get {
@@ -1008,7 +1008,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move to the previous occurance of the specified character and then forward one character..
+        ///   Looks up a localized string similar to Move to the previous occurrence of the specified character and then forward one character..
         /// </summary>
         internal static string SearchCharBackwardWithBackoffDescription {
             get {
@@ -1017,7 +1017,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move to the next occurance of the specified character..
+        ///   Looks up a localized string similar to Move to the next occurrence of the specified character..
         /// </summary>
         internal static string SearchCharDescription {
             get {
@@ -1026,7 +1026,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move to he next occurance of the specified character and then back one character..
+        ///   Looks up a localized string similar to Move to he next occurrence of the specified character and then back one character..
         /// </summary>
         internal static string SearchCharWithBackoffDescription {
             get {
@@ -1035,7 +1035,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Searches for the perscribed character in the perscribed direction..
+        ///   Looks up a localized string similar to Searches for the prescribed character in the prescribed direction..
         /// </summary>
         internal static string SearchDescription {
             get {
@@ -1488,7 +1488,7 @@ namespace Microsoft.PowerShell {
         /// <summary>
         ///   Looks up a localized string similar to Moves the cursor to the beginning of the line and switches to insert mode..
         /// </summary>
-        internal static string ViInsertAtBeginingDescription {
+        internal static string ViInsertAtBeginningDescription {
             get {
                 return ResourceManager.GetString("ViInsertAtBeginingDescription", resourceCulture);
             }
@@ -1585,7 +1585,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete to the end of the word, as delimited by white space and common delimters, and enter insert mode..
+        ///   Looks up a localized string similar to Delete to the end of the word, as delimited by white space and common delimiters, and enter insert mode..
         /// </summary>
         internal static string ViReplaceEndOfWordDescription {
             get {
@@ -1639,7 +1639,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Starts a new seach backward in the history..
+        ///   Looks up a localized string similar to Starts a new search backward in the history..
         /// </summary>
         internal static string ViSearchHistoryBackwardDescription {
             get {
@@ -1756,7 +1756,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Place all characters from before the cursor to the beginning of the previous word, as delimted by white space and common delimiters, into the local clipboard..
+        ///   Looks up a localized string similar to Place all characters from before the cursor to the beginning of the previous word, as delimited by white space and common delimiters, into the local clipboard..
         /// </summary>
         internal static string ViYankPreviousWordDescription {
             get {

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -127,7 +127,7 @@
     <value>Move the cursor back one character</value>
   </data>
   <data name="BackwardDeleteCharDescription" xml:space="preserve">
-    <value>Delete the charcter before the cursor</value>
+    <value>Delete the character before the cursor</value>
   </data>
   <data name="BackwardDeleteLineDescription" xml:space="preserve">
     <value>Delete text from the cursor to the start of the line</value>
@@ -154,7 +154,7 @@
     <value>Complete the input if there is a single completion, otherwise complete the input with common prefix for all completions.  Show possible completions if pressed a second time.</value>
   </data>
   <data name="DeleteCharDescription" xml:space="preserve">
-    <value>Delete the character under the cusor</value>
+    <value>Delete the character under the cursor</value>
   </data>
   <data name="ShellBackwardWordDescription" xml:space="preserve">
     <value>Move the cursor to the beginning of the current or previous token or start of the line</value>
@@ -412,7 +412,7 @@ Exception:
 If there are other parse errors, unresolved commands, or incorrect parameters, show the error and continue editing.</value>
   </data>
   <data name="DeleteCharOrExitDescription" xml:space="preserve">
-    <value>Delete the character under the cusor, or if the line is empty, exit the process.</value>
+    <value>Delete the character under the cursor, or if the line is empty, exit the process.</value>
   </data>
   <data name="CantTranslateKey" xml:space="preserve">
     <value>Unable to translate '{0}' to virtual key code: {1}.</value>
@@ -451,10 +451,10 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Repeats the last search.</value>
   </data>
   <data name="SearchBackwardCharDescription" xml:space="preserve">
-    <value>Searches backward for the perscribed character.</value>
+    <value>Searches backward for the prescribed character.</value>
   </data>
   <data name="SearchDescription" xml:space="preserve">
-    <value>Searches for the perscribed character in the perscribed direction.</value>
+    <value>Searches for the prescribed character in the prescribed direction.</value>
   </data>
   <data name="ViAppendAtEndDescription" xml:space="preserve">
     <value>Switches to insert mode after positioning the cursor past the end of the line.</value>
@@ -496,7 +496,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Moves the cursor forward to the end of the next word.</value>
   </data>
   <data name="GotoColumnDescription" xml:space="preserve">
-    <value>Moves the cursor to the perscribed column.</value>
+    <value>Moves the cursor to the prescribed column.</value>
   </data>
   <data name="ViInsertModeDescription" xml:space="preserve">
     <value>Switches to insert mode.</value>
@@ -547,7 +547,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Delete the current character and insert the next character.</value>
   </data>
   <data name="ViSearchHistoryBackwardDescription" xml:space="preserve">
-    <value>Starts a new seach backward in the history.</value>
+    <value>Starts a new search backward in the history.</value>
   </data>
   <data name="ViTransposeCharsDescription" xml:space="preserve">
     <value>Transposes the current character with the next character in the line.</value>
@@ -565,16 +565,16 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Repeat the last recorded character search.</value>
   </data>
   <data name="SearchCharBackwardDescription" xml:space="preserve">
-    <value>Move to the previous occurance of the specified character.</value>
+    <value>Move to the previous occurrence of the specified character.</value>
   </data>
   <data name="SearchCharBackwardWithBackoffDescription" xml:space="preserve">
-    <value>Move to the previous occurance of the specified character and then forward one character.</value>
+    <value>Move to the previous occurrence of the specified character and then forward one character.</value>
   </data>
   <data name="SearchCharDescription" xml:space="preserve">
-    <value>Move to the next occurance of the specified character.</value>
+    <value>Move to the next occurrence of the specified character.</value>
   </data>
   <data name="SearchCharWithBackoffDescription" xml:space="preserve">
-    <value>Move to he next occurance of the specified character and then back one character.</value>
+    <value>Move to he next occurrence of the specified character and then back one character.</value>
   </data>
   <data name="ViBackwardReplaceWordDescription" xml:space="preserve">
     <value>Replace the previous word.</value>
@@ -622,7 +622,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Delete to the beginning of the next word, as delimited by white space, and enter insert mode.</value>
   </data>
   <data name="ViReplaceEndOfWordDescription" xml:space="preserve">
-    <value>Delete to the end of the word, as delimited by white space and common delimters, and enter insert mode.</value>
+    <value>Delete to the end of the word, as delimited by white space and common delimiters, and enter insert mode.</value>
   </data>
   <data name="ViReplaceEndOfGlobDescription" xml:space="preserve">
     <value>Delete to the end of the word, as delimited by white space, and enter insert mode.</value>
@@ -634,7 +634,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Place all characters at and after the cursor into the local clipboard.</value>
   </data>
   <data name="ViYankPreviousWordDescription" xml:space="preserve">
-    <value>Place all characters from before the cursor to the beginning of the previous word, as delimted by white space and common delimiters, into the local clipboard.</value>
+    <value>Place all characters from before the cursor to the beginning of the previous word, as delimited by white space and common delimiters, into the local clipboard.</value>
   </data>
   <data name="ViYankPreviousGlobDescription" xml:space="preserve">
     <value>Place all characters from before the cursor to the beginning of the previous word, as delimited by white space, into the local clipboard.</value>

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -54,6 +54,9 @@ namespace Microsoft.PowerShell
             void StartRender();
             int LengthInBufferCells(char c);
             void EndRender();
+#if CORECLR
+            void Clear();
+#endif
         }
 
 #pragma warning restore 1591

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -125,7 +125,7 @@ namespace Microsoft.PowerShell
         /// <param name="length">The length to replace</param>
         /// <param name="replacement">The replacement text</param>
         /// <param name="instigator">The action that initiated the replace (used for undo)</param>
-        /// <param name="instigatorArg">The argument to the action that initiaed the replace (used for undo)</param>
+        /// <param name="instigatorArg">The argument to the action that initiated the replace (used for undo)</param>
         public static void Replace(int start, int length, string replacement, Action<ConsoleKeyInfo?, object> instigator = null, object instigatorArg = null)
         {
             if (start < 0 || start > _singleton._buffer.Length)
@@ -224,7 +224,7 @@ namespace Microsoft.PowerShell
 
         /// <summary>
         /// A helper method when your function expects an optional int argument (e.g. from DigitArgument)
-        /// If there is not argument (it's null), returns true and sets numericArg to derfaultNumericArg.
+        /// If there is not argument (it's null), returns true and sets numericArg to defaultNumericArg.
         /// Dings and returns false if the argument is not an int (no conversion is attempted)
         /// Otherwise returns true, and numericArg has the result.
         /// </summary>

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell
             void StartRender();
             int LengthInBufferCells(char c);
             void EndRender();
-#if CORECLR
+#if LINUX
             void Clear();
 #endif
         }

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell
             void StartRender();
             int LengthInBufferCells(char c);
             void EndRender();
-#if LINUX
+#if UNIX
             void Clear();
 #endif
         }

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -28,8 +28,9 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
         public interface IConsole
         {
-            uint GetConsoleInputMode();
-            void SetConsoleInputMode(uint mode);
+            object GetConsoleInputMode();
+            void SetConsoleInputMode(object mode);
+            void RestoreConsoleInputMode(object mode);
             ConsoleKeyInfo ReadKey();
             bool KeyAvailable { get; }
             int CursorLeft { get; set; }

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -47,10 +47,10 @@ namespace Microsoft.PowerShell
             void SetCursorPosition(int left, int top);
             void WriteLine(string s);
             void Write(string s);
-            void WriteBufferLines(CHAR_INFO[] buffer, ref int top);
-            void WriteBufferLines(CHAR_INFO[] buffer, ref int top, bool ensureBottomLineVisible);
+            void WriteBufferLines(BufferChar[] buffer, ref int top);
+            void WriteBufferLines(BufferChar[] buffer, ref int top, bool ensureBottomLineVisible);
             void ScrollBuffer(int lines);
-            CHAR_INFO[] ReadBufferLines(int top, int count);
+            BufferChar[] ReadBufferLines(int top, int count);
 
             void StartRender();
             int LengthInBufferCells(char c);

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -490,6 +490,7 @@ namespace Microsoft.PowerShell
                     dispatchTable.TryGetValue(key, out handler);
                 }
             }
+
             if (handler != null)
             {
                 if (handler.ScriptBlock != null)

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -557,13 +557,18 @@ namespace Microsoft.PowerShell
             _visualSelectionCommandCount = 0;
             _statusIsErrorMessage = false;
 
-            _consoleBuffer = ReadBufferLines(_initialY, 1 + Options.ExtraPromptLineCount);
+            
 #if UNIX // TODO: not necessary if ReadBufferLines worked, or if rendering worked on spans instead of complete lines
             string newPrompt = GetPrompt();
+            var bufferLineCount = (newPrompt.Length) / (_console.BufferWidth) + 1;
+            _consoleBuffer = ReadBufferLines(_initialY, bufferLineCount);
+            
             for (int i=0; i<newPrompt.Length; ++i)
             {
                 _consoleBuffer[i].UnicodeChar = newPrompt[i];
             }
+#else
+            _consoleBuffer = ReadBufferLines(_initialY, 1 + Options.ExtraPromptLineCount);
 #endif
             _lastRenderTime = Stopwatch.StartNew();
 

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PowerShell
                                 // There is an OnIdle event.  We're idle because we timed out.  Normally
                                 // PowerShell generates this event, but PowerShell assumes the engine is not
                                 // idle because it called PSConsoleHostReadline which isn't returning.
-                                // So we generate the event intstead.
+                                // So we generate the event instead.
                                 _singleton._engineIntrinsics.Events.GenerateEvent("PowerShell.OnIdle", null, null, null);
                                 runPipelineForEventProcessing = true;
                                 break;

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -485,8 +485,6 @@ namespace Microsoft.PowerShell
             _console = new ConhostConsole();
 #endif
 
-            SetDefaultWindowsBindings();
-
             _buffer = new StringBuilder(8 * 1024);
             _statusBuffer = new StringBuilder(256);
             _savedCurrentLine = new HistoryItem();
@@ -516,6 +514,7 @@ namespace Microsoft.PowerShell
                 hostName = "PSReadline";
             }
             _options = new PSConsoleReadlineOptions(hostName);
+            SetDefaultBindings(_options.EditMode);
         }
 
         private void Initialize(Runspace runspace, EngineIntrinsics engineIntrinsics)

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell
         private IConsole _console;
 
         private EngineIntrinsics _engineIntrinsics;
-#if !LINUX
+#if !UNIX
         private static GCHandle _breakHandlerGcHandle;
 #endif
         private Thread _readKeyThread;
@@ -479,7 +479,7 @@ namespace Microsoft.PowerShell
         private PSConsoleReadLine()
         {
             _mockableMethods = this;
-#if LINUX
+#if UNIX
             _console = new TTYConsole();
 #else
             _console = new ConhostConsole();
@@ -558,7 +558,7 @@ namespace Microsoft.PowerShell
             _statusIsErrorMessage = false;
 
             _consoleBuffer = ReadBufferLines(_initialY, 1 + Options.ExtraPromptLineCount);
-#if LINUX // TODO: not necessary if ReadBufferLines worked, or if rendering worked on spans instead of complete lines
+#if UNIX // TODO: not necessary if ReadBufferLines worked, or if rendering worked on spans instead of complete lines
             string newPrompt = GetPrompt();
             for (int i=0; i<newPrompt.Length; ++i)
             {
@@ -612,7 +612,7 @@ namespace Microsoft.PowerShell
                 }
             }
 
-#if LINUX
+#if UNIX
             _historyFileMutex = new Mutex(false);
 #else
             _historyFileMutex = new Mutex(false, GetHistorySaveFileMutexName());
@@ -649,7 +649,7 @@ namespace Microsoft.PowerShell
             _killIndex = -1; // So first add indexes 0.
             _killRing = new List<string>(Options.MaximumKillRingCount);
 
-#if !LINUX
+#if !UNIX
             _breakHandlerGcHandle = GCHandle.Alloc(new BreakHandler(_singleton.BreakHandler));
             NativeMethods.SetConsoleCtrlHandler((BreakHandler)_breakHandlerGcHandle.Target, true);
 #endif
@@ -865,7 +865,7 @@ namespace Microsoft.PowerShell
 
             _singleton._initialX = _singleton._console.CursorLeft;
             _singleton._consoleBuffer = ReadBufferLines(_singleton._initialY, 1 + _singleton.Options.ExtraPromptLineCount);
-#if LINUX // TODO: ReadBufferLines only needed for extra line, but doesn't work on Linux
+#if UNIX // TODO: ReadBufferLines only needed for extra line, but doesn't work on Linux
             for (int i=0; i<newPrompt.Length; ++i)
             {
                 _singleton._consoleBuffer[i].UnicodeChar = newPrompt[i];

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -258,6 +258,14 @@ namespace Microsoft.PowerShell
         public static string ReadLine(Runspace runspace, EngineIntrinsics engineIntrinsics)
         {
             var console = _singleton._console;
+
+            // If either stdin or stdout is redirected, PSReadline doesn't really work, so throw
+            // and let PowerShell call Console.ReadLine or do whatever else it decides to do.
+            if (Console.IsInputRedirected || Console.IsOutputRedirected)
+            {
+                throw new NotSupportedException();
+            }
+
 #if CORECLR
             _singleton._prePSReadlineControlCMode = Console.TreatControlCAsInput;
 #else

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -544,7 +544,12 @@ namespace Microsoft.PowerShell
             _initialY = _console.CursorTop - Options.ExtraPromptLineCount;
             _initialBackgroundColor = _console.BackgroundColor;
             _initialForegroundColor = _console.ForegroundColor;
-            _space = new CHAR_INFO(' ', _initialForegroundColor, _initialBackgroundColor);
+            _space = new BufferChar
+            {
+                UnicodeChar = ' ',
+                BackgroundColor = _initialBackgroundColor,
+                ForegroundColor = _initialForegroundColor
+            };
             _bufferWidth = _console.BufferWidth;
             _killCommandCount = 0;
             _yankCommandCount = 0;

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -876,6 +876,11 @@ namespace Microsoft.PowerShell
             _singleton.Render();
         }
 
+        /// <summary>
+        /// Gets the current prompt as possibly defined by the user through the
+        /// prompt function, and returns a default prompt if no other is
+        /// available. Also handles remote prompts.
+        /// </summary>
         public static string GetPrompt()
         {
             var runspaceIsRemote = _singleton._mockableMethods.RunspaceIsRemote(_singleton._runspace);

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -197,7 +197,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Read the next character and then find it, going backard, and then back off a character.
+        /// Read the next character and then find it, going backward, and then back off a character.
         /// This is for 'T' functionality.
         /// </summary>
         public static void SearchCharBackward(ConsoleKeyInfo? key = null, object arg = null)
@@ -219,7 +219,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Read the next character and then find it, going backard, and then back off a character.
+        /// Read the next character and then find it, going backward, and then back off a character.
         /// This is for 'T' functionality.
         /// </summary>
         public static void SearchCharBackwardWithBackoff(ConsoleKeyInfo? key = null, object arg = null)
@@ -570,7 +570,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Switch to Insert mode and position the cursor at the begining of the line.
+        /// Switch to Insert mode and position the cursor at the beginning of the line.
         /// </summary>
         public static void ViInsertAtBegining(ConsoleKeyInfo? key = null, object arg = null)
         {
@@ -887,7 +887,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Prompts for a string for history searching.
         /// </summary>
-        /// <param name="backward">True for seaching backward in the history.</param>
+        /// <param name="backward">True for searching backward in the history.</param>
         private void StartSearch(bool backward)
         {
             _statusLinePrompt = "find: ";

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -131,6 +131,7 @@ namespace Microsoft.PowerShell
                         // use the tokens color otherwise use the initial color.
                         var state = tokenStack.Peek();
                         var token = state.Tokens[state.Index];
+
                         if (i == token.Extent.EndOffset)
                         {
                             if (token == state.Tokens[state.Tokens.Length - 1])
@@ -153,7 +154,6 @@ namespace Microsoft.PowerShell
                             {
                                 foregroundColor = state.ForegroundColor;
                                 backgroundColor = state.BackgroundColor;
-
                                 token = state.Tokens[++state.Index];
                             }
                         }
@@ -231,12 +231,16 @@ namespace Microsoft.PowerShell
                         else if (size > 1)
                         {
                             _consoleBuffer[j].UnicodeChar = charToRender;
+#if !CORECLR
                             _consoleBuffer[j].Attributes = (ushort)(_consoleBuffer[j].Attributes |
                                                            (uint)CHAR_INFO_Attributes.COMMON_LVB_LEADING_BYTE);
+#endif
                             MaybeEmphasize(ref _consoleBuffer[j++], i, foregroundColor, backgroundColor);
                             _consoleBuffer[j].UnicodeChar = charToRender;
+#if !CORECLR
                             _consoleBuffer[j].Attributes = (ushort)(_consoleBuffer[j].Attributes |
                                                            (uint)CHAR_INFO_Attributes.COMMON_LVB_TRAILING_BYTE);
+#endif
                             MaybeEmphasize(ref _consoleBuffer[j++], i, foregroundColor, backgroundColor);
                         }
                         else

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -100,7 +100,9 @@ namespace Microsoft.PowerShell
 
             try
             {
+#if !CORECLR
                 _console.StartRender();
+#endif
 
                 bufferLineCount = ConvertOffsetToCoordinates(text.Length).Y - _initialY + 1 + statusLineCount;
                 if (_consoleBuffer.Length != bufferLineCount * bufferWidth)
@@ -247,7 +249,9 @@ namespace Microsoft.PowerShell
             }
             finally
             {
+#if !CORECLR
                 _console.EndRender();
+#endif
             }
 
             for (; j < (_consoleBuffer.Length - (statusLineCount * _bufferWidth)); j++)
@@ -311,7 +315,9 @@ namespace Microsoft.PowerShell
 
             if ((_initialY + bufferLineCount) > (_console.WindowTop + _console.WindowHeight))
             {
+#if !CORECLR               
                 _console.WindowTop = _initialY + bufferLineCount - _console.WindowHeight;
+#endif
             }
 
             _lastRenderTime.Restart();
@@ -638,9 +644,12 @@ namespace Microsoft.PowerShell
             return (_statusLinePrompt.Length + _statusBuffer.Length) / _console.BufferWidth + 1;
         }
 
+#if !CORECLR
         [ExcludeFromCodeCoverage]
+#endif
         void IPSConsoleReadLineMockableMethods.Ding()
         {
+#if !CORECLR
             switch (Options.BellStyle)
             {
             case BellStyle.None:
@@ -652,6 +661,7 @@ namespace Microsoft.PowerShell
                 // TODO: flash prompt? command line?
                 break;
             }
+#endif
         }
 
         /// <summary>

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -472,8 +472,14 @@ namespace Microsoft.PowerShell
                 // to invert only the lower 3 bits to change the color is somewhat
                 // but looks best with the 2 default color schemes - starting PowerShell
                 // from it's shortcut or from a cmd shortcut.
+#if CORECLR                
+                ConsoleColor tempColor = ((int)foregroundColor == -1) ? ConsoleColor.White : foregroundColor;
+                foregroundColor = ((int)backgroundColor == -1) ? ConsoleColor.Black : backgroundColor;
+                backgroundColor = tempColor;
+#else
                 foregroundColor = (ConsoleColor)((int)foregroundColor ^ 7);
                 backgroundColor = (ConsoleColor)((int)backgroundColor ^ 7);
+#endif
             }
 
             charInfo.ForegroundColor = foregroundColor;

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -696,6 +696,7 @@ namespace Microsoft.PowerShell
 
         #region Screen scrolling
 
+#if !CORECLR
         /// <summary>
         /// Scroll the display up one screen.
         /// </summary>
@@ -814,6 +815,7 @@ namespace Microsoft.PowerShell
             console.SetWindowPosition(0, newTop);
         }
 
+#endif
         #endregion Screen scrolling
     }
 }

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -462,7 +462,7 @@ namespace Microsoft.PowerShell
             else if (_visualSelectionCommandCount > 0 && InRegion(i))
             {
                 // We can't quite emulate real console selection because it inverts
-                // based on actual screen colors, our pallete is limited.  The choice
+                // based on actual screen colors, our palette is limited.  The choice
                 // to invert only the lower 3 bits to change the color is somewhat
                 // but looks best with the 2 default color schemes - starting PowerShell
                 // from it's shortcut or from a cmd shortcut.

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -13,6 +13,7 @@ namespace Microsoft.PowerShell
 {
     public partial class PSConsoleReadLine
     {
+        private const ConsoleColor UnknownColor = (ConsoleColor) (-1);
         private CHAR_INFO[] _consoleBuffer;
         private int _initialX;
         private int _initialY;
@@ -464,8 +465,8 @@ namespace Microsoft.PowerShell
                 // but looks best with the 2 default color schemes - starting PowerShell
                 // from it's shortcut or from a cmd shortcut.
 #if LINUX // TODO: set Inverse attribute and let render choose what to do.
-                ConsoleColor tempColor = ((int)foregroundColor == -1) ? ConsoleColor.White : foregroundColor;
-                foregroundColor = ((int)backgroundColor == -1) ? ConsoleColor.Black : backgroundColor;
+                ConsoleColor tempColor = (foregroundColor == UnknownColor) ? ConsoleColor.White : foregroundColor;
+                foregroundColor = (backgroundColor == UnknownColor) ? ConsoleColor.Black : backgroundColor;
                 backgroundColor = tempColor;
 #else
                 foregroundColor = (ConsoleColor)((int)foregroundColor ^ 7);

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerShell
 {
     public partial class PSConsoleReadLine
     {
-#if LINUX
+#if UNIX
         private const ConsoleColor UnknownColor = (ConsoleColor) (-1);
 #endif
         private BufferChar[] _consoleBuffer;
@@ -228,7 +228,7 @@ namespace Microsoft.PowerShell
                             MaybeEmphasize(ref _consoleBuffer[j++], i, foregroundColor, backgroundColor);
 
                         }
-#if !LINUX
+#if !UNIX
                         else if (size > 1)
                         {
                             _consoleBuffer[j].UnicodeChar = charToRender;
@@ -313,7 +313,7 @@ namespace Microsoft.PowerShell
 
             if ((_initialY + bufferLineCount) > (_console.WindowTop + _console.WindowHeight))
             {
-#if !LINUX // TODO: verify this isn't necessary for LINUX
+#if !UNIX // TODO: verify this isn't necessary for LINUX
                 _console.WindowTop = _initialY + bufferLineCount - _console.WindowHeight;
 #endif
             }
@@ -466,7 +466,7 @@ namespace Microsoft.PowerShell
                 // to invert only the lower 3 bits to change the color is somewhat
                 // but looks best with the 2 default color schemes - starting PowerShell
                 // from it's shortcut or from a cmd shortcut.
-#if LINUX // TODO: set Inverse attribute and let render choose what to do.
+#if UNIX // TODO: set Inverse attribute and let render choose what to do.
                 ConsoleColor tempColor = (foregroundColor == UnknownColor) ? ConsoleColor.White : foregroundColor;
                 foregroundColor = (backgroundColor == UnknownColor) ? ConsoleColor.Black : backgroundColor;
                 backgroundColor = tempColor;
@@ -656,7 +656,7 @@ namespace Microsoft.PowerShell
             case BellStyle.None:
                 break;
             case BellStyle.Audible:
-#if LINUX
+#if UNIX
                 Console.Beep();
 #else
                 Console.Beep(Options.DingTone, Options.DingDuration);
@@ -690,7 +690,7 @@ namespace Microsoft.PowerShell
 
 #region Screen scrolling
 
-#if !LINUX
+#if !UNIX
         /// <summary>
         /// Scroll the display up one screen.
         /// </summary>

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -656,7 +656,11 @@ namespace Microsoft.PowerShell
             case BellStyle.None:
                 break;
             case BellStyle.Audible:
+#if LINUX
+                Console.Beep();
+#else
                 Console.Beep(Options.DingTone, Options.DingDuration);
+#endif
                 break;
             case BellStyle.Visual:
                 // TODO: flash prompt? command line?

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -100,10 +100,7 @@ namespace Microsoft.PowerShell
 
             try
             {
-#if !CORECLR
                 _console.StartRender();
-#endif
-
                 bufferLineCount = ConvertOffsetToCoordinates(text.Length).Y - _initialY + 1 + statusLineCount;
                 if (_consoleBuffer.Length != bufferLineCount * bufferWidth)
                 {
@@ -231,16 +228,12 @@ namespace Microsoft.PowerShell
                         else if (size > 1)
                         {
                             _consoleBuffer[j].UnicodeChar = charToRender;
-#if !CORECLR
                             _consoleBuffer[j].Attributes = (ushort)(_consoleBuffer[j].Attributes |
                                                            (uint)CHAR_INFO_Attributes.COMMON_LVB_LEADING_BYTE);
-#endif
                             MaybeEmphasize(ref _consoleBuffer[j++], i, foregroundColor, backgroundColor);
                             _consoleBuffer[j].UnicodeChar = charToRender;
-#if !CORECLR
                             _consoleBuffer[j].Attributes = (ushort)(_consoleBuffer[j].Attributes |
                                                            (uint)CHAR_INFO_Attributes.COMMON_LVB_TRAILING_BYTE);
-#endif
                             MaybeEmphasize(ref _consoleBuffer[j++], i, foregroundColor, backgroundColor);
                         }
                         else
@@ -253,9 +246,7 @@ namespace Microsoft.PowerShell
             }
             finally
             {
-#if !CORECLR
                 _console.EndRender();
-#endif
             }
 
             for (; j < (_consoleBuffer.Length - (statusLineCount * _bufferWidth)); j++)
@@ -319,7 +310,7 @@ namespace Microsoft.PowerShell
 
             if ((_initialY + bufferLineCount) > (_console.WindowTop + _console.WindowHeight))
             {
-#if !CORECLR               
+#if !LINUX // TODO: verify this isn't necessary for LINUX
                 _console.WindowTop = _initialY + bufferLineCount - _console.WindowHeight;
 #endif
             }
@@ -472,7 +463,7 @@ namespace Microsoft.PowerShell
                 // to invert only the lower 3 bits to change the color is somewhat
                 // but looks best with the 2 default color schemes - starting PowerShell
                 // from it's shortcut or from a cmd shortcut.
-#if CORECLR                
+#if LINUX // TODO: set Inverse attribute and let render choose what to do.
                 ConsoleColor tempColor = ((int)foregroundColor == -1) ? ConsoleColor.White : foregroundColor;
                 foregroundColor = ((int)backgroundColor == -1) ? ConsoleColor.Black : backgroundColor;
                 backgroundColor = tempColor;
@@ -654,12 +645,9 @@ namespace Microsoft.PowerShell
             return (_statusLinePrompt.Length + _statusBuffer.Length) / _console.BufferWidth + 1;
         }
 
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         void IPSConsoleReadLineMockableMethods.Ding()
         {
-#if !CORECLR
             switch (Options.BellStyle)
             {
             case BellStyle.None:
@@ -671,7 +659,6 @@ namespace Microsoft.PowerShell
                 // TODO: flash prompt? command line?
                 break;
             }
-#endif
         }
 
         /// <summary>
@@ -696,7 +683,7 @@ namespace Microsoft.PowerShell
 
         #region Screen scrolling
 
-#if !CORECLR
+#if !LINUX
         /// <summary>
         /// Scroll the display up one screen.
         /// </summary>

--- a/PSReadLine/ScreenCapture.cs
+++ b/PSReadLine/ScreenCapture.cs
@@ -2,6 +2,7 @@
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
+#if !CORECLR
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
@@ -194,7 +195,7 @@ namespace Microsoft.PowerShell
             var handle = NativeMethods.GetStdHandle((uint) StandardHandleId.Output);
             var csbe = new NativeMethods.CONSOLE_SCREEN_BUFFER_INFO_EX
             {
-                cbSize = Marshal.SizeOf(typeof(NativeMethods.CONSOLE_SCREEN_BUFFER_INFO_EX))
+                cbSize = Marshal.SizeOf<NativeMethods.CONSOLE_SCREEN_BUFFER_INFO_EX>()
             };
             if (NativeMethods.GetConsoleScreenBufferInfoEx(handle, ref csbe))
             {
@@ -304,3 +305,4 @@ namespace Microsoft.PowerShell
         }
     }
 }
+#endif

--- a/PSReadLine/ScreenCapture.cs
+++ b/PSReadLine/ScreenCapture.cs
@@ -19,8 +19,16 @@ namespace Microsoft.PowerShell
             var buffer = ReadBufferLines(start, count);
             for (int i = 0; i < buffer.Length; i++)
             {
+#if CORECLR                
+                ConsoleColor tempColor = (int)buffer[i].ForegroundColor == -1 
+                    ? ConsoleColor.White : buffer[i].ForegroundColor;
+                buffer[i].ForegroundColor = (int)buffer[i].BackgroundColor == -1 
+                    ? ConsoleColor.Black : buffer[i].BackgroundColor;
+                buffer[i].BackgroundColor = tempColor;
+#else
                 buffer[i].ForegroundColor = (ConsoleColor)((int)buffer[i].ForegroundColor ^ 7);
                 buffer[i].BackgroundColor = (ConsoleColor)((int)buffer[i].BackgroundColor ^ 7);
+#endif
             }
             _singleton._console.WriteBufferLines(buffer, ref start, false);
         }

--- a/PSReadLine/ScreenCapture.cs
+++ b/PSReadLine/ScreenCapture.cs
@@ -2,7 +2,7 @@
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
-#if !LINUX
+#if !UNIX
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;

--- a/PSReadLine/UndoRedo.cs
+++ b/PSReadLine/UndoRedo.cs
@@ -76,7 +76,8 @@ namespace Microsoft.PowerShell
                     _singleton.ClearStatusMessage(render: false);
                 }
                 _singleton._edits[_singleton._undoEditIndex - 1].Undo();
-                _singleton._edits.RemoveAt(_singleton._undoEditIndex - 1);
+                // How do you redo if you remove it permanently?
+//                _singleton._edits.RemoveAt(_singleton._undoEditIndex - 1);
                 _singleton._undoEditIndex--;
                 if (_singleton._options.EditMode == EditMode.Vi && _singleton._current >= _singleton._buffer.Length)
                 {

--- a/PSReadLine/UndoRedo.cs
+++ b/PSReadLine/UndoRedo.cs
@@ -76,8 +76,6 @@ namespace Microsoft.PowerShell
                     _singleton.ClearStatusMessage(render: false);
                 }
                 _singleton._edits[_singleton._undoEditIndex - 1].Undo();
-                // How do you redo if you remove it permanently?
-//                _singleton._edits.RemoveAt(_singleton._undoEditIndex - 1);
                 _singleton._undoEditIndex--;
                 if (_singleton._options.EditMode == EditMode.Vi && _singleton._current >= _singleton._buffer.Length)
                 {

--- a/PSReadLine/VisualEditing.vi.cs
+++ b/PSReadLine/VisualEditing.vi.cs
@@ -96,6 +96,16 @@ namespace Microsoft.PowerShell
         private static string GetPreferredEditor()
         {
             string[] names = {"VISUAL", "EDITOR"};
+#if CORECLR
+            foreach (string name in names)
+            {
+                string editor = Environment.GetEnvironmentVariable(name);
+                if (!string.IsNullOrWhiteSpace(editor))
+                {
+                    return editor;
+                }
+            }
+#else
             EnvironmentVariableTarget[] targets = {
                                                       EnvironmentVariableTarget.Machine,
                                                       EnvironmentVariableTarget.Process,
@@ -112,7 +122,7 @@ namespace Microsoft.PowerShell
                     }
                 }
             }
-
+#endif
             return null;
         }
     }

--- a/PSReadLine/VisualEditing.vi.cs
+++ b/PSReadLine/VisualEditing.vi.cs
@@ -96,7 +96,6 @@ namespace Microsoft.PowerShell
         private static string GetPreferredEditor()
         {
             string[] names = {"VISUAL", "EDITOR"};
-#if CORECLR
             foreach (string name in names)
             {
                 string editor = Environment.GetEnvironmentVariable(name);
@@ -105,24 +104,7 @@ namespace Microsoft.PowerShell
                     return editor;
                 }
             }
-#else
-            EnvironmentVariableTarget[] targets = {
-                                                      EnvironmentVariableTarget.Machine,
-                                                      EnvironmentVariableTarget.Process,
-                                                      EnvironmentVariableTarget.User
-                                                  };
-            foreach (string name in names)
-            {
-                foreach (EnvironmentVariableTarget target in targets)
-                {
-                    string editor = Environment.GetEnvironmentVariable(name, target);
-                    if (!string.IsNullOrWhiteSpace(editor))
-                    {
-                        return editor;
-                    }
-                }
-            }
-#endif
+
             return null;
         }
     }

--- a/PSReadLine/Words.vi.cs
+++ b/PSReadLine/Words.vi.cs
@@ -129,7 +129,7 @@ namespace Microsoft.PowerShell
         /// Returns the beginning of the current/next word as defined by wordDelimiters and whitespace.
         /// </summary>
         /// <param name="i">Current cursor location.</param>
-        /// <param name="wordDelimiters">Characters used to deliminate words.</param>
+        /// <param name="wordDelimiters">Characters used to delimit words.</param>
         /// <returns>Location of the beginning of the previous word.</returns>
         private int ViFindPreviousWordPoint(int i, string wordDelimiters)
         {

--- a/PSReadLine/en-US/PSReadline.md
+++ b/PSReadLine/en-US/PSReadline.md
@@ -10,9 +10,9 @@ If neither -Bound nor -Unbound is specified, returns all bound keys and unbound 
 
 If -Bound is specified and -Unbound is not specified, only bound keys are returned.
 
-If -Unound is specified and -Bound is not specified, only unbound keys are returned.
+If -Unbound is specified and -Bound is not specified, only unbound keys are returned.
 
-If both -Bound and -Unound are specified, returns all bound keys and unbound functions.
+If both -Bound and -Unbound are specified, returns all bound keys and unbound functions.
 
 ## PARAMETERS
 

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -1,7 +1,6 @@
 {
     "name": "Microsoft.PowerShell.PSReadLine",
     "version": "1.0.0-*",
-    "authors": [ "andschwa" ],
 
     "buildOptions": {
         "keyFile": "../signing/visualstudiopublic.snk",

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -1,0 +1,22 @@
+{
+    "name": "Microsoft.PowerShell.PSReadLine",
+    "version": "1.0.0-*",
+    "authors": [ "andschwa" ],
+
+    "compilationOptions": {
+        "warningsAsErrors": true
+    },
+
+    "dependencies": {
+        "System.Management.Automation": "1.0.0-*"
+    },
+
+    "frameworks": {
+        "netstandard1.5": {
+            "compilationOptions": {
+                "define": [ "CORECLR" ]
+            },
+            "imports": [ "dnxcore50", "portable-net45+win8" ]
+        }
+    }
+}

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -19,6 +19,11 @@
             "imports": [ "dnxcore50", "portable-net45+win8" ]
         },
         "net451": {
+            "frameworkAssemblies": {
+                "System.Windows.Forms": {
+                    "type": "build"
+                }
+            }
         }
     }
 }

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -3,7 +3,7 @@
     "version": "1.0.0-*",
     "authors": [ "andschwa" ],
 
-    "compilationOptions": {
+    "buildOptions": {
         "warningsAsErrors": true
     },
 
@@ -13,7 +13,7 @@
 
     "frameworks": {
         "netstandard1.5": {
-            "compilationOptions": {
+            "buildOptions": {
                 "define": [ "CORECLR" ]
             },
             "imports": [ "dnxcore50", "portable-net45+win8" ]

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -17,6 +17,8 @@
                 "define": [ "CORECLR" ]
             },
             "imports": [ "dnxcore50", "portable-net45+win8" ]
+        },
+        "net451": {
         }
     }
 }

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -4,6 +4,9 @@
     "authors": [ "andschwa" ],
 
     "buildOptions": {
+        "keyFile": "../signing/visualstudiopublic.snk",
+        "delaySign": true,
+        "publicSign": false,
         "warningsAsErrors": true
     },
 

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -25,7 +25,8 @@
     "frameworks": {
         "netstandard1.6": {
             "buildOptions": {
-                "define": [ "CORECLR" ]
+                "define": [ "CORECLR" ],
+                "debugType": "portable"
             },
             "imports": [ "dnxcore50", "portable-net45+win8" ]
         },

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -9,6 +9,14 @@
         "warningsAsErrors": true
     },
 
+    "configurations": {
+        "Linux": {
+            "buildOptions": {
+                "define": [ "LINUX" ]
+            }
+        }
+    },
+
     "dependencies": {
         "System.Management.Automation": "1.0.0-*"
     },

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -14,7 +14,7 @@
     },
 
     "frameworks": {
-        "netstandard1.5": {
+        "netstandard1.6": {
             "buildOptions": {
                 "define": [ "CORECLR" ]
             },

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -13,7 +13,7 @@
     "configurations": {
         "Linux": {
             "buildOptions": {
-                "define": [ "LINUX" ]
+                "define": [ "UNIX" ]
             }
         }
     },

--- a/PSReadLine/project.json
+++ b/PSReadLine/project.json
@@ -4,9 +4,6 @@
 
     "buildOptions": {
         "xmlDoc": true,
-        "keyFile": "../signing/visualstudiopublic.snk",
-        "delaySign": true,
-        "publicSign": false,
         "warningsAsErrors": true
     },
 
@@ -18,17 +15,17 @@
         }
     },
 
-    "dependencies": {
-        "System.Management.Automation": "1.0.0-*"
-    },
-
     "frameworks": {
         "netstandard1.6": {
             "buildOptions": {
                 "define": [ "CORECLR" ],
                 "debugType": "portable"
             },
-            "imports": [ "dnxcore50", "portable-net45+win8" ]
+            "imports": [ "dnxcore50", "portable-net45+win8" ],
+            "dependencies": {
+                "System.Management.Automation": "1.0.0-alpha10"
+            }
+
         },
         "net451": {
             "frameworkAssemblies": {


### PR DESCRIPTION
Hello,

I exported the changes made to PSReadLine in the PowerShell repo, and imported them here. I've added a commit so that it can be built outside of the PowerShell repo; however, I have not dealt with merge conflicts.

I would advise against attempting to rebase this, as it is too far diverged (I tried; it's not worth it). Merging master in would be the best choice; and the conflicts didn't look too bad (mostly around the addition of the TTY Console abstraction).

All changes were either made by Microsoft employees/contractors, or people who signed the PowerShell CLA.

Issue reference: https://github.com/PowerShell/PowerShell/issues/996

To export and import changes, in the PowerShell repo I did:

``` sh
git format-patch -o ~/patches --relative=src/Microsoft.PowerShell.PSReadLine 3603f2810.. src/Microsoft.PowerShell.PSReadLine
```

(The last argument there may have been unnecessary.)

And to import into PSReadLine, I did:

``` sh
git am --directory=PSReadLine ~/patches/*
```

This procedure can continue to be used to sync patches back and forth, as long as the common base is known (which I obtained by inspecting 3603f2810, the first commit in the PSReadLine subtree). I'm sure there are other ways to go about this, but `format-patch` and `am` are the ones I am most familiar with.
