### PR TITLE
Add Azure Devops CI for Linux/Mac

### DIFF
--- a/az-ci/azure-devops-psreadline.yml
+++ b/az-ci/azure-devops-psreadline.yml
@@ -1,0 +1,24 @@
+
+parameters:
+  name: ''  # defaults for any parameters that aren't specified
+  vmImage: ''
+
+jobs:
+- job: ${{ parameters.name }}
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+
+  variables:
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    POWERSHELL_TELEMETRY_OPTOUT: 1
+    # Avoid expensive initialization of dotnet cli, see: http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+
+  steps:
+  - script: dotnet restore PSReadLine/PSReadLine.csproj
+  - script: dotnet nuget locals all --list
+  - powershell: |
+      Install-Module InvokeBuild,platyPS -Scope CurrentUser -Force
+      Import-Module InvokeBuild,platyPS
+      Invoke-Build -Task ZipRelease -Configuration Release
+

--- a/az-ci/azure-pipelines.yml
+++ b/az-ci/azure-pipelines.yml
@@ -1,0 +1,16 @@
+
+jobs:
+- template: azure-devops-psreadline.yml
+  parameters:
+    name: Linux
+    vmImage: 'ubuntu-16.04'
+
+- template: azure-devops-psreadline.yml
+  parameters:
+    name: macOS
+    vmImage: 'macOS-10.13'
+
+#- template: azure-devops-psreadline.yml
+#  parameters:
+#    name: Windows
+#    vmImage: 'vs2017-win2016'

--- a/nuget.config
+++ b/nuget.config
@@ -4,5 +4,6 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="powershell-core" value="https://powershell.myget.org/F/powershell-core/api/v3/index.json" />
+    <add key="powershell-modules" value="https://www.powershellgallery.com/api/v2/" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Tests all pass in Azure Devops on Linux and Mac, but fail on Windows so
the Windows job is disabled until that can be fixed.