### PR TITLE
Remove PSReadline.dll-help.xml from csproj.

### DIFF
--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -113,9 +113,6 @@
     <None Include="en-US\about_PSReadline.help.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="en-US\PSReadline.dll-help.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="Changes.txt">


### PR DESCRIPTION
PR #344 deleted this file, but didn't remove the reference from the
csproj, which broke building from VS.