### PR TITLE
Always display special language characters 

### DIFF
--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -551,8 +551,12 @@ namespace Microsoft.PowerShell
 
         internal static bool ShouldInsert(this ConsoleKeyInfo key)
         {
-            if (key.KeyChar == '\0') return false;
-
+            var keyChar = key.KeyChar;
+            if (keyChar == '\0') return false;
+            foreach (char c in "`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?") {
+                // we always want to insert chars essential to the PowerShell experience
+                if (keyChar == c) { return true; }
+            }
             if (key.Modifiers != 0)
             {
                 // We want to ignore control sequences - but distinguishing a control sequence


### PR DESCRIPTION
Always display special characters from the PowerShell language.
Many of these are behind AltGr in many
European keyboard layouts, but should always
be displayed.