### PR TITLE
Remove Keys.ShouldInsert

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -245,6 +245,9 @@ namespace Microsoft.PowerShell
                 { Keys.PageDown,               MakeKeyHandler(ScrollDisplayDown,         "ScrollDisplayDown") },
                 { Keys.CtrlPageUp,             MakeKeyHandler(ScrollDisplayUpLine,       "ScrollDisplayUpLine") },
                 { Keys.CtrlPageDown,           MakeKeyHandler(ScrollDisplayDownLine,     "ScrollDisplayDownLine") },
+                { Keys.VolumeDown,             MakeKeyHandler(Ignore,                    "Ignore") },
+                { Keys.VolumeUp,               MakeKeyHandler(Ignore,                    "Ignore") },
+                { Keys.VolumeMute,             MakeKeyHandler(Ignore,                    "Ignore") },
             };
 
             // Some bindings are not available on certain platforms
@@ -334,6 +337,9 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlAltY,        MakeKeyHandler(YankNthArg,           "YankNthArg") },
                 { Keys.PageUp,          MakeKeyHandler(ScrollDisplayUp,      "ScrollDisplayUp") },
                 { Keys.PageDown,        MakeKeyHandler(ScrollDisplayDown,    "ScrollDisplayDown") },
+                { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
+                { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
+                { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },
             };
 
             // Some bindings are not available on certain platforms

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -86,7 +86,10 @@ namespace Microsoft.PowerShell
                 { Keys.ShiftF3,         MakeKeyHandler(CharacterSearchBackward,"CharacterSearchBackward") },
                 { Keys.CtrlAltQuestion, MakeKeyHandler(ShowKeyBindings,        "ShowKeyBindings") },
                 { Keys.CtrlR,           MakeKeyHandler(ViSearchHistoryBackward,"ViSearchHistoryBackward") },
-                { Keys.CtrlS,           MakeKeyHandler(SearchForward,          "SearchForward") }
+                { Keys.CtrlS,           MakeKeyHandler(SearchForward,          "SearchForward") },
+                { Keys.VolumeDown,      MakeKeyHandler(Ignore,                 "Ignore") },
+                { Keys.VolumeUp,        MakeKeyHandler(Ignore,                 "Ignore") },
+                { Keys.VolumeMute,      MakeKeyHandler(Ignore,                 "Ignore") },
             };
 
             // Some bindings are not available on certain platforms
@@ -205,7 +208,10 @@ namespace Microsoft.PowerShell
                 { Keys.Minus,           MakeKeyHandler(PreviousHistory,      "PreviousHistory") },
                 { Keys.Period,          MakeKeyHandler(RepeatLastCommand,    "RepeatLastCommand") },
                 { Keys.Semicolon,       MakeKeyHandler(RepeatLastCharSearch, "RepeatLastCharSearch") },
-                { Keys.Comma,           MakeKeyHandler(RepeatLastCharSearchBackwards, "RepeatLastCharSearchBackwards") }
+                { Keys.Comma,           MakeKeyHandler(RepeatLastCharSearchBackwards, "RepeatLastCharSearchBackwards") },
+                { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
+                { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
+                { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },
             };
 
             // Some bindings are not available on certain platforms

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -560,43 +560,6 @@ namespace Microsoft.PowerShell
             return unchecked(((h1 << 5) + h1) ^ h2);
         }
 
-        internal static bool ShouldInsert(this ConsoleKeyInfo key)
-        {
-            var keyChar = key.KeyChar;
-            if (keyChar == '\0') return false;
-            foreach (char c in " `~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?") {
-                // we always want to insert chars essential to the PowerShell experience
-                if (keyChar == c) { return true; }
-            }
-            if (key.Modifiers != 0)
-            {
-                // We want to ignore control sequences - but distinguishing a control sequence
-                // isn't as simple as it could be because we will get inconsistent modifiers
-                // depending on the OS or keyboard layout.
-                //
-                // Windows will give us the key state even if we didn't care, e.g. it's normal
-                // to see Alt+Control (AltGr) on a Spanish, French, or German keyboard for many normal
-                // characters. So we just ask the OS what mods to expect for a given key.
-                // On non-Windows - anything but Shift is assumed to be a control sequence.
-                ConsoleModifiers expectedMods = default(ConsoleModifiers);
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    var keyWithMods = WindowsKeyScan(key.KeyChar);
-                    if (keyWithMods.HasValue)
-                    {
-                        expectedMods = keyWithMods.Value.Modifiers;
-                    }
-                }
-                else
-                {
-                    expectedMods = key.Modifiers & ConsoleModifiers.Shift;
-                }
-                return key.Modifiers == expectedMods;
-            }
-
-            return true;
-        }
-
         internal static bool IsUnmodifiedChar(this ConsoleKeyInfo key, char c)
         {
             return key.KeyChar == c &&

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -363,6 +363,9 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo CtrlAltRBracket     = CtrlAlt(']');
         public static ConsoleKeyInfo CtrlAltQuestion     = CtrlAlt('?');
 
+        public static ConsoleKeyInfo VolumeUp   = Key(ConsoleKey.VolumeUp);
+        public static ConsoleKeyInfo VolumeDown = Key(ConsoleKey.VolumeDown);
+        public static ConsoleKeyInfo VolumeMute = Key(ConsoleKey.VolumeMute);
 
         [DllImport("user32.dll")]
         public static extern int VkKeyScan(short wAsciiVal);
@@ -469,6 +472,9 @@ namespace Microsoft.PowerShell
                 case ConsoleKey.RightArrow:
                 case ConsoleKey.Tab:
                 case ConsoleKey.UpArrow:
+                case ConsoleKey.VolumeUp:
+                case ConsoleKey.VolumeDown:
+                case ConsoleKey.VolumeMute:
                     return true;
             }
 

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -848,6 +848,11 @@ namespace Microsoft.PowerShell
             }
         }
 
+        [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        private static void Ignore(ConsoleKeyInfo? key = null, object arg = null)
+        {
+        }
+
         /// <summary>
         /// Abort current action, e.g. incremental history search.
         /// </summary>

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -600,7 +600,7 @@ namespace Microsoft.PowerShell
                     handler.Action(key, arg);
                 }
             }
-            else if (!ignoreIfNoAction && key.ShouldInsert())
+            else if (!ignoreIfNoAction)
             {
                 SelfInsert(key, arg);
             }

--- a/PSReadLine/Replace.vi.cs
+++ b/PSReadLine/Replace.vi.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell
                         _singleton.Render();
                     }
                 }
-                else if (nextKey.ShouldInsert())
+                else
                 {
                     if (_singleton._current >= _singleton._buffer.Length)
                     {


### PR DESCRIPTION
The method Keys.ShouldInsert was a misguided attempt to avoid inserting
keys where there is no binding but the key really doesn't make sense as
input.

Unfortunately it is just causing more pain and probably wasn't
addressing a serious problem, so I'm removing it.

Fix #798