### PR TITLE
Make Get-PSReadLineOption show AnsiEscapeTimeout

### DIFF
--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -156,6 +156,9 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                 <PropertyName>WordDelimiters</PropertyName>
               </ListItem>
               <ListItem>
+                <PropertyName>AnsiEscapeTimeout</PropertyName>
+              </ListItem>
+              <ListItem>
                 <Label>CommandColor</Label>
                 <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.CommandColor)</ScriptBlock>
               </ListItem>


### PR DESCRIPTION
I don't feel strongly about where I stuck it in the list; feel free to tell me to move it.