### PR TITLE
Fixed PhysicalLineCount for proper rendering for a long line user input

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -393,7 +393,7 @@ namespace Microsoft.PowerShell
                     if (columns > maxFirstLine)
                     {
                         cnt += 1;
-                        columns -= maxFirstLine + 1;
+                        columns -= maxFirstLine;
                     }
                     else
                     {

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -393,7 +393,7 @@ namespace Microsoft.PowerShell
                     if (columns > maxFirstLine)
                     {
                         cnt += 1;
-                        columns -= maxFirstLine;
+                        columns -= maxFirstLine + 1;
                     }
                     else
                     {

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -403,6 +403,14 @@ namespace Microsoft.PowerShell
                 }
 
                 lenLastPhysicalLine = columns % bufferWidth;
+                if(lenLastPhysicalLine == 0)
+                {
+                    // Handle the last column when the columns is equal to n * bufferWidth
+                    // where n >= 1 integers
+                    lenLastPhysicalLine = bufferWidth;
+                    return cnt + (columns - 1) / bufferWidth;
+                }
+
                 return cnt + columns / bufferWidth;
             }
 

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -403,12 +403,12 @@ namespace Microsoft.PowerShell
                 }
 
                 lenLastPhysicalLine = columns % bufferWidth;
-                if(lenLastPhysicalLine == 0)
+                if (lenLastPhysicalLine == 0)
                 {
                     // Handle the last column when the columns is equal to n * bufferWidth
                     // where n >= 1 integers
                     lenLastPhysicalLine = bufferWidth;
-                    return cnt + (columns - 1) / bufferWidth;
+                    return cnt - 1 + columns / bufferWidth;
                 }
 
                 return cnt + columns / bufferWidth;


### PR DESCRIPTION
Fix https://github.com/lzybkr/PSReadLine/issues/686

Without the fix, text does not get refreshed for a case where a user has a long line input. For 80 x 24 console, if you type 3 lines long text, you will see the second line is showed up on Line 3 before you even type anything. 