### PR TITLE
Fix Backspace, Ctrl+H, Ctrl+Backspace and Alt+Backspace

### DIFF
--- a/PSReadLine/ConsoleKeyChordConverter.cs
+++ b/PSReadLine/ConsoleKeyChordConverter.cs
@@ -271,16 +271,7 @@ namespace Microsoft.PowerShell
             if (KeyMappings.TryGetValue(input, out var keyPair))
             {
                 key = keyPair.Key;
-
-                if (key == ConsoleKey.Backspace)
-                {
-                    keyChar = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == isCtrl
-                        ? '\x7f' : '\x08';
-                }
-                else
-                {
-                    keyChar = keyPair.KeyChar;
-                }
+                keyChar = keyPair.KeyChar;
                 return true;
             }
 

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -250,8 +250,9 @@ namespace Microsoft.PowerShell
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                // Ctrl+H is interpreted as 'Backspace' on Linux, but not on Windows, so we need to add an entry here.
+                // Ctrl+H is interpreted as 'Backspace' on Linux just like in Bash, but not on Windows, so we need to add an entry here.
                 _dispatchTable.Add(Keys.CtrlH,         MakeKeyHandler(BackwardDeleteChar, "BackwardDeleteChar"));
+                // Ctrl+Backspace generates the same chord as Ctrl+H on Linux, so it's also interpreted as 'Backspace' on Linux.
                 _dispatchTable.Add(Keys.CtrlBackspace, MakeKeyHandler(BackwardKillWord,   "BackwardKillWord"));
                 _dispatchTable.Add(Keys.CtrlSpace,     MakeKeyHandler(MenuComplete,       "MenuComplete"));
                 _dispatchTable.Add(Keys.AltF7,         MakeKeyHandler(ClearHistory,       "ClearHistory"));

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -220,7 +220,7 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlX,                  MakeKeyHandler(Cut,                       "Cut") },
                 { Keys.CtrlY,                  MakeKeyHandler(Redo,                      "Redo") },
                 { Keys.CtrlZ,                  MakeKeyHandler(Undo,                      "Undo") },
-                { Keys.CtrlBackspace,          MakeKeyHandler(BackwardKillWord,          "BackwardKillWord") },
+                { Keys.AltBackspace,           MakeKeyHandler(BackwardKillWord,          "BackwardKillWord") },
                 { Keys.CtrlHome,               MakeKeyHandler(BackwardDeleteLine,        "BackwardDeleteLine") },
                 { Keys.CtrlRBracket,           MakeKeyHandler(GotoBrace,                 "GotoBrace") },
                 { Keys.CtrlAltQuestion,        MakeKeyHandler(ShowKeyBindings,           "ShowKeyBindings") },
@@ -250,10 +250,13 @@ namespace Microsoft.PowerShell
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                _dispatchTable.Add(Keys.CtrlSpace,  MakeKeyHandler(MenuComplete,      "MenuComplete"));
-                _dispatchTable.Add(Keys.AltF7,      MakeKeyHandler(ClearHistory,      "ClearHistory"));
-                _dispatchTable.Add(Keys.CtrlDelete, MakeKeyHandler(KillWord,          "KillWord"));
-                _dispatchTable.Add(Keys.CtrlEnd,    MakeKeyHandler(ForwardDeleteLine, "ForwardDeleteLine"));
+                // Ctrl+H is interpreted as 'Backspace' on Linux, but not on Windows, so we need to add an entry here.
+                _dispatchTable.Add(Keys.CtrlH,         MakeKeyHandler(BackwardDeleteChar, "BackwardDeleteChar"));
+                _dispatchTable.Add(Keys.CtrlBackspace, MakeKeyHandler(BackwardKillWord,   "BackwardKillWord"));
+                _dispatchTable.Add(Keys.CtrlSpace,     MakeKeyHandler(MenuComplete,       "MenuComplete"));
+                _dispatchTable.Add(Keys.AltF7,         MakeKeyHandler(ClearHistory,       "ClearHistory"));
+                _dispatchTable.Add(Keys.CtrlDelete,    MakeKeyHandler(KillWord,           "KillWord"));
+                _dispatchTable.Add(Keys.CtrlEnd,       MakeKeyHandler(ForwardDeleteLine,  "ForwardDeleteLine"));
             }
 
             _chordDispatchTable = new Dictionary<ConsoleKeyInfo, Dictionary<ConsoleKeyInfo, KeyHandler>>(ConsoleKeyInfoComparer.Instance);
