### PR TITLE
Adding color for prompt text

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -361,15 +361,22 @@ namespace Microsoft.PowerShell
             PlaceCursor(_initialX, _initialY);
 
             // Possibly need to flip the color on the prompt if the error state changed.
-            if (!string.IsNullOrEmpty(_options.PromptText))
+            var promptText = _options.PromptText;
+            if (!string.IsNullOrEmpty(promptText))
             {
                 renderData.errorPrompt = (_parseErrors != null && _parseErrors.Length > 0);
                 if (renderData.errorPrompt != _previousRender.errorPrompt)
                 {
                     // We need to update the prompt
-                    _console.CursorLeft -= _options.PromptText.Length;
-                    UpdateColorsIfNecessary(renderData.errorPrompt ? _options._errorColor : defaultColor);
-                    _console.Write(_options.PromptText);
+
+                    // promptBufferCells is the number of visible characters in the prompt
+                    var promptBufferCells = LengthInBufferCells(promptText);
+                    _console.CursorLeft -= promptBufferCells;
+                    var color = renderData.errorPrompt ? _options._errorColor : defaultColor;
+                    if (renderData.errorPrompt && promptBufferCells != promptText.Length)
+                        promptText = promptText.Substring(promptText.Length - promptBufferCells);
+                    UpdateColorsIfNecessary(color);
+                    _console.Write(promptText);
                     _console.Write("\x1b[0m");
                 }
             }


### PR DESCRIPTION
When the promt is drawn with a different
color than the default text, it renders ugly when
we set it back to another color than what was
originally set.
![prompt](https://user-images.githubusercontent.com/3505151/37689231-12e429b6-2ca4-11e8-9a96-f07cd2b3d805.gif)

