### PR TITLE
Remove uses of CSI # S / ScrollConsoleScreenBuffer

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -270,7 +270,8 @@ namespace Microsoft.PowerShell
             }
 
             var point = ConvertOffsetToPoint(_current);
-            PlaceCursor(0, point.Y + 1);
+            _console.SetCursorPosition(point.X, point.Y);
+            _console.Write("\n");
             _inputAccepted = true;
             return true;
         }

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -113,7 +113,6 @@ namespace Microsoft.PowerShell.Internal
         public void SetCursorPosition(int left, int top) => Console.SetCursorPosition(left, top);
         public virtual void Write(string value)          => Console.Write(value);
         public virtual void WriteLine(string value)      => Console.WriteLine(value);
-        public virtual void ScrollBuffer(int lines)      => Console.Write("\x1b[" + lines + "S");
         public virtual void BlankRestOfLine()            => Console.Write("\x1b[K");
     }
 }

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -624,7 +624,8 @@ namespace Microsoft.PowerShell
 
             // Don't overwrite any of the line - so move to first line after the end of our buffer.
             var point = _singleton.ConvertOffsetToPoint(_singleton._buffer.Length);
-            _singleton.PlaceCursor(0, point.Y + 1);
+            console.SetCursorPosition(point.X, point.Y);
+            console.Write("\n");
 
             console.WriteLine(buffer.ToString());
             InvokePrompt(key: null, arg: _singleton._console.CursorTop);
@@ -677,12 +678,14 @@ namespace Microsoft.PowerShell
 
             _singleton.ClearStatusMessage(render: false);
 
+            var console = _singleton._console;
             // Don't overwrite any of the line - so move to first line after the end of our buffer.
             var point = _singleton.ConvertOffsetToPoint(_singleton._buffer.Length);
-            _singleton.PlaceCursor(0, point.Y + 1);
+            console.SetCursorPosition(point.X, point.Y);
+            console.Write("\n");
 
-            _singleton._console.WriteLine(buffer.ToString());
-            InvokePrompt(key: null, arg: _singleton._console.CursorTop);
+            console.WriteLine(buffer.ToString());
+            InvokePrompt(key: null, arg: console.CursorTop);
         }
     }
 }

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -394,18 +394,8 @@ namespace Microsoft.PowerShell
         public static void ClearScreen(ConsoleKeyInfo? key = null, object arg = null)
         {
             var console = _singleton._console;
-            int newY = _singleton._initialY - _singleton.Options.ExtraPromptLineCount;
-            if (newY + console.WindowHeight > console.BufferHeight)
-            {
-                var scrollCount = newY - console.WindowTop;
-                console.ScrollBuffer(scrollCount);
-                _singleton._initialY -= scrollCount;
-                console.SetCursorPosition(console.CursorLeft, console.CursorTop - scrollCount);
-            }
-            else
-            {
-                console.SetWindowPosition(0, newY);
-            }
+            console.Write("\x1b[2J");
+            InvokePrompt(null, console.WindowTop);
         }
 
         // Try to convert the arg to a char, return 0 for failure

--- a/PSReadLine/PlatformWindows.cs
+++ b/PSReadLine/PlatformWindows.cs
@@ -574,20 +574,6 @@ static class PlatformWindows
             WriteHelper(s, true);
         }
 