@@ -290,7 +293,6 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlG,           MakeKeyHandler(Abort,                "Abort") },
                 { Keys.CtrlL,           MakeKeyHandler(ClearScreen,          "ClearScreen") },
                 { Keys.CtrlK,           MakeKeyHandler(KillLine,             "KillLine") },
-                { Keys.CtrlM,           MakeKeyHandler(ValidateAndAcceptLine,"ValidateAndAcceptLine") },
                 { Keys.CtrlN,           MakeKeyHandler(NextHistory,          "NextHistory") },
                 { Keys.CtrlO,           MakeKeyHandler(AcceptAndGetNext,     "AcceptAndGetNext") },
                 { Keys.CtrlP,           MakeKeyHandler(PreviousHistory,      "PreviousHistory") },
@@ -337,6 +339,7 @@ namespace Microsoft.PowerShell
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                _dispatchTable.Add(Keys.CtrlM,        MakeKeyHandler(ValidateAndAcceptLine,"ValidateAndAcceptLine"));
                 _dispatchTable.Add(Keys.CtrlSpace,    MakeKeyHandler(MenuComplete,          "MenuComplete"));
                 _dispatchTable.Add(Keys.CtrlEnd,      MakeKeyHandler(ScrollDisplayToCursor, "ScrollDisplayToCursor"));
                 _dispatchTable.Add(Keys.CtrlHome,     MakeKeyHandler(ScrollDisplayTop,      "ScrollDisplayTop"));
@@ -345,8 +348,6 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                // Ctrl+H is the same KeyChar as Backspace on Windows, but not on Linux, so we need another entry.
-                _dispatchTable.Add(Keys.CtrlH,        MakeKeyHandler(BackwardDeleteChar,    "BackwardDeleteChar"));
                 _dispatchTable.Add(Keys.AltSpace,     MakeKeyHandler(SetMark,               "SetMark"));
             }
 

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlT,           MakeKeyHandler(SwapCharacters,         "SwapCharacters") },
                 { Keys.CtrlY,           MakeKeyHandler(Redo,                   "Redo") },
                 { Keys.CtrlZ,           MakeKeyHandler(Undo,                   "Undo") },
-                { Keys.CtrlBackspace,   MakeKeyHandler(BackwardKillWord,       "BackwardKillWord") },
+                { Keys.AltBackspace,    MakeKeyHandler(BackwardKillWord,       "BackwardKillWord") },
                 { Keys.CtrlEnd,         MakeKeyHandler(ForwardDeleteLine,      "ForwardDeleteLine") },
                 { Keys.CtrlHome,        MakeKeyHandler(BackwardDeleteLine,     "BackwardDeleteLine") },
                 { Keys.CtrlRBracket,    MakeKeyHandler(GotoBrace,              "GotoBrace") },
@@ -91,7 +91,8 @@ namespace Microsoft.PowerShell
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                _viInsKeyMap.Add(Keys.CtrlDelete, MakeKeyHandler(KillWord, "KillWord"));
+                _viInsKeyMap.Add(Keys.CtrlDelete,    MakeKeyHandler(KillWord,         "KillWord"));
+                _viInsKeyMap.Add(Keys.CtrlBackspace, MakeKeyHandler(BackwardKillWord, "BackwardKillWord"));
             }
 
             _viCmdKeyMap = new Dictionary<ConsoleKeyInfo, KeyHandler>(ConsoleKeyInfoComparer.Instance)
@@ -122,7 +123,7 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlW,           MakeKeyHandler(BackwardDeleteWord,   "BackwardDeleteWord") },
                 { Keys.CtrlY,           MakeKeyHandler(Redo,                 "Redo") },
                 { Keys.CtrlZ,           MakeKeyHandler(Undo,                 "Undo") },
