### PR TITLE
Fixed Defect #651

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -219,6 +219,12 @@ namespace Microsoft.PowerShell
 
         private void CompleteImpl(bool menuSelect)
         {
+            if (InViInsertMode())   // must close out the current edit group before engaging menu completion
+            {
+                ViCommandMode();
+                ViInsertWithAppend();
+            }
+
             var completions = GetCompletions();
             if (completions == null || completions.CompletionMatches.Count == 0)
                 return;

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -481,7 +481,7 @@ namespace Microsoft.PowerShell
         public static bool InViCommandMode() => _singleton._dispatchTable == _viCmdKeyMap;
 
         /// <summary>
-        /// Returns trud if in Vi Insert mode, otherwise false.
+        /// Returns true if in Vi Insert mode, otherwise false.
         /// </summary>
         public static bool InViInsertMode() => _singleton._dispatchTable == _viInsKeyMap;
 

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -481,6 +481,11 @@ namespace Microsoft.PowerShell
         public static bool InViCommandMode() => _singleton._dispatchTable == _viCmdKeyMap;
 
         /// <summary>
+        /// Returns trud if in Vi Insert mode, otherwise false.
+        /// </summary>
+        public static bool InViInsertMode() => _singleton._dispatchTable == _viInsKeyMap;
+
+        /// <summary>
         /// Temporarily swap in Vi-Command dispatch tables. Used for setting handlers.
         /// </summary>
         internal static IDisposable UseViCommandModeTables()

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -727,6 +727,18 @@ namespace Test
         }
 
         [Fact]
+        public void ViDefect651()
+        {
+            TestSetup(KeyMode.Vi, new KeyHandler("Tab", PSConsoleReadLine.MenuComplete));
+
+            Test("ls -Hidden", Keys(
+                "abcd", _.Escape, "0Cls -H", _.Tab, CheckThat(() => AssertLineIs("ls -Hidden")),
+                _.Enter
+                ));
+        }
+
+
+        [Fact]
         public void ViInsertLine()
         {
             int adder = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;

--- a/test/CompletionTest.cs
+++ b/test/CompletionTest.cs
@@ -257,6 +257,11 @@ namespace Test
                 replacementLength = int.MaxValue;
                 completions.Add(new CompletionResult("result"));
                 break;
+            case "ls -H":
+                replacementIndex = cursor;
+                replacementLength = 0;
+                completions.Add(new CompletionResult("idden"));
+                break;
             case "none":
                 break;
             }


### PR DESCRIPTION
Fixed Defect #651 by exiting Insert Mode to clear the GroupEdit and then re-entering Insert Mode.

> I was unable to get the new test to fail before implementing the fix.  But, I was able to reproduce the failure by hand and verify the fix by hand.