### PR TITLE
Add internal clipboard

### DIFF
--- a/PSReadLine/Clipboard.cs
+++ b/PSReadLine/Clipboard.cs
@@ -12,6 +12,9 @@ namespace Microsoft.PowerShell.Internal
     static class Clipboard
     {
         private static bool? _clipboardSupported;
+        // Used if an external clipboard is not available, e.g. if xclip is missing.
+        // This is useful for testing in CI as well.
+        private static string _internalClipboard;
 
         private static string StartProcess(
             string tool,
@@ -61,7 +64,7 @@ namespace Microsoft.PowerShell.Internal
             if (_clipboardSupported == false)
             {
                 PSConsoleReadLine.Ding();
-                return "";
+                return _internalClipboard ?? "";
             }
 
             string tool = "";
@@ -97,6 +100,7 @@ namespace Microsoft.PowerShell.Internal
 
             if (_clipboardSupported == false)
             {
+                _internalClipboard = text;
                 PSConsoleReadLine.Ding();
                 return;
             }
@@ -125,6 +129,10 @@ namespace Microsoft.PowerShell.Internal
             }
 
             StartProcess(tool, args, text);
+            if (_clipboardSupported == false)
+            {
+                _internalClipboard = text;
+            }
         }
 
         public static void SetRtf(string plainText, string rtfText)

--- a/test/KillYankTest.cs
+++ b/test/KillYankTest.cs
@@ -305,10 +305,10 @@ namespace Test
         {
             TestSetup(KeyMode.Cmd);
 
-            Clipboard.SetText("pastetest1");
+            SetClipboardText("pastetest1");
             Test("pastetest1", Keys(_.CtrlV));
 
-            Clipboard.SetText("pastetest2");
+            SetClipboardText("pastetest2");
             Test("echo pastetest2", Keys(
                 "echo foobar", _.CtrlShiftLeftArrow, _.CtrlV));
         }
@@ -318,7 +318,7 @@ namespace Test
         {
             TestSetup(KeyMode.Cmd);
 
-            Clipboard.SetText("");
+            SetClipboardText("");
             Test("", Keys(
                 "cuttest1", _.CtrlShiftLeftArrow, _.CtrlX));
             AssertClipboardTextIs("cuttest1");
@@ -329,12 +329,12 @@ namespace Test
         {
             TestSetup(KeyMode.Cmd);
 
-            Clipboard.SetText("");
+            SetClipboardText("");
             Test("copytest1", Keys(
                 "copytest1", _.CtrlShiftC));
             AssertClipboardTextIs("copytest1");
 
-            Clipboard.SetText("");
+            SetClipboardText("");
             Test("echo copytest2", Keys(
                 "echo copytest2", _.CtrlShiftLeftArrow, _.CtrlShiftC));
             AssertClipboardTextIs("copytest2");
@@ -345,7 +345,7 @@ namespace Test
         {
             TestSetup(KeyMode.Cmd);
 
-            Clipboard.SetText("");
+            SetClipboardText("");
             Test("echo copytest2", Keys(
                 "echo copytest2", _.CtrlShiftLeftArrow, _.CtrlC));
             AssertClipboardTextIs("copytest2");

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -39,9 +39,6 @@
     <Compile Include="..\PSReadLine\CharMap.cs">
       <Link>CharMap.cs</Link>
     </Compile>
-    <Compile Include="..\PSReadLine\Clipboard.cs">
-      <Link>Clipboard.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PSReadLine\PSReadLine.csproj">

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -511,9 +511,20 @@ namespace Test
             Assert.Equal(expected, input);
         }
 
+        static readonly MethodInfo ClipboardGetTextMethod =
+            typeof(PSConsoleReadLine).Assembly.GetType("Microsoft.PowerShell.Internal.Clipboard")
+                .GetMethod("GetText", BindingFlags.Static | BindingFlags.Public);
+        static readonly MethodInfo ClipboardSetTextMethod =
+            typeof(PSConsoleReadLine).Assembly.GetType("Microsoft.PowerShell.Internal.Clipboard")
+                .GetMethod("SetText", BindingFlags.Static | BindingFlags.Public);
         private static string GetClipboardText()
         {
-            return Clipboard.GetText();
+            return (string)ClipboardGetTextMethod.Invoke(null, null);
+        }
+
+        private static void SetClipboardText(string text)
+        {
+            ClipboardSetTextMethod.Invoke(null, new[] { text });
         }
 
         private void AssertClipboardTextIs(string text)


### PR DESCRIPTION
For Mac/Linux, if the commands to use the system clipboard are missing,
we can at least simulate a clipboard internally, just for PSReadLine.

This is allows the clipboard tests to run in the Azure DevOps CI for
Linux.