### PR TITLE
Include the code fences to OopsAnErrorMessage2

### DIFF
--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -395,10 +395,14 @@ Report on GitHub: https://github.com/lzybkr/PSReadLine/issues/new</value>
   <data name="OopsAnErrorMessage2" xml:space="preserve">
     <value>-----------------------------------------------------------------------
 Last {0} Keys:
+```
 {1}
+```
 
 Exception:
+```
 {2}
+```
 -----------------------------------------------------------------------</value>
   </data>
   <data name="NextLineDescription" xml:space="preserve">


### PR DESCRIPTION
That would make github copy-pasting better formatted.

Examples where it would help #709 #563 #671