-        public struct SMALL_RECT
-        {
-            public short Left;
-            public short Top;
-            public short Right;
-            public short Bottom;
-        }
-
-        internal struct COORD
-        {
-            public short X;
-            public short Y;
-        }
-
         public struct CHAR_INFO
         {
             public ushort UnicodeChar;

--- a/PSReadLine/PlatformWindows.cs
+++ b/PSReadLine/PlatformWindows.cs
@@ -5,6 +5,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.PowerShell;
 using Microsoft.PowerShell.Internal;
@@ -414,6 +415,7 @@ static class PlatformWindows
     {
         private static ConsoleColor InitialFG = Console.ForegroundColor;
         private static ConsoleColor InitialBG = Console.BackgroundColor;
+        private static int maxTop = 0;
 
         private static readonly Dictionary<int, Action> VTColorAction = new Dictionary<int, Action> {
             {40, () => Console.BackgroundColor = ConsoleColor.Black},
@@ -463,7 +465,12 @@ static class PlatformWindows
                 // The shortest pattern is 4 characters, <ESC>[0m
                 if (s[i] != '\x1b' || (i + 3) >= s.Length || s[i + 1] != '[') continue;
 
-                Console.Write(s.Substring(from, i - from));
+                var prefix = s.Substring(from, i - from);
+                if (prefix.Length > 0)
+                {
+                    Console.Write(prefix);
+                    maxTop = Console.CursorTop;
+                }
                 from = i;
 
                 Action action1 = null;
@@ -491,6 +498,23 @@ static class PlatformWindows
                         case 'm':
                             done = true;
                             goto case ';';
+
+                        case 'J':
+                            // We'll only support entire display for ED (Erase in Display)
+                            if (color == 2) {
+                                var cursorVisible = Console.CursorVisible;
+                                var left = Console.CursorLeft;
+                                var toScroll = maxTop - Console.WindowTop + 1;
+                                Console.CursorVisible = false;
+                                Console.SetCursorPosition(0, Console.WindowTop + Console.WindowHeight - 1);
+                                for (int k = 0; k < toScroll; k++)
+                                {
+                                    Console.WriteLine();
+                                }
+                                Console.SetCursorPosition(left, Console.WindowTop + toScroll - 1);
+                                Console.CursorVisible = cursorVisible;
+                            }
+                            break;
 
                         case ';':
                             if (VTColorAction.TryGetValue(color, out var action))
@@ -525,8 +549,19 @@ static class PlatformWindows
             }
 
             var tailSegment = s.Substring(from);
-            if (line) Console.WriteLine(tailSegment);
-            else Console.Write(tailSegment);
+            if (line)
+            {
+                Console.WriteLine(tailSegment);
+                maxTop = Console.CursorTop;
+            }
+            else
+            {
+                Console.Write(tailSegment);
+                if (tailSegment.Length > 0)
+                {
+                    maxTop = Console.CursorTop;
+                }
+            }
         }
 
         public override void Write(string s)
@@ -562,28 +597,6 @@ static class PlatformWindows
                 UnicodeChar = c;
                 Attributes = (ushort)(((int)background << 4) | (int)foreground);
             }
-        }
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern bool ScrollConsoleScreenBuffer(IntPtr hConsoleOutput,
-            ref SMALL_RECT lpScrollRectangle,
-            IntPtr lpClipRectangle,
-            COORD dwDestinationOrigin,
-            ref CHAR_INFO lpFill);
-
-        public override void ScrollBuffer(int lines)
-        {
-            var handle = GetStdHandle((uint) StandardHandleId.Output);
-            var scrollRectangle = new SMALL_RECT
-            {
-                Top = (short) lines,
-                Left = 0,
-                Bottom = (short)(Console.BufferHeight - 1),
-                Right = (short)Console.BufferWidth
-            };
-            var destinationOrigin = new COORD {X = 0, Y = 0};
-            var fillChar = new CHAR_INFO(' ', Console.ForegroundColor, Console.BackgroundColor);
-            ScrollConsoleScreenBuffer(handle, ref scrollRectangle, IntPtr.Zero, destinationOrigin, ref fillChar);
         }
 
         public override int CursorSize

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -48,7 +48,6 @@ namespace Microsoft.PowerShell
             void SetCursorPosition(int left, int top);
             void WriteLine(string s);
             void Write(string s);
