### PR TITLE
New - Support 'G' and 'gg' movements in multi-line buffers.

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -379,7 +379,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Used to group the built in functions for help and Get-PSReadLineKeyHander output.
+        /// Used to group the built in functions for help and Get-PSReadLineKeyHandler output.
         /// </summary>
         public static KeyHandlerGroup GetDisplayGrouping(string function)
         {
@@ -495,6 +495,8 @@ namespace Microsoft.PowerShell
             case nameof(GotoColumn):
             case nameof(GotoFirstNonBlankOfLine):
             case nameof(MoveToEndOfLine):
+            case nameof(MoveToFirstLine):
+            case nameof(MoveToLastLine):
             case nameof(NextLine):
             case nameof(NextWord):
             case nameof(NextWordEnd):

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell
                 { Keys.ucD,             MakeKeyHandler(DeleteToEnd,          "DeleteToEnd") },
                 { Keys.ucE,             MakeKeyHandler(ViEndOfGlob,          "ViEndOfGlob") },
                 { Keys.ucF,             MakeKeyHandler(SearchCharBackward,   "SearchCharBackward") },
-                { Keys.ucG,             MakeKeyHandler(MoveToLastLogicalLine,      "MoveToLastLogicalLine") },
+                { Keys.ucG,             MakeKeyHandler(MoveToLastLine,       "MoveToLastLine") },
                 { Keys.ucH,             MakeKeyHandler(Ding,                 "Ignore") },
                 { Keys.ucI,             MakeKeyHandler(ViInsertAtBegining,   "ViInsertAtBegining") },
                 { Keys.ucJ,             MakeKeyHandler(ViJoinLines,          "ViJoinLines") },
@@ -261,7 +261,7 @@ namespace Microsoft.PowerShell
 
             _viChordGTable = new Dictionary<ConsoleKeyInfo, KeyHandler>(ConsoleKeyInfoComparer.Instance)
             {
-                { Keys.G,               MakeKeyHandler( MoveToFirstLogicalLine,                    "MoveToFirstLogicalLine") },
+                { Keys.G,               MakeKeyHandler( MoveToFirstLine,                    "MoveToFirstLine") },
             };
 
             _viChordYTable = new Dictionary<ConsoleKeyInfo, KeyHandler>(ConsoleKeyInfoComparer.Instance)

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -40,6 +40,7 @@ namespace Microsoft.PowerShell
         private static Dictionary<ConsoleKeyInfo, KeyHandler> _viInsKeyMap;
         private static Dictionary<ConsoleKeyInfo, KeyHandler> _viCmdKeyMap;
         private static Dictionary<ConsoleKeyInfo, KeyHandler> _viChordDTable;
+        private static Dictionary<ConsoleKeyInfo, KeyHandler> _viChordGTable;
         private static Dictionary<ConsoleKeyInfo, KeyHandler> _viChordCTable;
         private static Dictionary<ConsoleKeyInfo, KeyHandler> _viChordYTable;
 
@@ -134,7 +135,7 @@ namespace Microsoft.PowerShell
                 { Keys.D,               MakeKeyHandler(ViChord,                "ChordFirstKey") },
                 { Keys.E,               MakeKeyHandler(NextWordEnd,          "NextWordEnd") },
                 { Keys.F,               MakeKeyHandler(SearchChar,           "SearchChar") },
-                { Keys.G,               MakeKeyHandler(Ding,                 "Ignore") },
+                { Keys.G,               MakeKeyHandler(ViChord,                 "ChordFirstKey") },
                 { Keys.H,               MakeKeyHandler(BackwardChar,         "BackwardChar") },
                 { Keys.I,               MakeKeyHandler(ViInsertMode,         "ViInsertMode") },
                 { Keys.J,               MakeKeyHandler(NextHistory,          "NextHistory") },
@@ -160,7 +161,7 @@ namespace Microsoft.PowerShell
                 { Keys.ucD,             MakeKeyHandler(DeleteToEnd,          "DeleteToEnd") },
                 { Keys.ucE,             MakeKeyHandler(ViEndOfGlob,          "ViEndOfGlob") },
                 { Keys.ucF,             MakeKeyHandler(SearchCharBackward,   "SearchCharBackward") },
-                { Keys.ucG,             MakeKeyHandler(Ding,                 "Ignore") },
+                { Keys.ucG,             MakeKeyHandler(MoveToLastLine,      "ViMultilineMoveToLastLine") },
                 { Keys.ucH,             MakeKeyHandler(Ding,                 "Ignore") },
                 { Keys.ucI,             MakeKeyHandler(ViInsertAtBegining,   "ViInsertAtBegining") },
                 { Keys.ucJ,             MakeKeyHandler(ViJoinLines,          "ViJoinLines") },
@@ -258,6 +259,11 @@ namespace Microsoft.PowerShell
                 { Keys.ucT,             MakeKeyHandler( ViReplaceToBeforeCharBackward,    "ViReplaceToBeforeCharBackward") },
             };
 
