### PR TITLE
Save/restore initial fg/bg colors

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -433,6 +433,8 @@ namespace Microsoft.PowerShell
                         if (!_singleton._closingWaitHandle.WaitOne(0))
                         {
                             console.OutputEncoding = _singleton._initialOutputEncoding;
+                            console.ForegroundColor = _singleton._initialForeground;
+                            console.BackgroundColor = _singleton._initialBackground;
                             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                             {
                                 Console.TreatControlCAsInput = oldControlCAsInput;
@@ -655,6 +657,8 @@ namespace Microsoft.PowerShell
             _inputAccepted = false;
             _initialX = _console.CursorLeft;
             _initialY = _console.CursorTop;
+            _initialForeground = _console.ForegroundColor;
+            _initialBackground = _console.BackgroundColor;
             _statusIsErrorMessage = false;
 
             _initialOutputEncoding = _console.OutputEncoding;

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -51,6 +51,8 @@ namespace Microsoft.PowerShell
         };
         private int _initialX;
         private int _initialY;
+        private ConsoleColor _initialForeground;
+        private ConsoleColor _initialBackground;
         private int _current;
         private int _emphasisStart;
         private int _emphasisLength;


### PR DESCRIPTION
Writing CSI 0 m resets the colors to the terminals initial colors, not
what the settings are before PSReadLine starts.

Fix #774