### PR TITLE
[Upgrading] Added SkipPublisher Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ In either case, you can create the appropriate file if you don't already have on
 
 When running one of the suggested commands below, be sure to exit all instances of powershell.exe, then run the suggested command from cmd.exe, powershell_ise.exe, or via the Win+R shortcut to make sure PSReadline isn't loaded.
 
-If you are using the version of PSReadline that ships with Windows 10, you need to run: `powershell -noprofile -command "Install-Module PSReadline -Force"`.
+If you are using the version of PSReadline that ships with Windows 10, you need to run: `powershell -noprofile -command "Install-Module PSReadline -Force -SkipPublisherCheck"`.
 
 If you've installed PSReadline yourself from the PowerShell Gallery or with `PSGet` (this is less common on Windows 10), you can simply run: `powershell -noprofile -command "Update-Module PSReadline"`.
 


### PR DESCRIPTION
Had a problem with upgrading in an elevated cmd prompt:

```
PackageManagement\Install-Package : The version '1.2' of the module 'PSReadline' being installed is not catalog signed. Ensure that the version '1.2' of the module 'PSReadline' has the catalog file 'PSReadline.cat' and signed with the same publisher 'CN=Microsoft Root Certificate Authority 2010, O=Microsoft Corporation, L=Redmond, S=Washington, C=US' as the previously-installed module '1.2' with version '1.2' under the directory 'C:\Program Files\WindowsPowerShell\Modules\PSReadline\1.2'. If you still want to install or update, use -SkipPublisherCheck parameter.
```
