### PR TITLE
Fix 'Ctrl+Backspace' in Linux

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -254,6 +254,7 @@ namespace Microsoft.PowerShell
                 _dispatchTable.Add(Keys.AltF7,      MakeKeyHandler(ClearHistory,      "ClearHistory"));
                 _dispatchTable.Add(Keys.CtrlDelete, MakeKeyHandler(KillWord,          "KillWord"));
                 _dispatchTable.Add(Keys.CtrlEnd,    MakeKeyHandler(ForwardDeleteLine, "ForwardDeleteLine"));
+                _dispatchTable.Add(Keys.CtrlH,      MakeKeyHandler(BackwardDeleteChar,"BackwardDeleteChar"));
             }
 
             _chordDispatchTable = new Dictionary<ConsoleKeyInfo, Dictionary<ConsoleKeyInfo, KeyHandler>>(ConsoleKeyInfoComparer.Instance);
@@ -302,6 +303,7 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlW,           MakeKeyHandler(UnixWordRubout,       "UnixWordRubout") },
                 { Keys.CtrlY,           MakeKeyHandler(Yank,                 "Yank") },
                 { Keys.CtrlAt,          MakeKeyHandler(SetMark,              "SetMark") },
+                { Keys.CtrlBackspace,   MakeKeyHandler(BackwardDeleteChar,   "BackwardDeleteChar") },
                 { Keys.CtrlUnderbar,    MakeKeyHandler(Undo,                 "Undo") },
                 { Keys.CtrlRBracket,    MakeKeyHandler(CharacterSearch,      "CharacterSearch") },
                 { Keys.CtrlAltRBracket, MakeKeyHandler(CharacterSearchBackward,"CharacterSearchBackward") },
@@ -337,6 +339,7 @@ namespace Microsoft.PowerShell
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                _dispatchTable.Add(Keys.CtrlH,        MakeKeyHandler(BackwardDeleteChar,    "BackwardDeleteChar"));
                 _dispatchTable.Add(Keys.CtrlSpace,    MakeKeyHandler(MenuComplete,          "MenuComplete"));
                 _dispatchTable.Add(Keys.CtrlEnd,      MakeKeyHandler(ScrollDisplayToCursor, "ScrollDisplayToCursor"));
                 _dispatchTable.Add(Keys.CtrlHome,     MakeKeyHandler(ScrollDisplayTop,      "ScrollDisplayTop"));
@@ -345,8 +348,6 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                // Ctrl+H is the same KeyChar as Backspace on Windows, but not on Linux, so we need another entry.
-                _dispatchTable.Add(Keys.CtrlH,        MakeKeyHandler(BackwardDeleteChar,    "BackwardDeleteChar"));
                 _dispatchTable.Add(Keys.AltSpace,     MakeKeyHandler(SetMark,               "SetMark"));
             }
 

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -304,12 +304,12 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo CtrlE               = Ctrl('\x05');
         public static ConsoleKeyInfo CtrlF               = Ctrl('\x06');
         public static ConsoleKeyInfo CtrlG               = Ctrl('\a');
-        public static ConsoleKeyInfo CtrlH               = Ctrl('\b');
-        public static ConsoleKeyInfo CtrlI               = Ctrl('\t');
-        public static ConsoleKeyInfo CtrlJ               = Ctrl('\n');
+        public static ConsoleKeyInfo CtrlH               = Ctrl('\b'); // !Linux, generate (keychar: '\b', key: Backspace, mods: 0), same as CtrlBackspace
+        public static ConsoleKeyInfo CtrlI               = Ctrl('\t'); // !Linux, generate (keychar: '\t', key: Tab,       mods: 0)
+        public static ConsoleKeyInfo CtrlJ               = Ctrl('\n'); // !Linux, generate (keychar: '\n', key: Enter,     mods: 0)
         public static ConsoleKeyInfo CtrlK               = Ctrl('\v');
         public static ConsoleKeyInfo CtrlL               = Ctrl('\f');
-        public static ConsoleKeyInfo CtrlM               = Ctrl('\r');
+        public static ConsoleKeyInfo CtrlM               = Ctrl('\r'); // !Linux, same as CtrlJ but 'showkey -a' shows they are different, CLR bug
         public static ConsoleKeyInfo CtrlN               = Ctrl('\x0e');
         public static ConsoleKeyInfo CtrlO               = Ctrl('\x0f');
         public static ConsoleKeyInfo CtrlP               = Ctrl('\x10');
@@ -328,7 +328,7 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo CtrlRBracket        = Ctrl('\x1d');
         public static ConsoleKeyInfo CtrlCaret           = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? CtrlShift('\x1e') : Ctrl('\x1e');
         public static ConsoleKeyInfo CtrlUnderbar        = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? CtrlShift('\x1f') : Ctrl('\x1f');
-        public static ConsoleKeyInfo CtrlBackspace       = Ctrl(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '\x7f' : '\x08');
+        public static ConsoleKeyInfo CtrlBackspace       = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Ctrl('\x7f') : Key('\x08');
         public static ConsoleKeyInfo CtrlDelete          = Ctrl(ConsoleKey.Delete); // !Linux
         public static ConsoleKeyInfo CtrlEnd             = Ctrl(ConsoleKey.End); // !Linux
         public static ConsoleKeyInfo CtrlHome            = Ctrl(ConsoleKey.Home); // !Linux
@@ -625,7 +625,10 @@ namespace Microsoft.PowerShell
                     case '\x1d': s = "]";         break;
                     case '\x1f': s = "_";         break;
                     case '\x7f': s = "Backspace"; break;
-                    case '\x08':
+
+                    // 'Ctrl+h' is represented as (keychar: 0x08, key: 0, mods: Control). In the case of 'Ctrl+h',
+                    // we don't want the keychar to be interpreted as 'Backspace'.
+                    case '\x08' when !isCtrl:
                         s = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Backspace" : "Ctrl+Backspace";
                         break;
 


### PR DESCRIPTION
Both `"Ctrl+H"` and `"Ctrl+Backspace"` generate the same `ConsoleKeyInfo` on Linux -- `(keychar: 0x08, key: Backspace, mods: 0)`. Change the `ConsoleKeyInfo` representation of `Ctrl+Backspace` on Linux to `(keychar: 0x08, key: 0, mods: 0)`, and make `Backspace`, `Ctrl+h` and `Ctrl+Backspace` work as follows:

| Key | Windows Mode on Windows | Emacs Mode | Windows Mode on Linux |
| ---- | -------------------------------- | -------------- | --------------------------- |
| Backspace  | BackwardDeleteChar   | BackwardDeleteChar | BackwardDeleteChar  |
| Ctrl+Backspace | BackwardKillWord | BackwardDeleteChar | BackwardKillWord     |
| Ctrl+h        | BackwardDeleteChar    | BackwardDeleteChar | BackwardKillWord   |

Fix #619, so that in `Emacs` mode, after applying `Ctrl+H` for `Backspace` in the terminal setting, `Backspace` still does `BackwardDeleteChar`. However, in `Windows` mode, `Backspace` in such case will do `BackwardKillWord`.