### PR TITLE
Disable stdin/stdout check for CI on non-Windows

### DIFF
--- a/PSReadLine.build.ps1
+++ b/PSReadLine.build.ps1
@@ -197,21 +197,9 @@ task RunTests BuildMainModule, {
         }
     }
 
-    if ($env:APPVEYOR)
-    {
-        $outXml = "$PSScriptRoot\xunit-results.xml"
-        Push-Location test
-        exec { & $runner test --no-build -c $configuration -f $target --logger "trx;LogFileName=$outXml" }
-        $wc = New-Object 'System.Net.WebClient'
-        $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", $outXml)
-        Pop-Location
-    }
-    else
-    {
-        Push-Location test
-        exec { & $runner test --no-build -c $configuration -f $target }
-        Pop-Location
-    }
+    Push-Location test
+    exec { & $runner test --no-build -c $configuration -f $target }
+    Pop-Location
 
     Remove-Item env:PSREADLINE_TESTRUN
 }
@@ -288,7 +276,7 @@ task LayoutModule BuildMainModule, BuildMamlHelp, {
 <#
 Synopsis: Zip up the binary for release.
 #>
-task ZipRelease CheckDotNetInstalled, LayoutModule, RunTests, {
+task ZipRelease CheckDotNetInstalled, LayoutModule, {
     Compress-Archive -Force -LiteralPath $targetDir -DestinationPath "bin/$Configuration/PSReadLine.zip"
 }
 

--- a/PSReadLine/PlatformWindows.cs
+++ b/PSReadLine/PlatformWindows.cs
@@ -160,10 +160,9 @@ static class PlatformWindows
         // and let PowerShell call Console.ReadLine or do whatever else it decides to do.
         if (IsHandleRedirected(stdin: false) || IsHandleRedirected(stdin: true))
         {
-            // If running in AppVeyor or local testing, this environment variable can be set
-            // to skip the exception.
-            if (Environment.GetEnvironmentVariable("PSREADLINE_TESTRUN") == null
-                && Environment.GetEnvironmentVariable("APPVEYOR") == null)
+            // Some CI environments redirect stdin/stdout, but that doesn't affect our test runs
+            // because the console is mocked, so we can skip the exception.
+            if (!PSConsoleReadLine.IsRunningCI())
             {
                 throw new NotSupportedException();
             }

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -333,7 +333,13 @@ namespace Microsoft.PowerShell
                     // by throwing an "InvalidOperationException".
                     // Therefore, if either stdin or stdout is redirected, PSReadLine doesn't really work,
                     // so throw and let PowerShell call Console.ReadLine or do whatever else it decides to do.
-                    throw new NotSupportedException();
+                    //
+                    // Some CI environments redirect stdin/stdout, but that doesn't affect our test runs
+                    // because the console is mocked, so we can skip the exception.
+                    if (!IsRunningCI())
+                    {
+                        throw new NotSupportedException();
+                    }
                 }
 
                 try
@@ -1050,6 +1056,11 @@ namespace Microsoft.PowerShell
                 newPrompt = "PS>";
 
             return newPrompt;
+        }
+
+        internal static bool IsRunningCI()
+        {
+            return Environment.GetEnvironmentVariable("PSREADLINE_TESTRUN") != null;
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
   POWERSHELL_TELEMETRY_OPTOUT: 1
   # Avoid expensive initialization of dotnet cli, see: http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  PSREADLINE_TESTRUN: 1
 
 cache:
   - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages -> PSReadLine.build.ps1'


### PR DESCRIPTION
When running CI on Mac/Linux, the NotSupportedException isn't needed
because the console is mocked.