+            _viChordGTable = new Dictionary<ConsoleKeyInfo, KeyHandler>(ConsoleKeyInfoComparer.Instance)
+            {
+                { Keys.G,               MakeKeyHandler( MoveToFirstLine,                    "MoveToFirstLine") },
+            };
+
             _viChordYTable = new Dictionary<ConsoleKeyInfo, KeyHandler>(ConsoleKeyInfoComparer.Instance)
             {
                 { Keys.Y,               MakeKeyHandler( ViYankLine,            "ViYankLine") },
@@ -281,6 +287,7 @@ namespace Microsoft.PowerShell
 
             _dispatchTable = _viInsKeyMap;
             _chordDispatchTable = _viInsChordTable;
+            _viCmdChordTable[Keys.G] = _viChordGTable;
             _viCmdChordTable[Keys.D] = _viChordDTable;
             _viCmdChordTable[Keys.C] = _viChordCTable;
             _viCmdChordTable[Keys.Y] = _viChordYTable;

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell
                 { Keys.ucD,             MakeKeyHandler(DeleteToEnd,          "DeleteToEnd") },
                 { Keys.ucE,             MakeKeyHandler(ViEndOfGlob,          "ViEndOfGlob") },
                 { Keys.ucF,             MakeKeyHandler(SearchCharBackward,   "SearchCharBackward") },
-                { Keys.ucG,             MakeKeyHandler(MoveToLastLine,      "ViMultilineMoveToLastLine") },
+                { Keys.ucG,             MakeKeyHandler(MoveToLastLogicalLine,      "MoveToLastLogicalLine") },
                 { Keys.ucH,             MakeKeyHandler(Ding,                 "Ignore") },
                 { Keys.ucI,             MakeKeyHandler(ViInsertAtBegining,   "ViInsertAtBegining") },
                 { Keys.ucJ,             MakeKeyHandler(ViJoinLines,          "ViJoinLines") },
@@ -261,7 +261,7 @@ namespace Microsoft.PowerShell
 
             _viChordGTable = new Dictionary<ConsoleKeyInfo, KeyHandler>(ConsoleKeyInfoComparer.Instance)
             {
-                { Keys.G,               MakeKeyHandler( MoveToFirstLine,                    "MoveToFirstLine") },
+                { Keys.G,               MakeKeyHandler( MoveToFirstLogicalLine,                    "MoveToFirstLogicalLine") },
             };
 
             _viChordYTable = new Dictionary<ConsoleKeyInfo, KeyHandler>(ConsoleKeyInfoComparer.Instance)

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -46,24 +46,10 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void BeginningOfLine(ConsoleKeyInfo? key = null, object arg = null)
         {
-            if (_singleton.LineIsMultiLine())
-            {
-                int i = Math.Max(0, _singleton._current - 1);
-                for (; i > 0; i--)
-                {
-                    if (_singleton._buffer[i] == '\n')
-                    {
-                        i += 1;
-                        break;
-                    }
-                }
+            var newCurrent = GetBeginningOfLinePos(_singleton._current);
+            newCurrent = newCurrent == _singleton._current ? 0 : newCurrent;
 
-                _singleton.MoveCursor((i == _singleton._current) ? 0 : i);
-            }
-            else
-            {
-                _singleton.MoveCursor(0);
-            }
+            _singleton.MoveCursor(newCurrent);
         }
 
         /// <summary>

--- a/PSReadLine/Movement.vi.multiline.cs
+++ b/PSReadLine/Movement.vi.multiline.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <param name="key" />
         /// <param name="arg" />
-        public void MoveToFirstLogicalLine(ConsoleKeyInfo? key = null, object arg = null)
+        public void MoveToFirstLine(ConsoleKeyInfo? key = null, object arg = null)
         {
             if (!LineIsMultiLine())
             {
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <param name="key" />
         /// <param name="arg" />
-        public void MoveToLastLogicalLine(ConsoleKeyInfo? key = null, object arg = null)
+        public void MoveToLastLine(ConsoleKeyInfo? key = null, object arg = null)
         {
             if (!LineIsMultiLine())
             {

--- a/PSReadLine/Movement.vi.multiline.cs
+++ b/PSReadLine/Movement.vi.multiline.cs
@@ -1,25 +1,28 @@
 ﻿using System;
-using System.IO;
 
 namespace Microsoft.PowerShell
 {
     public partial class PSConsoleReadLine
     {
         /// <summary>
-        /// Moves the cursor to the beginning of the first line.
+        /// Moves the cursor to the beginning of the first logical line
+        /// of a multi-line buffer.
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="arg"></param>
-        public void MoveToFirstLine(ConsoleKeyInfo? key = null, object arg = null)
+        /// <param name="key" />
+        /// <param name="arg" />
+        public void MoveToFirstLogicalLine(ConsoleKeyInfo? key = null, object arg = null)
         {
             if (!LineIsMultiLine())
+            {
                 Ding(key, arg);
+                return;
+            }
 
-            var number = GetCurrentLine();
+            var currentLine =  GetLogicalLineNumber(); 
 
             var pos = ConvertOffsetToPoint(_singleton._current);
 
-            pos.Y -= number -1;
+            pos.Y -= currentLine -1;
 
             var newCurrent = ConvertLineAndColumnToOffset(pos);
             var position = GetBeginningOfLinePos(newCurrent);
@@ -28,21 +31,25 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Moves the cursor to the beginning of the last line.
+        /// Moves the cursor to the beginning of the last logical logical line.
+        /// of a multi-line buffer.
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="arg"></param>
-        public void MoveToLastLine(ConsoleKeyInfo? key = null, object arg = null)
+        /// <param name="key" />
+        /// <param name="arg" />
+        public void MoveToLastLogicalLine(ConsoleKeyInfo? key = null, object arg = null)
         {
             if (!LineIsMultiLine())
+            {
                 Ding(key, arg);
+                return;
+            }
 
-            var count = GetLineCount();
-            var number = GetCurrentLine();
+            var count = GetLogicalLineCount();
+            var currentLine = GetLogicalLineNumber();
 
             var pos = ConvertOffsetToPoint(_singleton._current);
 
-            pos.Y += (count - number);
+            pos.Y += (count - currentLine);
 
             var newCurrent = ConvertLineAndColumnToOffset(pos);
             var position = GetBeginningOfLinePos(newCurrent);

--- a/PSReadLine/Movement.vi.multiline.cs
+++ b/PSReadLine/Movement.vi.multiline.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+
+namespace Microsoft.PowerShell
+{
+    public partial class PSConsoleReadLine
+    {
+        /// <summary>
+        /// Moves the cursor to the beginning of the first line.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="arg"></param>
+        public void MoveToFirstLine(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            if (!LineIsMultiLine())
+                Ding(key, arg);
+
+            var number = GetCurrentLine();
+
+            var pos = ConvertOffsetToPoint(_singleton._current);
+
+            pos.Y -= number -1;
+
+            var newCurrent = ConvertLineAndColumnToOffset(pos);
+            var position = GetBeginningOfLinePos(newCurrent);
+
+            _singleton.MoveCursor(position);
+        }
+
+        /// <summary>
+        /// Moves the cursor to the beginning of the last line.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="arg"></param>
+        public void MoveToLastLine(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            if (!LineIsMultiLine())
+                Ding(key, arg);
+
+            var count = GetLineCount();
+            var number = GetCurrentLine();
+
+            var pos = ConvertOffsetToPoint(_singleton._current);
+
+            pos.Y += (count - number);
+
+            var newCurrent = ConvertLineAndColumnToOffset(pos);
+            var position = GetBeginningOfLinePos(newCurrent);
+
+            _singleton.MoveCursor(position);
+        }
+    }
+}

--- a/PSReadLine/Position.cs
+++ b/PSReadLine/Position.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Microsoft.PowerShell
+{
+    public partial class PSConsoleReadLine
+    {
+        /// <summary>
+        /// Returns the position of the beginning of line
+        /// starting from the specified "current" position.
+        /// </summary>
+        /// <param name="current"></param>
+        /// <returns></returns>
+        private static int GetBeginningOfLinePos(int current)
+        {
+            var newCurrent = current;
+
+            if (_singleton.LineIsMultiLine())
+            {
+                int i = Math.Max(0, current - 1);
+                for (; i > 0; i--)
+                {
+                    if (_singleton._buffer[i] == '\n')
+                    {
+                        i += 1;
+                        break;
+                    }
+                }
+
+                newCurrent = i;
+            }
+            else
+            {
+                newCurrent = 0;
+            }
+
+            return newCurrent;
+        }
+    }
+}

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -800,35 +800,41 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Returns the line number under the cursor.
+        /// Returns the logical line number under the cursor in a multi-line buffer.
+        /// When rendering, a logical line may span multiple physical lines.
         /// </summary>
-        /// <returns></returns>
-        private int GetCurrentLine()
+        /// <returns>The current logical line number, the first line being numbered 1.</returns>
+        private int GetLogicalLineNumber()
         {
             var current = _current;
-            var number = 1;
+            var lineNumber = 1;
 
             for (int i = 0; i < current; i++)
             {
                 if (_buffer[i] == '\n')
-                    number++;
+                {
+                    lineNumber++;
+                }
             }
-            return number;
+            return lineNumber;
 
         }
 
         /// <summary>
-        /// Returns the number of lines in a multi-line buffer
+        /// Returns the number of logical lines in a multi-line buffer.
+        /// When rendering, a logical line may span multiple physical lines.
         /// </summary>
-        /// <returns></returns>
-        private int GetLineCount()
+        /// <returns>The number of logical lines, the first line being numbered 1.</returns>
+        private int GetLogicalLineCount()
         {
             var count = 1;
 
             for (int i = 0; i < _buffer.Length; i++)
             {
                 if (_buffer[i] == '\n')
+                {
                     count++;
+                }
             }
             return count;
         }

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -799,6 +799,40 @@ namespace Microsoft.PowerShell
             return (point.Y == y) ? offset : -1;
         }
 
+        /// <summary>
+        /// Returns the line number under the cursor.
+        /// </summary>
+        /// <returns></returns>
+        private int GetCurrentLine()
+        {
+            var current = _current;
+            var number = 1;
+
+            for (int i = 0; i < current; i++)
+            {
+                if (_buffer[i] == '\n')
+                    number++;
+            }
+            return number;
+
+        }
+
+        /// <summary>
+        /// Returns the number of lines in a multi-line buffer
+        /// </summary>
+        /// <returns></returns>
+        private int GetLineCount()
+        {
+            var count = 1;
+
+            for (int i = 0; i < _buffer.Length; i++)
+            {
+                if (_buffer[i] == '\n')
+                    count++;
+            }
+            return count;
+        }
+
         private bool LineIsMultiLine()
         {
             for (int i = 0; i < _buffer.Length; i++)

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -803,7 +803,6 @@ namespace Microsoft.PowerShell
         /// Returns the logical line number under the cursor in a multi-line buffer.
         /// When rendering, a logical line may span multiple physical lines.
         /// </summary>
-        /// <returns>The current logical line number, the first line being numbered 1.</returns>
         private int GetLogicalLineNumber()
         {
             var current = _current;
@@ -824,7 +823,6 @@ namespace Microsoft.PowerShell
         /// Returns the number of logical lines in a multi-line buffer.
         /// When rendering, a logical line may span multiple physical lines.
         /// </summary>
-        /// <returns>The number of logical lines, the first line being numbered 1.</returns>
         private int GetLogicalLineCount()
         {
             var count = 1;

--- a/test/MovementTest.VI.Multiline.cs
+++ b/test/MovementTest.VI.Multiline.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Management.Automation.Language;
 using Microsoft.PowerShell;
 using Xunit;
@@ -10,7 +11,7 @@ namespace Test
     public partial class ReadLine
     {
         [Fact]
-        public void ViMoveToFirstLine()
+        public void ViMoveToFirstLogicalLineThenJumpToLastLogicalLine()
         {
             TestSetup(KeyMode.Vi);
 
@@ -28,7 +29,44 @@ namespace Test
                 "gg", CheckThat(() => AssertCursorLeftTopIs(0, 0)),
                 'G', CheckThat(() => AssertCursorLeftTopIs(continuationPrefixLength, 4))
             ));
+        }
 
+        [Fact]
+        public void ViMoveToLastLogicalLine_MustDing_ForEmptyLine()
+        {
+            const string buffer = "";
+            var keys = new object[] {"", _.Escape, 'G',};
+            ViJumpMustDing(buffer, keys);
+        }
+
+        [Fact]
+        public void ViMoveToFirstLogicalLine_MustDing_ForEmptyLine()
+        {
+            const string buffer = "";
+            var keys = new object[] {"", _.Escape, "gg",};
+            ViJumpMustDing(buffer, keys);
+        }
+
+        [Fact]
+        public void ViMoveToLastLogicalLine_MustDing_ForSingleLine()
+        {
+            const string buffer = "Ding";
+            var keys = new object[] {"Ding", _.Escape, 'G',};
+            ViJumpMustDing(buffer, keys);
+        }
+
+        [Fact]
+        public void ViMoveToFirstLogicalLine_MustDing_ForSingleLine()
+        {
+            const string buffer = "Ding";
+            var keys = new object[] {"Ding", _.Escape, "gg",};
+            ViJumpMustDing(buffer, keys);
+        }
+
+        private void ViJumpMustDing(string expectedResult, params object[] keys)
+        {
+            TestSetup(KeyMode.Vi);
+            TestMustDing(expectedResult, Keys(keys));
         }
     }
 }

--- a/test/MovementTest.VI.Multiline.cs
+++ b/test/MovementTest.VI.Multiline.cs
@@ -1,0 +1,34 @@
+﻿using System.IO;
+using System.Management.Automation.Language;
+using Microsoft.PowerShell;
+using Xunit;
+
+namespace Test
+{
+    using _ = Keys;
+
+    public partial class ReadLine
+    {
+        [Fact]
+        public void ViMoveToFirstLine()
+        {
+            TestSetup(KeyMode.Vi);
+
+            const string buffer = "\"Multiline buffer\n containing an empty line\n\nand text aligned on the left\n\"";
+
+            var continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
+
+            Test(buffer, Keys(
+                _.DQuote, "Multiline buffer", _.Enter,
+                " containing an empty line", _.Enter,
+                _.Enter,
+                "and text aligned on the left", _.Enter,
+                _.DQuote,
+                _.Escape, CheckThat(() => AssertCursorTopIs(4)),
+                "gg", CheckThat(() => AssertCursorLeftTopIs(0, 0)),
+                'G', CheckThat(() => AssertCursorLeftTopIs(continuationPrefixLength, 4))
+            ));
+
+        }
+    }
+}


### PR DESCRIPTION
As discussed, in [#789](https://github.com/lzybkr/PSReadLine/issues/789) here is a pull request, and accompanying test.

This supports <kbd>G</kbd> and <kbd>gg</kbd> movements to, respectively, move to the end or the beginning of a multiline buffer.

Please, let me know if I need to provide more informations or put some more work into this pull request.