### PR TITLE
Fix crash and rendering where large content is pasted to console on non-Windows

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -50,6 +50,9 @@ namespace Microsoft.PowerShell
             lines = new[] { new RenderedLineData{ columns = 0, line = ""}}
         };
         private int _initialX;
+
+        // This represents the initial Y position of the cursor.  If this position has scrolled off screen, this value will be negative indicating
+        // the number of lines off screen.
         private int _initialY;
         private ConsoleColor _initialForeground;
         private ConsoleColor _initialBackground;
@@ -436,8 +439,8 @@ namespace Microsoft.PowerShell
                 var lineData = renderLines[logicalLine];
                 var physicalLineCount = PhysicalLineCount(lineData.columns, logicalLine == 0, out var lenLastLine);
 
-                // If the initial position was scrolled off the screen, only output for lines still
-                // in the screen buffer
+                // If the initial position was scrolled off the screen, _initialY will be negative.
+                // Only output for lines still in the screen buffer.
                 if (_initialY + physicalLine >= 0)
                 {
                     // First time redrawing from the top

--- a/test/KillYankTest.cs
+++ b/test/KillYankTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Windows;
 using Microsoft.PowerShell;
 using Xunit;
@@ -311,6 +312,23 @@ namespace Test
             Clipboard.SetText("pastetest2");
             Test("echo pastetest2", Keys(
                 "echo foobar", _.CtrlShiftLeftArrow, _.CtrlV));
+        }
+
+        [Fact]
+        public void PasteLarge()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            StringBuilder text = new StringBuilder();
+            text.Append("@{");
+            for (int i = 0; i < _console.BufferHeight + 10; i++)
+            {
+                text.Append(string.Format("prop{0}={0}", i));
+            }
+            text.Append("}");
+
+            Clipboard.SetText(text.ToString());
+            Test(text.ToString(), Keys(_.CtrlV));
         }
 
         [Fact]


### PR DESCRIPTION
Several issues:

1. When large content is pasted to the console window on Windows, the buffer scrolls and PSReadLine now has a negative value for the cursor.  Exception is raised when trying to set the cursor location to a negative y value.  Fix is to check for this and set y to 0 (top).
2. When the buffer scrolls on paste, the re-rendering gets confused as it didn't track the scrolling appropriately.  Fix is to skip drawing content that is off screen.
3. If the last line drawn to the screen is at the bottom of the screen buffer and the width of the output is exactly the window width, scroll doesn't happen until the next character is drawn; however, PSReadLine expected it to scroll so it's off by one.  Fix here is to catch this and reset position back one line.

Fix https://github.com/lzybkr/PSReadLine/issues/663