### PR TITLE
Enabled Ctrl+LeftArrow and Ctrl+RightArrow on Linux and cloudshell

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -269,6 +269,8 @@ namespace Microsoft.PowerShell
                 { Keys.ShiftEnter,      MakeKeyHandler(AddLine,              "AddLine") },
                 { Keys.LeftArrow,       MakeKeyHandler(BackwardChar,         "BackwardChar") },
                 { Keys.RightArrow,      MakeKeyHandler(ForwardChar,          "ForwardChar") },
+                { Keys.CtrlLeftArrow,   MakeKeyHandler(BackwardWord,         "BackwardWord") },
+                { Keys.CtrlRightArrow,  MakeKeyHandler(NextWord,             "NextWord") },
                 { Keys.ShiftLeftArrow,  MakeKeyHandler(SelectBackwardChar,   "SelectBackwardChar") },
                 { Keys.ShiftRightArrow, MakeKeyHandler(SelectForwardChar,    "SelectForwardChar") },
                 { Keys.UpArrow,         MakeKeyHandler(PreviousHistory,      "PreviousHistory") },


### PR DESCRIPTION
Currently the (Get-PSReadLineOption).EditMode is set to "Emacs" on pwsh Linux. The lookup key_dispatchTable for Emacs does not have Ctrl+LeftArrow or RightArrow defined. Therefore we cannot use them to move to next word on Linux or Azure CloudShell.
The workaround is set the edit mode to Windows on Linux OS to make the key work. This is a bit odd.
This change to add Ctrl+LeftArrow and Ctrl+RightArrow  to the emacsBindings for Linux. I tested the changes on my Linux VM and worked fine.
