### PR TITLE
Remove dependency on the Utility module

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
+using System.Management.Automation.Host;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
@@ -625,8 +626,8 @@ namespace Microsoft.PowerShell
             {
                 try
                 {
-                    var results = ps.AddScript("$Host").Invoke();
-                    dynamic host = results.Count == 1 ? results[0] : null;
+                    var results = ps.AddScript("$Host").Invoke<PSHost>();
+                    PSHost host = results.Count == 1 ? results[0] : null;
                     if (host != null)
                     {
                         hostName = host.Name as string;

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -628,10 +628,7 @@ namespace Microsoft.PowerShell
                 {
                     var results = ps.AddScript("$Host").Invoke<PSHost>();
                     PSHost host = results.Count == 1 ? results[0] : null;
-                    if (host != null)
-                    {
-                        hostName = host.Name as string;
-                    }
+                    hostName = host?.Name;
                 }
                 catch
                 {

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -625,8 +625,7 @@ namespace Microsoft.PowerShell
             {
                 try
                 {
-                    ps.AddCommand("Get-Variable").AddParameter("Name", "host").AddParameter("ValueOnly");
-                    var results = ps.Invoke();
+                    var results = ps.AddScript("$Host").Invoke();
                     dynamic host = results.Count == 1 ? results[0] : null;
                     if (host != null)
                     {


### PR DESCRIPTION
#### Problem

The code `ps.AddCommand("Get-Variable").AddParameter("Name", "host").AddParameter("ValueOnly")` triggers the loading of the `Utility` module at powershell startup time, which causes the following two PS assemblies being loaded:
- Microsoft.PowerShell.Commands.Utility
- Microsoft.PowerShell.MarkdownRender

When loading the `Utility` module, powershell will go through all public types in `Utility.dll` to discover defined cmdlets. The type `PSMarkdownOptionInfo` is a property type used in a markdown cmdlet, and it's also used in the `OutputTypeAttribute` for two markdown cmdlets. So this type needs to be loaded during the cmdlet discovery. The type comes from `MarkdownRender.dll` and thus the `MarkdownRender.dll` gets implicitly loaded. 

#### Motivation

There are very likely other assemblies also being loaded implicitly during the cmdlet discovery of the `Utility` module. By changing the code to use `ps.AddScript("$Host")` we can avoid the loading of `Utility` module, and thus reduce the reference set during powershell startup.

#### Loaded PS assemblies before this change
```powershell
cmd > pwsh.exe -noprofile
ps > [System.AppDomain]::CurrentDomain.GetAssemblies() | ? FullName -Like "*Microsoft.PowerShell*" | % fullname
Microsoft.PowerShell.ConsoleHost, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
Microsoft.PowerShell.CoreCLR.Eventing, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
Microsoft.PowerShell.Security, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
Microsoft.PowerShell.PSReadLine2, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null
Microsoft.PowerShell.Commands.Utility, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
Microsoft.PowerShell.MarkdownRender, Version=6.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
```

#### Loaded PS assemblies after this change
```powershell
cmd > pwsh.exe -noprofile
ps > [System.AppDomain]::CurrentDomain.GetAssemblies() | ? FullName -Like "*Microsoft.PowerShell*" | % fullname
Microsoft.PowerShell.ConsoleHost, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
Microsoft.PowerShell.CoreCLR.Eventing, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
Microsoft.PowerShell.Security, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
Microsoft.PowerShell.PSReadLine2, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null
```