-                { Keys.CtrlBackspace,   MakeKeyHandler(BackwardKillWord,     "BackwardKillWord") },
+                { Keys.AltBackspace,    MakeKeyHandler(BackwardKillWord,     "BackwardKillWord") },
                 { Keys.CtrlEnd,         MakeKeyHandler(ForwardDeleteLine,    "ForwardDeleteLine") },
                 { Keys.CtrlHome,        MakeKeyHandler(BackwardDeleteLine,   "BackwardDeleteLine") },
                 { Keys.CtrlRBracket,    MakeKeyHandler(GotoBrace,            "GotoBrace") },
@@ -210,7 +211,8 @@ namespace Microsoft.PowerShell
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                _viCmdKeyMap.Add(Keys.CtrlDelete, MakeKeyHandler(KillWord, "KillWord"));
+                _viCmdKeyMap.Add(Keys.CtrlDelete,    MakeKeyHandler(KillWord,         "KillWord"));
+                _viCmdKeyMap.Add(Keys.CtrlBackspace, MakeKeyHandler(BackwardKillWord, "BackwardKillWord"));
             }
 
 

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -203,7 +203,7 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo Plus                = Key('+');
         public static ConsoleKeyInfo Eq                  = Key('=');
         public static ConsoleKeyInfo Space               = Key(' ');
-        public static ConsoleKeyInfo Backspace           = Key(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '\x08' : '\x7f');
+        public static ConsoleKeyInfo Backspace           = Key(ConsoleKey.Backspace);
         public static ConsoleKeyInfo Delete              = Key(ConsoleKey.Delete);
         public static ConsoleKeyInfo DownArrow           = Key(ConsoleKey.DownArrow);
         public static ConsoleKeyInfo End                 = Key(ConsoleKey.End);
@@ -290,7 +290,7 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo AltEquals           = Alt('=');  // !Linux, CLR bug
         public static ConsoleKeyInfo AltMinus            = Alt('-');
         public static ConsoleKeyInfo AltUnderbar         = Alt('_');  // !Linux, CLR bug
-        public static ConsoleKeyInfo AltBackspace        = Alt(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '\x08' : '\x7f');
+        public static ConsoleKeyInfo AltBackspace        = Alt(ConsoleKey.Backspace);
         public static ConsoleKeyInfo AltLess             = Alt('<');  // !Linux, CLR bug
         public static ConsoleKeyInfo AltGreater          = Alt('>');  // !Linux, CLR bug
         public static ConsoleKeyInfo AltQuestion         = Alt('?');  // !Linux, CLR bug
@@ -304,12 +304,12 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo CtrlE               = Ctrl('\x05');
         public static ConsoleKeyInfo CtrlF               = Ctrl('\x06');
         public static ConsoleKeyInfo CtrlG               = Ctrl('\a');
-        public static ConsoleKeyInfo CtrlH               = Ctrl('\b');
-        public static ConsoleKeyInfo CtrlI               = Ctrl('\t');
-        public static ConsoleKeyInfo CtrlJ               = Ctrl('\n');
+        public static ConsoleKeyInfo CtrlH               = Ctrl('\b'); // !Linux, generate (keychar: '\b', key: Backspace, mods: 0), same as CtrlBackspace
+        public static ConsoleKeyInfo CtrlI               = Ctrl('\t'); // !Linux, generate (keychar: '\t', key: Tab,       mods: 0)
+        public static ConsoleKeyInfo CtrlJ               = Ctrl('\n'); // !Linux, generate (keychar: '\n', key: Enter,     mods: 0)
         public static ConsoleKeyInfo CtrlK               = Ctrl('\v');
         public static ConsoleKeyInfo CtrlL               = Ctrl('\f');
-        public static ConsoleKeyInfo CtrlM               = Ctrl('\r');
+        public static ConsoleKeyInfo CtrlM               = Ctrl('\r'); // !Linux, same as CtrlJ
         public static ConsoleKeyInfo CtrlN               = Ctrl('\x0e');
         public static ConsoleKeyInfo CtrlO               = Ctrl('\x0f');
         public static ConsoleKeyInfo CtrlP               = Ctrl('\x10');
