### PR TITLE
Workaround for reversed right click paste

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -466,6 +466,20 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void InsertLineAbove(ConsoleKeyInfo? key = null, object arg = null)
         {
+            // If there are more keys, assume the user pasted with a right click and
+            // we shouldn't reverse the order of the lines
+            if (_singleton._queuedKeys.Count > 0)
+            {
+                _singleton.AcceptLineImpl(false);
+            }
+            else
+            {
+                _singleton.InsertLineAboveImpl();
+            }
+        }
+
+        private void InsertLineAboveImpl()
+        {
             // Move the current position to the beginning of the current line and only the current line.
             if (_singleton.LineIsMultiLine())
             {


### PR DESCRIPTION
Fixes #496 

Not sure if this is the correct way to detect right click, but I found the same method in https://github.com/lzybkr/PSReadLine/blob/9d592b875ebea83d6385b9cc6b6899584b08277a/PSReadLine/BasicEditing.cs#L246-L249