### PR TITLE
Fix rendering issue when menu complete shifts due to length of completion

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -519,7 +519,7 @@ namespace Microsoft.PowerShell
                 if (bufferEndPoint.Y < PreviousTop)
                 {
                     console.BlankRestOfLine();
-                    Singleton.WriteBlankLines(1);
+                    Singleton.WriteBlankLines(PreviousTop - bufferEndPoint.Y);
                 }
 
                 PreviousTop = bufferEndPoint.Y;

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -447,6 +447,8 @@ namespace Microsoft.PowerShell
         {
             internal PSConsoleReadLine Singleton;
             internal int Top;
+
+            internal int PreviousTop;
             internal int ColumnWidth;
             internal int BufferLines;
             internal int Rows;
@@ -512,6 +514,15 @@ namespace Microsoft.PowerShell
                         Singleton.WriteBlankLines(previousMenu.Rows + previousMenu.ToolTipLines - Rows);
                     }
                 }
+
+                // if the menu has moved, we need to clear the lines under it
+                if (bufferEndPoint.Y < PreviousTop)
+                {
+                    console.BlankRestOfLine();
+                    Singleton.WriteBlankLines(1);
+                }
+
+                PreviousTop = bufferEndPoint.Y;
 
                 if (menuSelect)
                 {


### PR DESCRIPTION
When a menu item renders longer than the current line and takes up a second row, the menu shifts down.  When a shorter item is selected that fits within the line, the menu shifts back up resulting in the last row to be left on the screen.  Fix is to detect when the menu shifts and clear out the rest of the previous last line and blank out the last line.

Fix https://github.com/lzybkr/PSReadLine/issues/689