### PR TITLE
Fix dynamic changing of font in Windows console on CJK codepages

### DIFF
--- a/PSReadLine/PlatformWindows.cs
+++ b/PSReadLine/PlatformWindows.cs
@@ -368,13 +368,18 @@ static class PlatformWindows
             && SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
     }
 
+    internal static bool IsConsoleInput()
+    {
+        var handle = GetStdHandle((uint)StandardHandleId.Input);
+        return GetFileType(handle) == FILE_TYPE_CHAR;
+    }
+
     private static bool IsHandleRedirected(bool stdin)
     {
         var handle = GetStdHandle((uint)(stdin ? StandardHandleId.Input : StandardHandleId.Output));
 
         // If handle is not to a character device, we must be redirected:
-        int fileType = GetFileType(handle);
-        if ((fileType & FILE_TYPE_CHAR) != FILE_TYPE_CHAR)
+        if (GetFileType(handle) != FILE_TYPE_CHAR)
             return true;
 
         // Char device - if GetConsoleMode succeeds, we are NOT redirected.

--- a/PSReadLine/PlatformWindows.cs
+++ b/PSReadLine/PlatformWindows.cs
@@ -93,6 +93,41 @@ static class PlatformWindows
         return false;
     }
 
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct CONSOLE_FONT_INFO_EX
+    {
+        internal int cbSize;
+        internal int nFont;
+        internal short FontWidth;
+        internal short FontHeight;
+        internal FontFamily FontFamily;
+        internal uint FontWeight;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        internal string FontFace;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool GetCurrentConsoleFontEx(IntPtr consoleOutput, bool bMaximumWindow, ref CONSOLE_FONT_INFO_EX consoleFontInfo);
+
+    [Flags()]
+    internal enum FontFamily : uint
+    {
+        TMPF_FIXED_PITCH = 0x01
+    }
+
+    internal static bool IsUsingRasterFont()
+    {
+        CONSOLE_FONT_INFO_EX fontInfo = new CONSOLE_FONT_INFO_EX();
+        fontInfo.cbSize = Marshal.SizeOf(fontInfo);
+        var handle = _outputHandle.Value.DangerousGetHandle();
+        bool result = GetCurrentConsoleFontEx(handle, false, ref fontInfo);
+        // If this bit is set the font is a variable pitch font.
+        // If this bit is clear the font is a fixed pitch font.
+        // Note very carefully that those meanings are the opposite of what the constant name implies.
+        return !fontInfo.FontFamily.HasFlag(FontFamily.TMPF_FIXED_PITCH);
+    }
+
+
     private static PSConsoleReadLine _singleton;
     internal static IConsole OneTimeInit(PSConsoleReadLine singleton)
     {

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell
         private IConsole _console;
         private ICharMap _charMap;
         private Encoding _initialOutputEncoding;
-        private bool _changeOutputEncoding;
+        private bool _skipOutputEncodingChange;
         private EngineIntrinsics _engineIntrinsics;
         private Thread _readKeyThread;
         private AutoResetEvent _readKeyWaitHandle;
@@ -532,7 +532,7 @@ namespace Microsoft.PowerShell
             }
             finally
             {
-                if (_changeOutputEncoding)
+                if (!_skipOutputEncodingChange)
                 {
                     _console.OutputEncoding = Encoding.UTF8;
                 }
@@ -652,15 +652,13 @@ namespace Microsoft.PowerShell
 
             _initialOutputEncoding = _console.OutputEncoding;
 
-            // Don't change the OutputEncoding if already UTF8 or using raster font on Windows
-            _changeOutputEncoding = _initialOutputEncoding != Encoding.UTF8;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && PlatformWindows.IsConsoleInput() && PlatformWindows.IsUsingRasterFont())
-            {
-                _changeOutputEncoding = false;
-            }
+            // Don't change the OutputEncoding if already UTF8, no console, or using raster font on Windows
+            _skipOutputEncodingChange = _initialOutputEncoding == Encoding.UTF8
+                || (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    && PlatformWindows.IsConsoleInput()
+                    && PlatformWindows.IsUsingRasterFont());
 
-            if (_changeOutputEncoding)
-            {
+            if (!_skipOutputEncodingChange) {
                 _console.OutputEncoding = Encoding.UTF8;
             }
 

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -2,7 +2,6 @@
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
-using ConsoleHandle = Microsoft.Win32.SafeHandles.SafeFileHandle;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -654,7 +654,7 @@ namespace Microsoft.PowerShell
 
             // Don't change the OutputEncoding if already UTF8 or using raster font on Windows
             _changeOutputEncoding = _initialOutputEncoding != Encoding.UTF8;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && PlatformWindows.IsUsingRasterFont())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && PlatformWindows.IsConsoleInput() && PlatformWindows.IsUsingRasterFont())
             {
                 _changeOutputEncoding = false;
             }


### PR DESCRIPTION
On Windows, the outputencoding is tied to a codepage which is tied to a font.  When using a CJK locale, the default is using a raster font that can render the CJK glyphs.  Previously, PSReadLine 2.0.0 was manipulating the OutputEncoding to utf8 which resulted in a visible font change in the console and the resulting rendering in the screen buffer was not correct.

The fix is to detect that a raster font is being used and not change the output encoding.  Also in cases where the output encoding is already utf8, there's no need to change it.