### PR TITLE
test for negative _killIndex

### DIFF
--- a/PSReadLine/KillYank.cs
+++ b/PSReadLine/KillYank.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell
                 _buffer.Remove(start, length);
                 _current = start;
                 Render();
-                if (_killCommandCount > 0)
+                if (_killCommandCount > 0 && _killIndex >= 0)
                 {
                     if (prepend)
                     {

--- a/UnitTestPSReadLine/KillYankTest.cs
+++ b/UnitTestPSReadLine/KillYankTest.cs
@@ -86,6 +86,17 @@ namespace UnitTestPSReadLine
 
             // Make sure an empty kill doesn't end up in the kill ring
             Test("a", Keys("a", _.CtrlU, _.CtrlU, "b", _.CtrlU, _.CtrlY, _.AltY));
+
+            // Make sure an empty kill doesn't end up in the kill ring after movement commands
+            Test("abc def", Keys(
+                "abc def",
+                _.CtrlW, // remove 'def'
+                _.CtrlA, _.CtrlU, // empty kill at beginning of line
+                _.CtrlE, // back to end of line
+                "ghi",
+                _.CtrlW, // remove 'ghi'
+                _.CtrlY, // yank 'ghi'
+                _.AltY)); // replace busy with previous text in kill ring
         }
 
         [TestMethod]
@@ -134,6 +145,30 @@ namespace UnitTestPSReadLine
 
             // Test empty kill doesn't affect kill append
             Test("ab", Keys("ab", _.LeftArrow, _.CtrlK, _.CtrlK, _.CtrlU, _.CtrlY));
+
+            // test empty kill then good kill
+            Test("abc", Keys(
+                "abc",
+                _.CtrlK,
+                _.CtrlU,
+                _.CtrlY));
+
+            // test undo/redo history after empty kill
+            Test("abc def ghi", Keys(
+                "abc def ghi",
+                _.CtrlW, // remove ghi
+                _.CtrlK, // empty kill
+                _.CtrlW, // remove def
+                _.CtrlUnderbar, // bring back def
+                _.CtrlUnderbar)); // bring back ghi
+
+            // startup edge condition
+            TestSetup(KeyMode.Emacs);
+            Test("abc", Keys(
+                "abc",
+                _.CtrlK,
+                _.CtrlU,
+                _.CtrlY));
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes issue #241 (Reproducible with "A CTRL+K CTRL+U", typed in a fresh Powershell window)
Just tests `_killIndex` for negativity. `_killIndex` starts at -1 and erroneously indexes `_killRing`.