-            void ScrollBuffer(int lines);
             void BlankRestOfLine();
         }
 

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -955,12 +955,6 @@ namespace Microsoft.PowerShell
 
             if (arg is int newY)
             {
-                if (newY >= console.BufferHeight)
-                {
-                    var toScroll = newY - console.BufferHeight + 1;
-                    console.ScrollBuffer(toScroll);
-                    newY -= toScroll;
-                }
                 console.SetCursorPosition(0, newY);
             }
             else

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -4,6 +4,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -51,6 +52,7 @@ namespace Microsoft.PowerShell
         };
         private int _initialX;
         private int _initialY;
+
         private ConsoleColor _initialForeground;
         private ConsoleColor _initialBackground;
         private int _current;
@@ -363,7 +365,7 @@ namespace Microsoft.PowerShell
 
             // Move the cursor to where we started, but make cursor invisible while we're rendering.
             _console.CursorVisible = false;
-            PlaceCursor(_initialX, _initialY);
+            _console.SetCursorPosition(_initialX, _initialY);
 
             // Possibly need to flip the color on the prompt if the error state changed.
             var promptText = _options.PromptText;
@@ -512,7 +514,7 @@ namespace Microsoft.PowerShell
             }
 
             var point = ConvertOffsetToPoint(_current);
-            PlaceCursor(point.X, point.Y);
+            _console.SetCursorPosition(point.X, point.Y);
             _console.CursorVisible = true;
 
             // TODO: set WindowTop if necessary
@@ -661,19 +663,6 @@ namespace Microsoft.PowerShell
             }
         }
 
-        private void PlaceCursor(int x, int y)
-        {
-            int statusLineCount = GetStatusLineCount();
-            if ((y + statusLineCount) >= _console.BufferHeight)
-            {
-                var scrollCount = y + statusLineCount - _console.BufferHeight + 1;
-                _console.ScrollBuffer(scrollCount);
-                _initialY -= scrollCount;
-                y -= scrollCount;
-            }
-            _console.SetCursorPosition(x, y);
-        }
-
         private void MoveCursor(int newCursor)
         {
             // In case the buffer was resized
@@ -682,7 +671,7 @@ namespace Microsoft.PowerShell
             _previousRender.bufferHeight = _console.BufferHeight;
 
             var point = ConvertOffsetToPoint(newCursor);
-            PlaceCursor(point.X, point.Y);
+            _console.SetCursorPosition(point.X, point.Y);
             _current = newCursor;
         }
 

--- a/PSReadLine/ScreenCapture.cs
+++ b/PSReadLine/ScreenCapture.cs
@@ -161,12 +161,6 @@ namespace Microsoft.PowerShell
 
             int bufferWidth = Console.BufferWidth;
             int bufferLineCount = buffer.Length / bufferWidth;
-            if ((top + bufferLineCount) > Console.BufferHeight)
-            {
-                var scrollCount = (top + bufferLineCount) - Console.BufferHeight;
-                console.ScrollBuffer(scrollCount);
-                top -= scrollCount;
-            }
             var bufferSize = new COORD
             {
                 X = (short) bufferWidth,

--- a/test/CompletionTest.cs
+++ b/test/CompletionTest.cs
@@ -87,6 +87,7 @@ namespace Test
                 ps.AddScript($@"function prompt {{ ""{promptLine1}`n{promptLine2}"" }}");
                 ps.Invoke();
             }
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {ExtraPromptLineCount = 1});
 
             _console.Clear();
             Test("psvar", Keys(
@@ -108,7 +109,7 @@ namespace Test
 
             using (var ps = PowerShell.Create(RunspaceMode.CurrentRunspace))
             {
-                ps.AddCommand("Remove-Item").AddArgument("prompt");
+                ps.AddCommand("Remove-Item").AddArgument("function:prompt");
                 ps.Invoke();
             }
 


### PR DESCRIPTION
This hopefully fixes some weird issues in WSL and some Linux terminals.

This also works around a Windows 1809 Console bug for the Ctrl+l binding
to clear the screen by using the same escape sequence that bash uses.

Fix #724