@@ -328,7 +328,7 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo CtrlRBracket        = Ctrl('\x1d');
         public static ConsoleKeyInfo CtrlCaret           = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? CtrlShift('\x1e') : Ctrl('\x1e');
         public static ConsoleKeyInfo CtrlUnderbar        = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? CtrlShift('\x1f') : Ctrl('\x1f');
-        public static ConsoleKeyInfo CtrlBackspace       = Ctrl(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '\x7f' : '\x08');
+        public static ConsoleKeyInfo CtrlBackspace       = Ctrl(ConsoleKey.Backspace); // !Linux, same as CtrlH
         public static ConsoleKeyInfo CtrlDelete          = Ctrl(ConsoleKey.Delete); // !Linux
         public static ConsoleKeyInfo CtrlEnd             = Ctrl(ConsoleKey.End); // !Linux
         public static ConsoleKeyInfo CtrlHome            = Ctrl(ConsoleKey.Home); // !Linux
@@ -459,6 +459,7 @@ namespace Microsoft.PowerShell
                 case ConsoleKey.F22:
                 case ConsoleKey.F23:
                 case ConsoleKey.F24:
+                case ConsoleKey.Backspace:
                 case ConsoleKey.Delete:
                 case ConsoleKey.DownArrow:
                 case ConsoleKey.End:
@@ -624,10 +625,6 @@ namespace Microsoft.PowerShell
                     case '\x1c': s = "\\";        break;
                     case '\x1d': s = "]";         break;
                     case '\x1f': s = "_";         break;
-                    case '\x7f': s = "Backspace"; break;
-                    case '\x08':
-                        s = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Backspace" : "Ctrl+Backspace";
-                        break;
 
                     case char _ when c <= 26:
                         s = ((char)((isShift ? 'A' : 'a') + c - 1)).ToString();

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -309,7 +309,7 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo CtrlJ               = Ctrl('\n'); // !Linux, generate (keychar: '\n', key: Enter,     mods: 0)
         public static ConsoleKeyInfo CtrlK               = Ctrl('\v');
         public static ConsoleKeyInfo CtrlL               = Ctrl('\f');
-        public static ConsoleKeyInfo CtrlM               = Ctrl('\r'); // !Linux, same as CtrlJ
+        public static ConsoleKeyInfo CtrlM               = Ctrl('\r'); // !Linux, same as CtrlJ but 'showkey -a' shows they are different, CLR bug
         public static ConsoleKeyInfo CtrlN               = Ctrl('\x0e');
         public static ConsoleKeyInfo CtrlO               = Ctrl('\x0f');
         public static ConsoleKeyInfo CtrlP               = Ctrl('\x10');


### PR DESCRIPTION
Fix #619

Both `"Ctrl+H"` and `"Ctrl+Backspace"` generate the same `ConsoleKeyInfo` on Linux -- `(keychar: '\b', key: Backspace, mods: 0)`, and they have the same behavior as `"Backspace"` in Bash. So the fix is to make them behave the same in `PSReadline` as in Bash. Here are the changes:
1. Change the `ConsoleKeyInfo` of `"Backspace", "AltBackspace" and "CtrlBackspace"` to ignore the `KeyChar`, and depend on the `ConsoleKey` instead.
2. Update `IgnoreKeyChar` to ignore the `KeyChar` for `ConsoleKey.Backspace` when comparing two `ConsoleKeyInfo` instances. So `"Ctrl+H"` and `"Ctrl+Backspace"` are interpreted the same as `"Backspace"` on Linux, while they remain different on Windows. With this change, changing `Backspace` to `Ctrl+H` in an internal doesn't affect the behavior of `Backspace` on Linux, because `Ctrl+H` will trigger the keybinding of `Backspace` anyway.
3. `"Ctrl+H"` behaves as `"Backspace"` in CMD, so also add the same behavior to `PSReadline`.
4. Add comments to point out some more chords are not applicable on Linux.
5. Since `Ctrl+Backspace` doesn't apply to Linux, update some existing keybinding of it to make them only available on Windows.
6. `Alt+Backspace` works on both Linux and Windows, so add `Alt+Backspace` to all keybindings that have `Ctrl+Backspace` to point to the same action. Therefore, we can have it working consistently across platforms.