### PR TITLE
User should not be able to set MaxHistoryCount to unsupported value

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -461,6 +461,7 @@ namespace Microsoft.PowerShell
         internal SwitchParameter? _historySearchCursorMovesToEnd;
 
         [Parameter(ParameterSetName = "OptionsSet")]
+        [ValidateRange(1, int.MaxValue)]
         public int MaximumHistoryCount
         {
             get { return _maximumHistoryCount.GetValueOrDefault(); }


### PR DESCRIPTION
Resolving #431
Validate that MaxHistoryCount lies within the range of 1-int.maxValue.