### PR TITLE
Add ScriptBlock vi mode indicator

### DIFF
--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -112,6 +112,14 @@ namespace Microsoft.PowerShell
             {
                 Options.ViModeIndicator = options.ViModeIndicator;
             }
+            if (options.ViModeChangeHandler != null)
+            {
+                if (Options.ViModeIndicator != ViModeStyle.Script)
+                {
+                    throw new ParameterBindingException("ViModeChangeHandler option requires ViModeStyle.Script");
+                }
+                Options.ViModeChangeHandler = options.ViModeChangeHandler;
+            }
             if (options.HistorySavePath != null)
             {
                 Options.HistorySavePath = options.HistorySavePath;

--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -148,6 +148,11 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                 <PropertyName>ViModeIndicator</PropertyName>
               </ListItem>
               <ListItem>
+                  <Label>ViModeChangeHandler</Label>
+                  <ItemSelectionCondition><ScriptBlock>$null -ne $_.ViModeChangeHandler</ScriptBlock></ItemSelectionCondition>
+                  <PropertyName>ViModeChangeHandler</PropertyName>
+              </ListItem>
+              <ListItem>
                 <PropertyName>WordDelimiters</PropertyName>
               </ListItem>
               <ListItem>

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -534,6 +534,10 @@ namespace Microsoft.PowerShell
                 InvokePrompt();
                 _console.BackgroundColor = savedBackground;
             }
+            else if (_options.ViModeIndicator == ViModeStyle.Script && _options.ViModeChangeHandler != null)
+            {
+                _options.ViModeChangeHandler.InvokeReturnAsIs(ViMode.Command);
+            }
         }
 
         private void ViIndicateInsertMode()
@@ -545,6 +549,10 @@ namespace Microsoft.PowerShell
             else if (_options.ViModeIndicator == ViModeStyle.Prompt)
             {
                 InvokePrompt();
+            }
+            else if (_options.ViModeIndicator == ViModeStyle.Script && _options.ViModeChangeHandler != null)
+            {
+                _options.ViModeChangeHandler.InvokeReturnAsIs(ViMode.Insert);
             }
         }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ image: Visual Studio 2017
 
 before_build:
   - ps: |
-      nuget install platyPS -Version 0.4.0 -source https://www.powershellgallery.com/api/v2 -outputDirectory . -ExcludeVersion
+      nuget install platyPS -Version 0.9.0 -source https://www.powershellgallery.com/api/v2 -outputDirectory . -ExcludeVersion
       nuget install InvokeBuild -Version 4.1.0 -source https://www.powershellgallery.com/api/v2 -outputDirectory . -ExcludeVersion
       Import-Module .\platyPS
       Import-Module .\InvokeBuild

--- a/docs/Set-PSReadLineOption.md
+++ b/docs/Set-PSReadLineOption.md
@@ -35,6 +35,7 @@ Set-PSReadLineOption
  [-WordDelimiters <string>]
  [-AnsiEscapeTimeout <int>]
  [-ViModeIndicator <ViModeStyle>]
+ [-ViModeChangeHandler <ScriptBlock>]
 ```
 
 ## DESCRIPTION
@@ -74,6 +75,23 @@ PS C:\> $PSReadLineOptions = @{
     }
 }
 PS C:\> Set-PSReadLineOption @PSReadLineOptions
+```
+
+### --------------  Example 3  --------------
+
+This example emits a cursor change VT escape in response to a vi mode change:
+
+```
+PS C:\> function OnViModeChange {
+    if ($args[0] -eq 'Command') {
+        # Set the cursor to a blinking block.
+        Write-Host -NoNewLine "`e[1 q"
+    } else {
+        # Set the cursor to a blinking line.
+        Write-Host -NoNewLine "`e[5 q"
+    }
+}
+PS C:\> Set-PSReadLineOption -ViModeIndicator Script -ViModeChangeHandler OnViModeChange
 ```
 
 ## PARAMETERS
@@ -540,6 +558,8 @@ Valid values are:
 
 -- Cursor - the cursor changes size
 
+-- Script - user-specified text is printed
+
 ```yaml
 Type: ViModeStyle
 Parameter Sets: (All)
@@ -550,6 +570,22 @@ Position: Named
 Default value:
 Accept pipeline input: false
 Accept wildcard characters: False
+```
+
+### -ViModeChangeHandler
+
+When the `ViModeIndicator` is set to `Script`, the script block provided will be invoked every time the mode changes. The script block is provided one argument of type `ViMode`. Example usage is shown in Example 3 in this document.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value:
+Accept pipeline input: false
+Accept wildcard characters: false
 ```
 
 ## INPUTS


### PR DESCRIPTION
I messed something up with git and it closed my old PR, so continuing from #675...

Changed the new option to take a script block and added an example to the docs of using it to change the cursor.

The official docs say you can use `$_` in the script block, but I could only get `$args[0]` to work. I also made the option an error unless the correct mode is set. The script block can't be set to null since that's used to determine whether the option was passed, but you can always set it to an empty script block or just change the mode.