### PR TITLE
Fix System.ArgumentOutOfRangeException while get-tab

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -537,7 +537,7 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    // Update the cursor position to the start of the first line after our input.
+                    // Update the cursor coordinates after showing the menu.
                     _singleton._initialX = console.CursorLeft;
                     _singleton._initialY = console.CursorTop;
                     _singleton._previousRender = _initialPrevRender;
@@ -751,7 +751,7 @@ namespace Microsoft.PowerShell
             else
             {
                 menu.DrawMenu(null, menuSelect:false);
-                InvokePrompt(key: null, arg:null);
+                InvokePrompt(key: null, arg: _console.CursorTop);
             }
         }
 

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -545,13 +545,6 @@ namespace Microsoft.PowerShell
                     console.RestoreCursor();
                     console.CursorVisible = true;
                 }
-                else
-                {
-                    // Update the cursor coordinates after showing the menu.
-                    _singleton._initialX = console.CursorLeft;
-                    _singleton._initialY = console.CursorTop;
-                    _singleton._previousRender = _initialPrevRender;
-                }
             }
 
             public void Clear()

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -464,13 +464,13 @@ namespace Microsoft.PowerShell
             internal CompletionResult CurrentMenuItem => MenuItems[CurrentSelection];
             internal int CurrentSelection;
 
-            void EnsureMenuAndInputIsVisible(IConsole console, int tooltipLineCount, int rows)
+            void EnsureMenuAndInputIsVisible(IConsole console, int tooltipLineCount)
             {
                 // The +1 lets us write a newline after the last row, which isn't strictly necessary
                 // It does help with:
                 //   * Console selecting multiple lines of text
                 //   * Adds a little extra space underneath the menu
-                var bottom = this.Top + rows + tooltipLineCount + 1;
+                var bottom = this.Top + this.Rows + tooltipLineCount + 1;
                 if (bottom > console.BufferHeight)
                 {
                     var toScroll = bottom - console.BufferHeight;
@@ -491,17 +491,22 @@ namespace Microsoft.PowerShell
                 this.Top = Singleton.ConvertOffsetToPoint(Singleton._buffer.Length).Y + 1;
                 if (menuSelect)
                 {
-                    EnsureMenuAndInputIsVisible(console, tooltipLineCount: 0, rows:this.Rows);
+                    EnsureMenuAndInputIsVisible(console, tooltipLineCount: 0);
 
                     console.CursorVisible = false;
                     console.SaveCursor();
+                    console.SetCursorPosition(0, this.Top);
                 }
                 else
                 {
-                    EnsureMenuAndInputIsVisible(console, tooltipLineCount: 0, rows:0);
+                    // Start a new line to show the menu contents
+                    console.SetCursorPosition(0, this.Top);
+                    // Scroll one line up if the cursor is at the bottom of the window
+                    if (this.Top == console.BufferHeight)
+                    {
+                        console.Write("\n");
+                    }
                 }
-
-                console.SetCursorPosition(0, this.Top);
 
                 var bufferWidth = console.BufferWidth;
                 var columnWidth = this.ColumnWidth;
@@ -611,7 +616,7 @@ namespace Microsoft.PowerShell
 
                 if (showTooltips)
                 {
-                    EnsureMenuAndInputIsVisible(console, toolTipLines, this.Rows);
+                    EnsureMenuAndInputIsVisible(console, toolTipLines);
                 }
 
                 console.SaveCursor();

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -464,13 +464,13 @@ namespace Microsoft.PowerShell
             internal CompletionResult CurrentMenuItem => MenuItems[CurrentSelection];
             internal int CurrentSelection;
 
-            void EnsureMenuAndInputIsVisible(IConsole console, int tooltipLineCount)
+            void EnsureMenuAndInputIsVisible(IConsole console, int tooltipLineCount, int rows)
             {
                 // The +1 lets us write a newline after the last row, which isn't strictly necessary
                 // It does help with:
                 //   * Console selecting multiple lines of text
                 //   * Adds a little extra space underneath the menu
-                var bottom = this.Top + this.Rows + tooltipLineCount + 1;
+                var bottom = this.Top + rows + tooltipLineCount + 1;
                 if (bottom > console.BufferHeight)
                 {
                     var toScroll = bottom - console.BufferHeight;
@@ -487,21 +487,21 @@ namespace Microsoft.PowerShell
             {
                 IConsole console = Singleton._console;
 
+                // Move cursor to the start of the first line after our input.
+                this.Top = Singleton.ConvertOffsetToPoint(Singleton._buffer.Length).Y + 1;
                 if (menuSelect)
                 {
-                    // Move cursor to the start of the first line after our input.
-                    this.Top = Singleton.ConvertOffsetToPoint(Singleton._buffer.Length).Y + 1;
-                    EnsureMenuAndInputIsVisible(console, tooltipLineCount: 0);
+                    EnsureMenuAndInputIsVisible(console, tooltipLineCount: 0, rows:this.Rows);
 
                     console.CursorVisible = false;
                     console.SaveCursor();
-                    console.SetCursorPosition(0, this.Top);
                 }
                 else
                 {
-                    // Start a new line to show the menu contents
-                    console.Write("\n");
+                    EnsureMenuAndInputIsVisible(console, tooltipLineCount: 0, rows:0);
                 }
+
+                console.SetCursorPosition(0, this.Top);
 
                 var bufferWidth = console.BufferWidth;
                 var columnWidth = this.ColumnWidth;
@@ -618,7 +618,7 @@ namespace Microsoft.PowerShell
 
                 if (showTooltips)
                 {
-                    EnsureMenuAndInputIsVisible(console, toolTipLines);
+                    EnsureMenuAndInputIsVisible(console, toolTipLines, this.Rows);
                 }
 
                 console.SaveCursor();

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -599,7 +599,8 @@ namespace Microsoft.PowerShell
                         }
                     }
 
-                    if (BufferLines + Rows + toolTipLines > console.WindowHeight)
+                    // The +1 is for a new line after showing the tool tips
+                    if ((Top + Rows + toolTipLines + 1) > console.WindowHeight)
                     {
                         showTooltips = false;
                     }


### PR DESCRIPTION
In the https://github.com/lzybkr/PSReadLine/issues/663, @gshacklett has commented get- and then tab PSReadLine will throw. This case is very often on cloudshell because Azure cmdlets are quite long and people use tab a lot. 

The fix is to let contents display until complete for the menu not selected case. I tested on Windows, Linux and cloudshell, the fix seems to be working. Please code review. Thanks.

However I broke the PossibleCompletions() tests.  The fix changed the parameter in calling InvokePrompt https://github.com/lzybkr/PSReadLine/blob/master/PSReadLine/Completion.cs#L736 so code path is different. With the fix, we are executing the else block in https://github.com/lzybkr/PSReadLine/blob/master/PSReadLine/ReadLine.cs#L942.