### PR TITLE
Adding space as an `essential` PS character.

### DIFF
--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -553,7 +553,7 @@ namespace Microsoft.PowerShell
         {
             var keyChar = key.KeyChar;
             if (keyChar == '\0') return false;
-            foreach (char c in "`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?") {
+            foreach (char c in " `~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?") {
                 // we always want to insert chars essential to the PowerShell experience
                 if (keyChar == c) { return true; }
             }


### PR DESCRIPTION
Space should be added even if a modifier is added.

Currently, Shift+Space is eaten by PSReadline, which is different from all other editors I've tried.
Notepad, Code, VS etc all input a space even if shift is pressed.
