### PR TITLE
Update docs for v2 release

### DIFF
--- a/docs/About/about_PSReadLine.md
+++ b/docs/About/about_PSReadLine.md
@@ -1,0 +1,1410 @@
+---
+ms.date:  12/08/2018
+schema:  2.0.0
+locale:  en-us
+keywords:  powershell,cmdlet
+title:  About PSReadLine
+---
+# PSReadLine
+
+## about_PSReadLine
+
+## SHORT DESCRIPTION
+
+PSReadLine provides an improved command line editing experience in the
+PowerShell console.
+
+## LONG DESCRIPTION
+
+PSReadLine provides a powerful command line editing experience for the
+PowerShell console. It provides:
+
+- Syntax coloring of the command line
+- A visual indication of syntax errors
+- A better multi-line experience (both editing and history)
+- Customizable key bindings
+- Cmd and Emacs modes
+- Many configuration options
+- Bash style completion (optional in Cmd mode, default in Emacs mode)
+- Emacs yank/kill ring
+- PowerShell token based "word" movement and kill
+
+The following functions are available in the class
+**[Microsoft.PowerShell.PSConsoleReadLine]**.
+
+## Basic editing functions
+
+### Abort
+
+Abort current action, e.g. incremental history search.
+
+- Emacs: `<Ctrl+g>`
+
+### AcceptAndGetNext
+
+Attempt to execute the current input. If it can be executed (like AcceptLine),
+then recall the next item from history the next time ReadLine is called.
+
+- Emacs: `<Ctrl+o>`
+
+### AcceptLine
+
+Attempt to execute the current input. If the current input is incomplete (for
+example there is a missing closing parenthesis, bracket, or quote, then the
+continuation prompt is displayed on the next line and PSReadLine waits for
+keys to edit the current input.
+
+- Cmd: `<Enter>`
+- Emacs: `<Enter>`
+- Vi insert mode: `<Enter>`
+
+### AddLine
+
+The continuation prompt is displayed on the next line and PSReadLine waits for
+keys to edit the current input. This is useful to enter multi-line input as a
+single command even when a single line is complete input by itself.
+
+- Cmd: `<Shift+Enter>`
+- Emacs: `<Shift+Enter>`
+- Vi insert mode: `<Shift+Enter>`
+- Vi command mode: `<Shift+Enter>`
+
+### BackwardDeleteChar
+
+Delete the character before the cursor.
+
+- Cmd: `<Backspace>`, `<Ctrl+h>`
+- Emacs: `<Backspace>`, `<Ctrl+Backspace>`, `<Ctrl+h>`
+- Vi insert mode: `<Backspace>`
+- Vi command mode: `<X>`, `<d,h>`
+
+### BackwardDeleteLine
+
+Like BackwardKillLine - deletes text from the point to the start of the line,
+but does not put the deleted text in the kill ring.
+
+- Cmd: `<Ctrl+Home>`
+- Vi insert mode: `<Ctrl+u>`, `<Ctrl+Home>`
+- Vi command mode: `<Ctrl+u>`, `<Ctrl+Home>`, `<d,0>`
+
+### BackwardDeleteWord
+
+Deletes the previous word.
+
+- Vi command mode: `<Ctrl+w>`, `<d,b>`
+
+### BackwardKillLine
+
+Clear the input from the start of the input to the cursor. The cleared text is
+placed in the kill ring.
+
+- Emacs: `<Ctrl+u>`, `<Ctrl+x,Backspace>`
+
+### BackwardKillWord
+
+Clear the input from the start of the current word to the cursor. If the
+cursor is between words, the input is cleared from the start of the previous
+word to the cursor. The cleared text is placed in the kill ring.
+
+- Cmd: `<Ctrl+Backspace>`
+- Emacs: `<Alt+Backspace>`, `<Escape,Backspace>`
+- Vi insert mode: `<Ctrl+Backspace>`
+- Vi command mode: `<Ctrl+Backspace>`
+
+### CancelLine
+
+Cancel the current input, leaving the input on the screen, but returns back to
+the host so the prompt is evaluated again.
+
+- Vi insert mode: `<Ctrl+c>`
+- Vi command mode: `<Ctrl+c>`
+
+### Copy
+
+Copy selected region to the system clipboard. If no region is selected, copy
+the whole line.
+
+- Cmd: `<Ctrl+C>`
+
+### CopyOrCancelLine
+
+If text is selected, copy to the clipboard, otherwise cancel the line.
+
+- Cmd: `<Ctrl+c>`
+- Emacs: `<Ctrl+c>`
+
+### Cut
+
+Delete selected region placing deleted text in the system clipboard.
+
+- Cmd: `<Ctrl+x>`
+
+### DeleteChar
+
+Delete the character under the cursor.
+
+- Cmd: `<Delete>`
+- Emacs: `<Delete>`
+- Vi insert mode: `<Delete>`
+- Vi command mode: `<Delete>`, `<x>`, `<d,l>`, `<d,Space>`
+
+### DeleteCharOrExit
+
+Delete the character under the cursor, or if the line is empty, exit the
+process.
+
+- Emacs: `<Ctrl+d>`
+
+### DeleteEndOfWord
+
+Delete to the end of the word.
+
+- Vi command mode: `<d,e>`
+
+### DeleteLine
+
+Deletes the current line, enabling undo.
+
+- Vi command mode: `<d,d>`
+
+### DeleteLineToFirstChar
+
+Deletes text from the cursor to the first non-blank character of the line.
+
+- Vi command mode: `<d,^>`
+
+### DeleteToEnd
+
+Delete to the end of the line.
+
+- Vi command mode: `<D>`, `<d,$>`
+
+### DeleteWord
+
+Delete the next word.
+
+- Vi command mode: `<d,w>`
+
+### ForwardDeleteLine
+
+Like ForwardKillLine - deletes text from the point to the end of the line, but
+does not put the deleted text in the kill ring.
+
+- Cmd: `<Ctrl+End>`
+- Vi insert mode: `<Ctrl+End>`
+- Vi command mode: `<Ctrl+End>`
+
+### InsertLineAbove
+
+A new empty line is created above the current line regardless of where the
+cursor is on the current line. The cursor moves to the beginning of the new
+line.
+
+- Cmd: `<Ctrl+Enter>`
+
+### InsertLineBelow
+
+A new empty line is created below the current line regardless of where the
+cursor is on the current line. The cursor moves to the beginning of the new
+line.
+
+- Cmd: `<Shift+Ctrl+Enter>`
+
+### InvertCase
+
+Invert the case of the current character and move to the next one.
+
+- Vi command mode: `<~>`
+
+### KillLine
+
+Clear the input from the cursor to the end of the input. The cleared text is
+placed in the kill ring.
+
+- Emacs: `<Ctrl+k>`
+
+### KillRegion
+
+Kill the text between the cursor and the mark.
+
+- Function is unbound.
+
+### KillWord
+
+Clear the input from the cursor to the end of the current word. If the cursor
+is between words, the input is cleared from the cursor to the end of the next
+word. The cleared text is placed in the kill ring.
+
+- Cmd: `<Ctrl+Delete>`
+- Emacs: `<Alt+d>`, `<Escape,d>`
+- Vi insert mode: `<Ctrl+Delete>`
+- Vi command mode: `<Ctrl+Delete>`
+
+### Paste
+
+Paste text from the system clipboard.
+
+- Cmd: `<Ctrl+v>`, `<Shift+Insert>`
+- Vi insert mode: `<Ctrl+v>`
+- Vi command mode: `<Ctrl+v>`
+
+### PasteAfter
+
+Paste the clipboard after the cursor, moving the cursor to the end of the
+pasted text.
+
+- Vi command mode: `<p>`
+
+### PasteBefore
+
+Paste the clipboard before the cursor, moving the cursor to the end of the
+pasted text.
+
+- Vi command mode: `<P>`
+
+### PrependAndAccept
+
+Prepend a '#' and accept the line.
+
+- Vi command mode: `<#>`
+
+### Redo
+
+Undo an undo.
+
+- Cmd: `<Ctrl+y>`
+- Vi insert mode: `<Ctrl+y>`
+- Vi command mode: `<Ctrl+y>`
+
+### RepeatLastCommand
+
+Repeat the last text modification.
+
+- Vi command mode: `<.>`
+
+### RevertLine
+
+Reverts all of the input to the current input.
+
+- Cmd: `<Escape>`
+- Emacs: `<Alt+r>`, `<Escape,r>`
+
+### ShellBackwardKillWord
+
+Clear the input from the start of the current word to the cursor. If the
+cursor is between words, the input is cleared from the start of the previous
+word to the cursor. The cleared text is placed in the kill ring.
+
+Function is unbound.
+
+### ShellKillWord
+
+Clear the input from the cursor to the end of the current word. If the cursor
+is between words, the input is cleared from the cursor to the end of the next
+word. The cleared text is placed in the kill ring.
+
+Function is unbound.
+
+### SwapCharacters
+
+Swap the current character and the one before it.
+
+- Emacs: `<Ctrl+t>`
+- Vi insert mode: `<Ctrl+t>`
+- Vi command mode: `<Ctrl+t>`
+
+### Undo
+
+Undo a previous edit.
+
+- Cmd: `<Ctrl+z>`
+- Emacs: `<Ctrl+_>`, `<Ctrl+x,Ctrl+u>`
+- Vi insert mode: `<Ctrl+z>`
+- Vi command mode: `<Ctrl+z>`, `<u>`
+
+### UndoAll
+
+Undo all previous edits for line.
+
+- Vi command mode: `<U>`
+
+### UnixWordRubout
+
+Clear the input from the start of the current word to the cursor. If the
+cursor is between words, the input is cleared from the start of the previous
+word to the cursor. The cleared text is placed in the kill ring.
+
+- Emacs: `<Ctrl+w>`
+
+### ValidateAndAcceptLine
+
+Attempt to execute the current input. If the current input is incomplete (for
+example there is a missing closing parenthesis, bracket, or quote, then the
+continuation prompt is displayed on the next line and PSReadLine waits for
+keys to edit the current input.
+
+- Emacs: `<Ctrl+m>`
+
+### ViAcceptLine
+
+Accept the line and switch to Insert mode.
+
+- Vi command mode: `<Enter>`
+
+### ViAcceptLineOrExit
+
+Like DeleteCharOrExit in Emacs mode, but accepts the line instead of deleting
+a character.
+
+- Vi insert mode: `<Ctrl+d>`
+- Vi command mode: `<Ctrl+d>`
+
+### ViAppendLine
+
+A new line is inserted below the current line.
+
+- Vi command mode: `<o>`
+
+### ViBackwardDeleteGlob
+
+Deletes the previous word, using only white space as the word delimiter.
+
+- Vi command mode: `<d,B>`
+
+### ViBackwardGlob
+
+Moves the cursor back to the beginning of the previous word, using only white
+space as delimiters.
+
+- Vi command mode: `<B>`
+
+### ViDeleteBrace
+
+Find the matching brace, paren, or square bracket and delete all contents
+within, including the brace.
+
+- Vi command mode: `<d,%>`
+
+### ViDeleteEndOfGlob
+
+Delete to the end of the word.
+
+- Vi command mode: `<d,E>`
+
+### ViDeleteGlob
+
+Delete the next glob (white space delimited word).
+
+- Vi command mode: `<d,W>`
+
+### ViDeleteToBeforeChar
+
+Deletes until given character.
+
+- Vi command mode: `<d,t>`
+
+### ViDeleteToBeforeCharBackward
+
+Deletes until given character.
+
+- Vi command mode: `<d,T>`
+
+### ViDeleteToChar
+
+Deletes until given character.
+
+- Vi command mode: `<d,f>`
+
+### ViDeleteToCharBackward
+
+Deletes backwards until given character.
+
+- Vi command mode: `<d,F>`
+
+### ViInsertAtBegining
+
+Switch to Insert mode and position the cursor at the beginning of the line.
+
+- Vi command mode: `<I>`
+
+### ViInsertAtEnd
+
+Switch to Insert mode and position the cursor at the end of the line.
+
+- Vi command mode: `<A>`
+
+### ViInsertLine
+
+A new line is inserted above the current line.
+
+- Vi command mode: `<O>`
+
+### ViInsertWithAppend
+
+Append from the current line position.
+
+- Vi command mode: `<a>`
+
+### ViInsertWithDelete
+
+Delete the current character and switch to Insert mode.
+
+- Vi command mode: `<s>`
+
+### ViJoinLines
+
+Joins the current line and the next line.
+
+- Vi command mode: `<J>`
+
+### ViReplaceLine
+
+Erase the entire command line.
+
+- Vi command mode: `<S>`, `<c,c>`
+
+### ViReplaceToBeforeChar
+
+Replaces until given character.
+
+- Vi command mode: `<c,t>`
+
+### ViReplaceToBeforeCharBackward
+
+Replaces until given character.
+
+- Vi command mode: `<c,T>`
+
+### ViReplaceToChar
+
+Deletes until given character.
+
+- Vi command mode: `<c,f>`
+
+### ViReplaceToCharBackward
+
+Replaces until given character.
+
+- Vi command mode: `<c,F>`
+
+### ViYankBeginningOfLine
+
+Yank from the beginning of the buffer to the cursor.
+
+- Vi command mode: `<y,0>`
+
+### ViYankEndOfGlob
+
+Yank from the cursor to the end of the WORD(s).
+
+- Vi command mode: `<y,E>`
+
+### ViYankEndOfWord
+
+Yank from the cursor to the end of the word(s).
+
+- Vi command mode: `<y,e>`
+
+### ViYankLeft
+
+Yank character(s) to the left of the cursor.
+
+- Vi command mode: `<y,h>`
+
+### ViYankLine
+
+Yank the entire buffer.
+
+- Vi command mode: `<y,y>`
+
+### ViYankNextGlob
+
+Yank from cursor to the start of the next WORD(s).
+
+- Vi command mode: `<y,W>`
+
+### ViYankNextWord
+
+Yank the word(s) after the cursor.
+
+- Vi command mode: `<y,w>`
+
+### ViYankPercent
+
+Yank to/from matching brace.
+
+- Vi command mode: `<y,%>`
+
+### ViYankPreviousGlob
+
+Yank from beginning of the WORD(s) to cursor.
+
+- Vi command mode: `<y,B>`
+
+### ViYankPreviousWord
+
+Yank the word(s) before the cursor.
+
+- Vi command mode: `<y,b>`
+
+### ViYankRight
+
+Yank character(s) under and to the right of the cursor.
+
+- Vi command mode: `<y,l>`, `<y,Space>`
+
+### ViYankToEndOfLine
+
+Yank from the cursor to the end of the buffer.
+
+- Vi command mode: `<y,$>`
+
+### ViYankToFirstChar
+
+Yank from the first non-whitespace character to the cursor.
+
+- Vi command mode: `<y,^>`
+
+### Yank
+
+Add the most recently killed text to the input.
+
+- Emacs: `<Ctrl+y>`
+
+### YankLastArg
+
+Yank the last argument from the previous history line. With an argument, the
+first time it is invoked, behaves just like YankNthArg. If invoked multiple
+times, instead it iterates through history and arg sets the direction
+(negative reverses the direction.)
+
+- Cmd: `<Alt+.>`
+- Emacs: `<Alt+.>`, `<Alt+_>`, `<Escape,.>`, `<Escape,_>`
+
+### YankNthArg
+
+Yank the first argument (after the command) from the previous history line.
+With an argument, yank the nth argument (starting from 0), if the argument is
+negative, start from the last argument.
+
+- Emacs: `<Ctrl+Alt+y>`, `<Escape,Ctrl+y>`
+
+### YankPop
+
+If the previous operation was Yank or YankPop, replace the previously yanked
+text with the next killed text from the kill ring.
+
+- Emacs: `<Alt+y>`, `<Escape,y>`
+
+## Cursor movement functions
+
+### BackwardChar
+
+Move the cursor one character to the left. This may move the cursor to the
+previous line of multi-line input.
+
+- Cmd: `<LeftArrow>`
+- Emacs: `<LeftArrow>`, `<Ctrl+b>`
+- Vi insert mode: `<LeftArrow>`
+- Vi command mode: `<LeftArrow>`, `<Backspace>`, `<h>`
+
+### BackwardWord
+
+Move the cursor back to the start of the current word, or if between words,
+the start of the previous word. Word boundaries are defined by a configurable
+set of characters.
+
+- Cmd: `<Ctrl+LeftArrow>`
+- Emacs: `<Alt+b>`, `<Escape,b>`
+- Vi insert mode: `<Ctrl+LeftArrow>`
+- Vi command mode: `<Ctrl+LeftArrow>`
+
+### BeginningOfLine
+
+If the input has multiple lines, move to the start of the current line, or if
+already at the start of the line, move to the start of the input. If the input
+has a single line, move to the start of the input.
+
+- Cmd: `<Home>`
+- Emacs: `<Home>`, `<Ctrl+a>`
+- Vi insert mode: `<Home>`
+- Vi command mode: `<Home>`
+
+### EndOfLine
+
+If the input has multiple lines, move to the end of the current line, or if
+already at the end of the line, move to the end of the input. If the input has
+a single line, move to the end of the input.
+
+- Cmd: `<End>`
+- Emacs: `<End>`, `<Ctrl+e>`
+- Vi insert mode: `<End>`
+
+### ForwardChar
+
+Move the cursor one character to the right. This may move the cursor to the
+next line of multi-line input.
+
+- Cmd: `<RightArrow>`
+- Emacs: `<RightArrow>`, `<Ctrl+f>`
+- Vi insert mode: `<RightArrow>`
+- Vi command mode: `<RightArrow>`, `<Space>`, `<l>`
+
+### ForwardWord
+
+Move the cursor forward to the end of the current word, or if between words,
+to the end of the next word. Word boundaries are defined by a configurable set
+of characters.
+
+- Emacs: `<Alt+f>`, `<Escape,f>`
+
+### GotoBrace
+
+Go to the matching brace, paren, or square bracket.
+
+- Cmd: `<Ctrl+]>`
+- Vi insert mode: `<Ctrl+]>`
+- Vi command mode: `<Ctrl+]>`
+
+### GotoColumn
+
+Move to the column indicated by arg.
+
+- Vi command mode: `<|>`
+
+### GotoFirstNonBlankOfLine
+
+Move the cursor to the first non-blank character in the line.
+
+- Vi command mode: `<^>`
+
+### MoveToEndOfLine
+
+Move the cursor to the end of the input.
+
+- Vi command mode: `<End>`, `<$>`
+
+### NextLine
+
+Move the cursor to the next line.
+
+- Function is unbound.
+
+### NextWord
+
+Move the cursor forward to the start of the next word. Word boundaries are
+defined by a configurable set of characters.
+
+- Cmd: `<Ctrl+RightArrow>`
+- Vi insert mode: `<Ctrl+RightArrow>`
+- Vi command mode: `<Ctrl+RightArrow>`
+
+### NextWordEnd
+
+Move the cursor forward to the end of the current word, or if between words,
+to the end of the next word. Word boundaries are defined by a configurable set
+of characters.
+
+- Vi command mode: `<e>`
+
+### PreviousLine
+
+Move the cursor to the previous line.
+
+- Function is unbound.
+
+### ShellBackwardWord
+
+Move the cursor back to the start of the current word, or if between words,
+the start of the previous word. Word boundaries are defined by PowerShell
+tokens.
+
+- Function is unbound.
+
+### ShellForwardWord
+
+Move the cursor forward to the start of the next word. Word boundaries are
+defined by PowerShell tokens.
+
+- Function is unbound.
+
+### ShellNextWord
+
+Move the cursor forward to the end of the current word, or if between words,
+to the end of the next word. Word boundaries are defined by PowerShell tokens.
+
+- Function is unbound.
+
+### ViBackwardWord
+
+Move the cursor back to the start of the current word, or if between words,
+the start of the previous word. Word boundaries are defined by a configurable
+set of characters.
+
+- Vi command mode: `<b>`
+
+### ViEndOfGlob
+
+Moves the cursor to the end of the word, using only white space as delimiters.
+
+- Vi command mode: `<E>`
+
+### ViEndOfPreviousGlob
+
+Moves to the end of the previous word, using only white space as a word
+delimiter.
+
+- Function is unbound.
+
+### ViGotoBrace
+
+Similar to GotoBrace, but is character based instead of token based.
+
+- Vi command mode: `<%>`
+
+### ViNextGlob
+
+Moves to the next word, using only white space as a word delimiter.
+
+- Vi command mode: `<W>`
+
+### ViNextWord
+
+Move the cursor forward to the start of the next word. Word boundaries are
+defined by a configurable set of characters.
+
+- Vi command mode: `<w>`
+
+## History functions
+
+### BeginningOfHistory
+
+Move to the first item in the history.
+
+- Emacs: `<Alt+`<>`
+
+### ClearHistory
+
+Clears history in PSReadLine. This does not affect PowerShell history.
+
+- Cmd: `<Alt+F7>`
+
+### EndOfHistory
+
+Move to the last item (the current input) in the history.
+
+- Emacs: `<Alt+>>`
+
+### ForwardSearchHistory
+
+Perform an incremental forward search through history.
+
+- Cmd: `<Ctrl+s>`
+- Emacs: `<Ctrl+s>`
+
+### HistorySearchBackward
+
+Replace the current input with the 'previous' item from PSReadLine history
+that matches the characters between the start and the input and the cursor.
+
+- Cmd: `<F8>`
+
+### HistorySearchForward
+
+Replace the current input with the 'next' item from PSReadLine history that
+matches the characters between the start and the input and the cursor.
+
+- Cmd: `<Shift+F8>`
+
+### NextHistory
+
+Replace the current input with the 'next' item from PSReadLine history.
+
+- Cmd: `<DownArrow>`
+- Emacs: `<DownArrow>`, `<Ctrl+n>`
+- Vi insert mode: `<DownArrow>`
+- Vi command mode: `<DownArrow>`, `<j>`, `<+>`
+
+### PreviousHistory
+
+Replace the current input with the 'previous' item from PSReadLine history.
+
+- Cmd: `<UpArrow>`
+- Emacs: `<UpArrow>`, `<Ctrl+p>`
+- Vi insert mode: `<UpArrow>`
+- Vi command mode: `<UpArrow>`, `<k>`, `<->`
+
+### ReverseSearchHistory
+
+Perform an incremental backward search through history.
+
+- Cmd: `<Ctrl+r>`
+- Emacs: `<Ctrl+r>`
+
+### ViSearchHistoryBackward
+
+Prompts for a search string and initiates search upon AcceptLine.
+
+- Vi insert mode: `<Ctrl+r>`
+- Vi command mode: `</>`, `<Ctrl+r>`
+
+## Completion functions
+
+### Complete
+
+Attempt to perform completion on the text surrounding the cursor. If there are
+multiple possible completions, the longest unambiguous prefix is used for
+completion. If trying to complete the longest unambiguous completion, a list
+of possible completions is displayed.
+
+- Emacs: `<Tab>`
+
+### MenuComplete
+
+Attempt to perform completion on the text surrounding the cursor. If there are
+multiple possible completions, the longest unambiguous prefix is used for
+completion. If trying to complete the longest unambiguous completion, a list
+of possible completions is displayed.
+
+- Cmd: `<Ctrl+Space>`
+- Emacs: `<Ctrl+Space>`
+
+### PossibleCompletions
+
+Display the list of possible completions.
+
+- Emacs: `<Alt+=>`
+- Vi insert mode: `<Ctrl+Space>`
+- Vi command mode: `<Ctrl+Space>`
+
+### TabCompleteNext
+
+Attempt to complete the text surrounding the cursor with the next available
+completion.
+
+- Cmd: `<Tab>`
+- Vi command mode: `<Tab>`
+
+### TabCompletePrevious
+
+Attempt to complete the text surrounding the cursor with the previous
+available completion.
+
+- Cmd: `<Shift+Tab>`
+- Vi command mode: `<Shift+Tab>`
+
+### ViTabCompleteNext
+
+Ends the current edit group, if needed, and invokes TabCompleteNext.
+
+- Vi insert mode: `<Tab>`
+
+### ViTabCompletePrevious
+
+Ends the current edit group, if needed, and invokes TabCompletePrevious.
+
+- Vi insert mode: `<Shift+Tab>`
+
+## Miscellaneous functions
+
+### CaptureScreen
+
+Start interactive screen capture - up/down arrows select lines, enter copies
+selected text to clipboard as text and html.
+
+- Function is unbound.
+
+### ClearScreen
+
+Clear the screen and draw the current line at the top of the screen.
+
+- Cmd: `<Ctrl+l>`
+- Emacs: `<Ctrl+l>`
+- Vi insert mode: `<Ctrl+l>`
+- Vi command mode: `<Ctrl+l>`
+
+### DigitArgument
+
+Start a new digit argument to pass to other functions.
+
+- Cmd: `<Alt+0>`, `<Alt+1>`, `<Alt+2>`, `<Alt+3>`, `<Alt+4>`, `<Alt+5>`,
+  `<Alt+6>`, `<Alt+7>`, `<Alt+8>`, `<Alt+9>`, `<Alt+->`
+- Emacs: `<Alt+0>`, `<Alt+1>`, `<Alt+2>`, `<Alt+3>`, `<Alt+4>`, `<Alt+5>`,
+  `<Alt+6>`, `<Alt+7>`, `<Alt+8>`, `<Alt+9>`, `<Alt+->`
+- Vi command mode: `<0>`, `<1>`, `<2>`, `<3>`, `<4>`, `<5>`, `<6>`, `<7>`,
+  `<8>`, `<9>`
+
+### InvokePrompt
+
+Erases the current prompt and calls the prompt function to redisplay the
+prompt. Useful for custom key handlers that change state, e.g. change the
+current directory.
+
+- Function is unbound.
+
+### ScrollDisplayDown
+
+Scroll the display down one screen.
+
+- Cmd: `<PageDown>`
+- Emacs: `<PageDown>`
+
+### ScrollDisplayDownLine
+
+Scroll the display down one line.
+
+- Cmd: `<Ctrl+PageDown>`
+- Emacs: `<Ctrl+PageDown>`
+
+### ScrollDisplayToCursor
+
+Scroll the display to the cursor.
+
+- Emacs: `<Ctrl+End>`
+
+### ScrollDisplayTop
+
+Scroll the display to the top.
+
+- Emacs: `<Ctrl+Home>`
+
+### ScrollDisplayUp
+
+Scroll the display up one screen.
+
+- Cmd: `<PageUp>`
+- Emacs: `<PageUp>`
+
+### ScrollDisplayUpLine
+
+Scroll the display up one line.
+
+- Cmd: `<Ctrl+PageUp>`
+- Emacs: `<Ctrl+PageUp>`
+
+### SelfInsert
+
+Insert the key.
+
+- Function is unbound.
+
+### ShowKeyBindings
+
+Show all bound keys.
+
+- Cmd: `<Ctrl+Alt+?>`
+- Emacs: `<Ctrl+Alt+?>`
+- Vi insert mode: `<Ctrl+Alt+?>`
+
+### ViCommandMode
+
+Switch the current operating mode from Vi-Insert to Vi-Command.
+
+- Vi insert mode: `<Escape>`
+
+### ViDigitArgumentInChord
+
+Start a new digit argument to pass to other functions while in one of vi's
+chords.
+
+- Function is unbound.
+
+### ViEditVisually
+
+Edit the command line in a text editor specified by $env:EDITOR or
+$env:VISUAL.
+
+- Emacs: `<Ctrl+x,Ctrl+e>`
+- Vi command mode: `<v>`
+
+### ViExit
+
+Exits the shell.
+
+- Function is unbound.
+
+### ViInsertMode
+
+Switch to Insert mode.
+
+- Vi command mode: `<i>`
+
+### WhatIsKey
+
+Read a key and tell me what the key is bound to.
+
+- Cmd: `<Alt+?>`
+- Emacs: `<Alt+?>`
+
+## Selection functions
+
+### ExchangePointAndMark
+
+The cursor is placed at the location of the mark and the mark is moved to the
+location of the cursor.
+
+- Emacs: `<Ctrl+x,Ctrl+x>`
+
+### SelectAll
+
+Select the entire line.
+
+- Cmd: `<Ctrl+a>`
+
+### SelectBackwardChar
+
+Adjust the current selection to include the previous character.
+
+- Cmd: `<Shift+LeftArrow>`
+- Emacs: `<Shift+LeftArrow>`
+
+### SelectBackwardsLine
+
+Adjust the current selection to include from the cursor to the start of the
+line.
+
+- Cmd: `<Shift+Home>`
+- Emacs: `<Shift+Home>`
+
+### SelectBackwardWord
+
+Adjust the current selection to include the previous word.
+
+- Cmd: `<Shift+Ctrl+LeftArrow>`
+- Emacs: `<Alt+B>`
+
+### SelectForwardChar
+
+Adjust the current selection to include the next character.
+
+- Cmd: `<Shift+RightArrow>`
+- Emacs: `<Shift+RightArrow>`
+
+### SelectForwardWord
+
+Adjust the current selection to include the next word using ForwardWord.
+
+- Emacs: `<Alt+F>`
+
+### SelectLine
+
+Adjust the current selection to include from the cursor to the end of the line.
+
+- Cmd: `<Shift+End>`
+- Emacs: `<Shift+End>`
+
+### SelectNextWord
+
+Adjust the current selection to include the next word.
+
+- Cmd: `<Shift+Ctrl+RightArrow>`
+
+### SelectShellBackwardWord
+
+Adjust the current selection to include the previous word using
+ShellBackwardWord.
+
+- Function is unbound.
+
+### SelectShellForwardWord
+
+Adjust the current selection to include the next word using ShellForwardWord.
+
+- Function is unbound.
+
+### SelectShellNextWord
+
+Adjust the current selection to include the next word using ShellNextWord.
+
+- Function is unbound.
+
+### SetMark
+
+Mark the current location of the cursor for use in a subsequent editing
+command.
+
+- Emacs: `<Ctrl+`>`
+
+## Search functions
+
+### CharacterSearch
+
+Read a character and search forward for the next occurrence of that character.
+If an argument is specified, search forward (or backward if negative) for the
+nth occurence.
+
+- Cmd: `<F3>`
+- Emacs: `<Ctrl+]>`
+- Vi insert mode: `<F3>`
+- Vi command mode: `<F3>`
+
+### CharacterSearchBackward
+
+Read a character and search backward for the next occurrence of that character. If an
+argument is specified, search backward (or forward if negative) for the nth
+occurence.
+
+- Cmd: `<Shift+F3>`
+- Emacs: `<Ctrl+Alt+]>`
+- Vi insert mode: `<Shift+F3>`
+- Vi command mode: `<Shift+F3>`
+
+### RepeatLastCharSearch
+
+Repeat the last recorded character search.
+
+- Vi command mode: `<;>`
+
+### RepeatLastCharSearchBackwards
+
+Repeat the last recorded character search, but in the opposite direction.
+
+- Vi command mode: `<,>`
+
+### RepeatSearch
+
+Repeat the last search in the same direction as before.
+
+- Vi command mode: `<n>`
+
+### RepeatSearchBackward
+
+Repeat the last search in the same direction as before.
+
+- Vi command mode: `<N>`
+
+### SearchChar
+
+Read the next character and then find it, going forward, and then back off a
+character. This is for 't' functionality.
+
+- Vi command mode: `<f>`
+
+### SearchCharBackward
+
+Read the next character and then find it, going backward, and then back off a
+character. This is for 'T' functionality.
+
+- Vi command mode: `<F>`
+
+### SearchCharBackwardWithBackoff
+
+Read the next character and then find it, going backward, and then back off a
+character. This is for 'T' functionality.
+
+- Vi command mode: `<T>`
+
+### SearchCharWithBackoff
+
+Read the next character and then find it, going forward, and then back off a
+character. This is for 't' functionality.
+
+- Vi command mode: `<t>`
+
+### SearchForward
+
+Prompts for a search string and initiates search upon AcceptLine.
+
+- Vi insert mode: `<Ctrl+s>`
+- Vi command mode: `<?>`, `<Ctrl+s>`
+
+## Custom Key Bindings
+
+PSReadLine supports custom key bindings using the cmdlet
+`Set-PSReadLineKeyHandler`. Most custom key bindings call one of the above
+functions, for example
+
+```powershell
+Set-PSReadLineKeyHandler -Key UpArrow -Function HistorySearchBackward
+```
+
+You can bind a ScriptBlock to a key. The ScriptBlock can do pretty much
+anything you want. Some useful examples include
+
+- edit the command line
+- opening a new window (e.g. help)
+- change directories without changing the command line
+
+The ScriptBlock receives two arguments:
+
+- `$key` - A **[ConsoleKeyInfo]** object that is the key that triggered the
+  custom binding. If you bind the same ScriptBlock to multiple keys and need
+  to perform different actions depending on the key, you can check $key. Many
+  custom bindings ignore this argument.
+
+- `$arg` - An arbitrary argument. Most often, this would be an integer
+  argument that the user passes from the key bindings DigitArgument. If your
+  binding doesn't accept arguments, it's reasonable to ignore this argument.
+
+Let's take a look at an example that adds a command line to history without
+executing it. This is useful when you realize you forgot to do something, but
+don't want to re-enter the command line you've already entered.
+
+```powershell
+$parameters = @{
+    Key = 'Alt+w'
+    BriefDescription = 'SaveInHistory'
+    LongDescription = 'Save current line in history but do not execute'
+    ScriptBlock = {
+      param($key, $arg)   # The arguments are ignored in this example
+
+      # GetBufferState gives us the command line (with the cursor position)
+      $line = $null
+      $cursor = $null
+      [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line,
+        [ref]$cursor)
+
+      # AddToHistory saves the line in history, but does not execute it.
+      [Microsoft.PowerShell.PSConsoleReadLine]::AddToHistory($line)
+
+      # RevertLine is like pressing Escape.
+      [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+  }
+}
+Set-PSReadLineKeyHandler @parameters
+```
+
+You can see many more examples in the file `SamplePSReadLineProfile.ps1` which
+is installed in the PSReadLine module folder.
+
+Most key bindings use some helper functions for editing the command line.
+Those APIs are documented in the next section.
+
+## Custom Key Binding Support APIs
+
+The following functions are public in Microsoft.PowerShell.PSConsoleReadLine,
+but cannot be directly bound to a key. Most are useful in custom key bindings.
+
+```csharp
+void AddToHistory(string command)
+```
+
+Add a command line to history without executing it.
+
+```csharp
+void ClearKillRing()
+```
+
+Clear the kill ring.  This is mostly used for testing.
+
+```csharp
+void Delete(int start, int length)
+```
+
+Delete length characters from start.  This operation supports undo/redo.
+
+```csharp
+void Ding()
+```
+
+Perform the Ding action based on the users preference.
+
+```csharp
+void GetBufferState([ref] string input, [ref] int cursor)
+void GetBufferState([ref] Ast ast, [ref] Token[] tokens,
+  [ref] ParseError[] parseErrors, [ref] int cursor)
+```
+
+These two functions retrieve useful information about the current state of
+the input buffer.  The first is more commonly used for simple cases.  The
+second is used if your binding is doing something more advanced with the Ast.
+
+```csharp
+IEnumerable[Microsoft.PowerShell.KeyHandler]
+  GetKeyHandlers(bool includeBound, bool includeUnbound)
+
+```
+
+This function is used by Get-PSReadLineKeyHandler and probably isn't useful in
+a custom key binding.
+
+```csharp
+Microsoft.PowerShell.PSConsoleReadLineOptions GetOptions()
+```
+
+This function is used by Get-PSReadLineOption and probably isn't too useful in
+a custom key binding.
+
+```csharp
+void GetSelectionState([ref] int start, [ref] int length)
+```
+
+If there is no selection on the command line, -1 will be returned in both
+start and length. If there is a selection on the command line, the start and
+length of the selection are returned.
+
+```csharp
+void Insert(char c)
+void Insert(string s)
+```
+
+Insert a character or string at the cursor.  This operation supports undo/redo.
+
+```csharp
+string ReadLine(runspace remoteRunspace,
+  System.Management.Automation.EngineIntrinsics engineIntrinsics)
+```
+
+This is the main entry point to PSReadLine. It does not support recursion, so
+is not useful in a custom key binding.
+
+```csharp
+void RemoveKeyHandler(string[] key)
+```
+
+This function is used by Remove-PSReadLineKeyHandler and probably isn't too
+useful in a custom key binding.
+
+```csharp
+void Replace(int start, int length, string replacement)
+```
+
+Replace some of the input. This operation supports undo/redo. This is
+preferred over Delete followed by Insert because it is treated as a single
+action for undo.
+
+```csharp
+void SetCursorPosition(int cursor)
+```
+
+Move the cursor to the given offset. Cursor movement is not tracked for undo.
+
+```csharp
+void SetOptions(Microsoft.PowerShell.SetPSReadLineOption options)
+```
+
+This function is a helper method used by the cmdlet Set-PSReadLineOption, but
+might be useful to a custom key binding that wants to temporarily change a
+setting.
+
+```csharp
+bool TryGetArgAsInt(System.Object arg, [ref] int numericArg,
+  int defaultNumericArg)
+```
+
+This helper method is used for custom bindings that honor DigitArgument. A
+typical call looks like
+
+```powershell
+[int]$numericArg = 0
+[Microsoft.PowerShell.PSConsoleReadLine]::TryGetArgAsInt($arg,
+  [ref]$numericArg, 1)
+```
+
+## NOTE
+
+### POWERSHELL COMPATIBILITY
+
+PSReadLine requires PowerShell 3.0, or newer, and the console host. It does
+not work in PowerShell ISE. It does work in the console of Visual Studio Code.
+
+### FEEDBACK & CONTRIBUTING TO PSReadLine
+
+[PSReadLine on GitHub](https://github.com/lzybkr/PSReadLine)
+
+Feel free to submit a pull request or submit feedback on the github page.
+
+## SEE ALSO
+
+PSReadLine is heavily influenced by the GNU
+[readline](https://tiswww.case.edu/php/chet/readline/rltop.html) library.

--- a/docs/Get-PSReadLineKeyHandler.md
+++ b/docs/Get-PSReadLineKeyHandler.md
@@ -1,82 +1,169 @@
 ---
+external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml
+keywords: powershell,cmdlet
+locale: en-us
+Module Name: PSReadLine
+ms.date:  12/07/2018
+online version: http://go.microsoft.com/fwlink/?LinkID=821449
 schema: 2.0.0
-external help file: Microsoft.PowerShell.PSReadLine2.dll-help.xml
+title: Get-PSReadLineKeyHandler
 ---
 
 # Get-PSReadLineKeyHandler
 
 ## SYNOPSIS
-
 Gets the key bindings for the PSReadLine module.
 
 ## SYNTAX
 
 ```
-Get-PSReadLineKeyHandler [-Bound] [-Unbound]
+Get-PSReadLineKeyHandler [-Bound] [-Unbound] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Gets the key bindings for the PSReadLine module.
-
-If neither -Bound nor -Unbound is specified, returns all bound keys functions.
-
-If -Bound is specified and -Unbound is not specified, only bound keys are returned.
-
-If -Unbound is specified and -Bound is not specified, only unbound keys are returned.
-
-If both -Bound and -Unbound are specified, returns all bound keys and unbound functions.
+The **Get-PSReadLineKeyHandler** cmdlet returns the currently bound key bindings.
 
 ## EXAMPLES
+
+### Example 1: Get all key mappings
+
+This command returns all key mappings, bound and unbound.
+
+```powershell
+Get-PSReadLineKeyHandler -Bound -Unbound
+```
+
+```Output
+Key                   Function                Description
+---                   --------                -----------
+Enter                 AcceptLine              Accept the input or move to the next line if input is missing a closing token.
+Shift+Enter           AddLine                 Move the cursor to the next line without attempting to execute the input
+Escape                RevertLine              Equivalent to undo all edits (clears the line except lines imported from history)
+LeftArrow             BackwardChar            Move the cursor back one character
+RightArrow            ForwardChar             Move the cursor forward one character
+Ctrl+LeftArrow        BackwardWord            Move the cursor to the beginning of the current or previous word
+Ctrl+RightArrow       NextWord                Move the cursor forward to the start of the next word
+Shift+LeftArrow       SelectBackwardChar      Adjust the current selection to include the previous character
+Shift+RightArrow      SelectForwardChar       Adjust the current selection to include the next character
+Ctrl+Shift+LeftArrow  SelectBackwardWord      Adjust the current selection to include the previous word
+Ctrl+Shift+RightArrow SelectNextWord          Adjust the current selection to include the next word
+UpArrow               PreviousHistory         Replace the input with the previous item in the history
+DownArrow             NextHistory             Replace the input with the next item in the history
+Home                  BeginningOfLine         Move the cursor to the beginning of the line
+End                   EndOfLine               Move the cursor to the end of the line
+Shift+Home            SelectBackwardsLine     Adjust the current selection to include from the cursor to the end of the line
+Shift+End             SelectLine              Adjust the current selection to include from the cursor to the start of the line
+Delete                DeleteChar              Delete the character under the cursor
+Backspace             BackwardDeleteChar      Delete the charcter before the cursor
+Ctrl+Spacebar         MenuComplete            Complete the input if there is a single completion, otherwise complete the input by selecting from a menu o...
+Tab                   TabCompleteNext         Complete the input using the next completion
+Shift+Tab             TabCompletePrevious     Complete the input using the previous completion
+Ctrl+a                SelectAll               Select the entire line. Moves the cursor to the end of the line
+Ctrl+c                CopyOrCancelLine        Either copy selected text to the clipboard, or if no text is selected, cancel editing the line with Cancel...
+Ctrl+C                Copy                    Copy selected region to the system clipboard.  If no region is selected, copy the whole line
+Ctrl+l                ClearScreen             Clear the screen and redraw the current line at the top of the screen
+Ctrl+r                ReverseSearchHistory    Search history backwards interactively
+...
+```
+
+### Example 2: Get bound keys
+
+This command returns only bound keys and key combinations.
+
+```powershell
+Get-PSReadLineKeyHandler
+```
+
+```Output
+Key                   Function                Description
+---                   --------                -----------
+Enter                 AcceptLine              Accept the input or move to the next line if input is missing a closing token.
+Shift+Enter           AddLine                 Move the cursor to the next line without attempting to execute the input
+Escape                RevertLine              Equivalent to undo all edits (clears the line except lines imported from history)
+LeftArrow             BackwardChar            Move the cursor back one character
+RightArrow            ForwardChar             Move the cursor forward one character
+Ctrl+LeftArrow        BackwardWord            Move the cursor to the beginning of the current or previous word
+Ctrl+RightArrow       NextWord                Move the cursor forward to the start of the next word
+Shift+LeftArrow       SelectBackwardChar      Adjust the current selection to include the previous character
+Shift+RightArrow      SelectForwardChar       Adjust the current selection to include the next character
+Ctrl+Shift+LeftArrow  SelectBackwardWord      Adjust the current selection to include the previous word
+Ctrl+Shift+RightArrow SelectNextWord          Adjust the current selection to include the next word
+UpArrow               PreviousHistory         Replace the input with the previous item in the history
+DownArrow             NextHistory             Replace the input with the next item in the history
+Home                  BeginningOfLine         Move the cursor to the beginning of the line
+End                   EndOfLine               Move the cursor to the end of the line
+Shift+Home            SelectBackwardsLine     Adjust the current selection to include from the cursor to the end of the line
+Shift+End             SelectLine              Adjust the current selection to include from the cursor to the start of the line
+Delete                DeleteChar              Delete the character under the cursor
+Backspace             BackwardDeleteChar      Delete the charcter before the cursor
+Ctrl+Spacebar         MenuComplete            Complete the input if there is a single completion, otherwise complete the input by selecting from a menu o...
+Tab                   TabCompleteNext         Complete the input using the next completion
+...
+```
 
 ## PARAMETERS
 
 ### -Bound
 
-Include functions that are bound.
+Indicates that this cmdlet returns functions that are bound.
 
 ```yaml
-Type: switch
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
 Default value: True
-Accept pipeline input: false
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Unbound
 
-Include functions that are unbound.
+Indicates that this cmdlet returns functions that are unbound.
 
 ```yaml
-Type: switch
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
 Default value: True
-Accept pipeline input: false
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information,
+see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
 
-You cannot pipe objects to Get-PSReadLineKeyHandler
+You cannot pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.KeyHandler
 
-Returns one entry for each key binding (or chord) for bound functions and/or one entry for each unbound function
+This cmdlet returns one entry for each key binding, or chord, for bound functions and one entry for
+each unbound function.
 
 ## NOTES
 
 ## RELATED LINKS
 
-[about_PSReadLine]()
+[Remove-PSReadLineKeyHandler](Remove-PSReadLineKeyHandler.md)
+
+[Get-PSReadLineOption](Get-PSReadLineOption.md)
+
+[Set-PSReadLineOption](Set-PSReadLineOption.md)
+
+[Set-PSReadLineKeyHandler](Set-PSReadLineKeyHandler.md)

--- a/docs/Get-PSReadLineOption.md
+++ b/docs/Get-PSReadLineOption.md
@@ -1,47 +1,109 @@
 ---
+external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml
+keywords: powershell,cmdlet
+locale: en-us
+Module Name: PSReadLine
+ms.date: 12/07/2018
+online version: http://go.microsoft.com/fwlink/?LinkId=821450
 schema: 2.0.0
-external help file: Microsoft.PowerShell.PSReadLine2.dll-help.xml
+title: Get-PSReadLineOption
 ---
 
 # Get-PSReadLineOption
 
 ## SYNOPSIS
-
 Returns the values for the options that can be configured.
 
 ## SYNTAX
 
 ```
-Get-PSReadLineOption
+Get-PSReadLineOption [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Get-PSReadLineOption returns the current state of the settings that can be configured by Set-PSReadLineOption.
-
-The object returned can be used to change PSReadLine options.
-
-This provides a slightly simpler way of setting syntax coloring options for multiple kinds of tokens.
+The `Get-PSReadLineOption` cmdlet returns the current state of the settings that can be configured
+by using the `Set-PSReadLineOption` cmdlet. You can use the returned object to change
+**PSReadLine** options. This provides a slightly simpler way to set syntax coloring options for
+multiple kinds of tokens.
 
 ## EXAMPLES
 
+### Example 1: Get options and their values
+
+```powershell
+Get-PSReadLineOption
+```
+
+```Output
+EditMode                               : Windows
+AddToHistoryHandler                    :
+HistoryNoDuplicates                    : True
+HistorySavePath                        : C:\Users\testuser\AppData\Roaming\Microsoft\Windows\PowerShell\PSReadLine\Consol
+                                         eHost_history.txt
+HistorySaveStyle                       : SaveIncrementally
+HistorySearchCaseSensitive             : False
+HistorySearchCursorMovesToEnd          : False
+MaximumHistoryCount                    : 4096
+ContinuationPrompt                     : >>
+ExtraPromptLineCount                   : 0
+PromptText                             :
+BellStyle                              : Audible
+DingDuration                           : 50
+DingTone                               : 1221
+CommandsToValidateScriptBlockArguments : {ForEach-Object, %, Invoke-Command, icm...}
+CommandValidationHandler               :
+CompletionQueryItems                   : 100
+MaximumKillRingCount                   : 10
+ShowToolTips                           : True
+ViModeIndicator                        : None
+WordDelimiters                         : ;:,.[]{}()/\|^&*-=+'"–—―
+CommandColor                           : "`e[93m"
+CommentColor                           : "`e[32m"
+ContinuationPromptColor                : "`e[37m"
+DefaultTokenColor                      : "`e[37m"
+EmphasisColor                          : "`e[96m"
+ErrorColor                             : "`e[91m"
+KeywordColor                           : "`e[92m"
+MemberColor                            : "`e[97m"
+NumberColor                            : "`e[97m"
+OperatorColor                          : "`e[90m"
+ParameterColor                         : "`e[90m"
+SelectionColor                         : "`e[30;47m"
+StringColor                            : "`e[36m"
+TypeColor                              : "`e[37m"
+VariableColor                          : "`e[92m"
+```
+
+This command returns the list of available PSReadLine options and their current values.
+
 ## PARAMETERS
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
 
-You cannot pipe objects to Get-PSReadLineOption
+You cannot pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### Microsoft.PowerShell.PSConsoleReadLineOptions
 
-An instance of the current options.
-Changing the values will update the settings in PSReadLine directly without invoking Set-PSReadLineOption.
-
 ## NOTES
 
 ## RELATED LINKS
 
-[about_PSReadLine]()
+[Remove-PSReadLineKeyHandler](Remove-PSReadLineKeyHandler.md)
+
+[Get-PSReadLineKeyHandler](Get-PSReadLineKeyHandler.md)
+
+[Set-PSReadLineOption](Set-PSReadLineOption.md)
+
+[Set-PSReadLineKeyHandler](Set-PSReadLineKeyHandler.md)

--- a/docs/PSConsoleHostReadline.md
+++ b/docs/PSConsoleHostReadline.md
@@ -1,0 +1,50 @@
+---
+ms.date: 12/07/2018
+schema: 2.0.0
+locale: en-us
+keywords: powershell,cmdlet
+external help file: PSReadLine-help.xml
+title:  PSConsoleHostReadLine
+---
+
+# PSConsoleHostReadLine
+
+## SYNOPSIS
+This function is the main entry point for PSReadLine.
+
+## SYNTAX
+
+```
+PSConsoleHostReadLine
+```
+
+## DESCRIPTION
+
+`PSConsoleHostReadLine` is the main entry point for the PSReadLine module. The PowerShell console
+host automatically loads the PSReadLine modules and calls this function. Under normal operating
+conditions, this function is not intended to be used from the command line.
+
+If you wanted to create your own custom ReadLine function, you could replace this function with
+your own implementation.
+
+## EXAMPLES
+
+### Example 1
+
+This function is not intended to be used from the command line.
+
+## PARAMETERS
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS
+
+[about_PSReadLine](./About/about_PSReadLine.md)

--- a/docs/PSReadLine.md
+++ b/docs/PSReadLine.md
@@ -1,0 +1,39 @@
+---
+ms.date: 12/07/2018
+schema: 2.0.0
+locale: en-US
+keywords: powershell
+Help Version: 6.1.0.1
+Download Help Link: https://go.microsoft.com/fwlink/?linkid=855966
+Module Guid: 5714753b-2afd-4492-a5fd-01d9e2cff8b5
+title: PSReadLine
+Module Name: PSReadLine
+---
+
+# PSReadLine Module
+
+## Description
+
+The PSReadLine module contains cmdlets that let you customize the command-line editing environment
+in PowerShell. These articles documents PSReadLine v2.0. This version ships in PowerShell v6 and
+the Windows 10 October 2018 Update (Build 1809).
+
+## PSReadLine Cmdlets
+
+### [PSConsoleHostReadLine](PSConsoleHostReadLine.md)
+The main entry point for PSReadLine.
+
+### [Get-PSReadLineKeyHandler](Get-PSReadLineKeyHandler.md)
+Gets the key bindings for the PSReadLine module.
+
+### [Get-PSReadLineOption](Get-PSReadLineOption.md)
+Gets values for the options that can be configured.
+
+### [Remove-PSReadLineKeyHandler](Remove-PSReadLineKeyHandler.md)
+Removes a key binding.
+
+### [Set-PSReadLineKeyHandler](Set-PSReadLineKeyHandler.md)
+Binds keys to user-defined or PSReadLine-provided key handlers.
+
+### [Set-PSReadLineOption](Set-PSReadLineOption.md)
+Customizes the behavior of command line editing in PSReadLine.

--- a/docs/Remove-PSReadlineKeyHandler.md
+++ b/docs/Remove-PSReadlineKeyHandler.md
@@ -1,0 +1,107 @@
+---
+external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml
+keywords: powershell,cmdlet
+locale: en-us
+Module Name: PSReadLine
+ms.date: 12/07/2018
+online version: http://go.microsoft.com/fwlink/?LinkId=821451
+schema: 2.0.0
+title: Remove-PSReadLineKeyHandler
+---
+
+# Remove-PSReadLineKeyHandler
+
+## SYNOPSIS
+Removes a key binding.
+
+## SYNTAX
+
+```
+Remove-PSReadLineKeyHandler [-Chord] <String[]> [-ViMode <ViMode>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Remove-PSReadLineKeyHandler` cmdlet removes a specified key binding.
+
+## EXAMPLES
+
+### Example 1: Remove a binding
+
+```powershell
+Remove-PSReadLineKeyHandler -Chord Ctrl+Shift+B
+```
+
+This command removes the binding from the key combination, or chord, `Ctrl+Shift+B`.
+The `Ctrl+Shift+B` chord is created in the `Set-PSReadLineKeyHandler` article.
+
+## PARAMETERS
+
+### -Chord
+
+Specifies an array of keys or sequences of keys to be removed. A single binding is specified by
+using a single string. If the binding is a sequence of keys, separate the keys by a comma, as in
+the following example:
+
+`Ctrl+X,Ctrl+L`
+
+This parameter accepts an array of strings. Each string is a separate binding, not a sequence of
+keys for a single binding.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: Key
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ViMode
+
+Specify which vi mode the binding applies to. Possible values are: Insert, Command.
+
+```yaml
+Type: ViMode
+Parameter Sets: (All)
+Aliases:
+Accepted values: Insert, Command
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+You cannot pipe objects to this cmdlet.
+
+## OUTPUTS
+
+### None
+
+## NOTES
+
+## RELATED LINKS
+
+[Get-PSReadLineKeyHandler](Get-PSReadLineKeyHandler.md)
+
+[Get-PSReadLineOption](Get-PSReadLineOption.md)
+
+[Set-PSReadLineOption](Set-PSReadLineOption.md)
+
+[Set-PSReadLineKeyHandler](Set-PSReadLineKeyHandler.md)

--- a/docs/Set-PSReadLineKeyHandler.md
+++ b/docs/Set-PSReadLineKeyHandler.md
@@ -1,150 +1,157 @@
 ---
+external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml
+keywords: powershell,cmdlet
+locale: en-us
+Module Name: PSReadLine
+ms.date: 12/07/2018
+online version: http://go.microsoft.com/fwlink/?LinkID=821452
 schema: 2.0.0
-external help file: Microsoft.PowerShell.PSReadLine2.dll-help.xml
+title: Set-PSReadLineKeyHandler
 ---
 
 # Set-PSReadLineKeyHandler
 
 ## SYNOPSIS
-
-Binds or rebinds keys to user defined or PSReadLine provided key handlers.
+Binds keys to user-defined or PSReadLine key handler functions.
 
 ## SYNTAX
 
-### Set 1
+### ScriptBlock
 
 ```
-Set-PSReadLineKeyHandler [-Chord] <String[]> [-ScriptBlock] <ScriptBlock> [-BriefDescription <String>]
- [-Description <String>] [-ViMode <ViMode>]
+Set-PSReadLineKeyHandler [-ScriptBlock] <ScriptBlock> [-BriefDescription <String>] [-Description <String>]
+ [-Chord] <String[]> [-ViMode <ViMode>] [<CommonParameters>]
 ```
 
-### Set 2
+### Function
 
 ```
-Set-PSReadLineKeyHandler [-Chord] <String[]> [-Function] <String> [-ViMode <ViMode>]
+Set-PSReadLineKeyHandler [-Chord] <String[]> [-ViMode <ViMode>] [-Function] <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-This cmdlet is used to customize what happens when a particular key or sequence of keys is pressed while PSReadLine is reading input.
-
-With user defined key bindings, you can do nearly anything that is possible from a PowerShell script.
-Typically you might just edit the command line in some novel way, but because the handlers are just PowerShell scripts, you can do interesting things like change directories, launch programs, etc.
+The `Set-PSReadLineKeyHandler` cmdlet customizes the result when a key or sequence of keys is
+pressed. With user-defined key bindings, you can do almost anything that is possible from within a
+PowerShell script.
 
 ## EXAMPLES
 
-### --------------  Example 1  --------------
+### Example 1: Bind the arrow key to a function
 
+This command binds the up arrow key to the function **HistorySearchBackward**. This function uses
+the current contents of the command line as the search string used to search the command history.
+
+```powershell
+Set-PSReadLineKeyHandler -Chord UpArrow -Function HistorySearchBackward
 ```
-PS C:\> Set-PSReadLineKeyHandler -Key UpArrow -Function HistorySearchBackward
-```
 
-This command binds the up arrow key to the function HistorySearchBackward which will use the currently entered command line as the beginning of the search string when searching through history.
+### Example 2: Bind a key to a script block
 
-### --------------  Example 2  --------------
+This example shows how a single key can be used to run a command. The command binds the key
+`Ctrl+Shift+B` to a script block that clears the line, inserts the word "build", and then accepts
+the line.
 
-```
-PS C:\> Set-PSReadLineKeyHandler -Chord Shift+Ctrl+B -ScriptBlock {
->>    [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
->>    [Microsoft.PowerShell.PSConsoleReadLine]::Insert('msbuild')
->>    [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+```powershell
+Set-PSReadLineKeyHandler -Chord Ctrl+Shift+B -ScriptBlock {
+    [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+    [Microsoft.PowerShell.PSConsoleReadLine]::Insert('build')
+    [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
 }
 ```
 
-This example binds the key Ctrl+Shift+B to a script block that clears the line, inserts build, then accepts the line.
-This example shows how a single key can be used to execute a command.
-
 ## PARAMETERS
-
-### -Chord
-
-The key or sequence of keys to be bound to a Function or ScriptBlock.
-A single binding is specified with a single string.
-If the binding is a sequence of keys, the keys are separated with a comma, e.g. "Ctrl+X,Ctrl+X".
-Note that this parameter accepts multiple strings.
-Each string is a separate binding, not a sequence of keys for a single binding.
-
-```yaml
-Type: String[]
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 0
-Default value:
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -ScriptBlock
-
-The ScriptBlock is called when the Chord is entered.
-The ScriptBlock is passed one or sometimes two arguments.
-The first argument is the key pressed (a ConsoleKeyInfo.)  The second argument could be any object depending on the context.
-
-```yaml
-Type: ScriptBlock
-Parameter Sets: Set 1
-Aliases:
-
-Required: True
-Position: 1
-Default value:
-Accept pipeline input: false
-Accept wildcard characters: False
-```
 
 ### -BriefDescription
 
-A brief description of the key binding.
-Used in the output of cmdlet Get-PSReadLineKeyHandler.
+A brief description of the key binding. This description is displayed by the
+`Get-PSReadLineKeyHandler` cmdlet.
 
 ```yaml
 Type: String
-Parameter Sets: Set 1
+Parameter Sets: ScriptBlock
 Aliases:
 
 Required: False
 Position: Named
-Default value:
-Accept pipeline input: false
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Chord
+
+The key or sequence of keys to be bound to a function or script block. Use a single string to
+specify a single binding. If the binding is a sequence of keys, separate the keys by a comma, as in
+the following example:
+
+`Ctrl+X,Ctrl+L`
+
+This parameter accepts an array of strings. Each string is a separate binding, not a sequence of
+keys for a single binding.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: Key
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Description
 
-A more verbose description of the key binding.
-Used in the output of the cmdlet Get-PSReadLineKeyHandler.
+Specifies a more detailed description of the key binding that is visible in the output of the
+`Get-PSReadLineKeyHandler` cmdlet.
 
 ```yaml
 Type: String
-Parameter Sets: Set 1
-Aliases:
+Parameter Sets: ScriptBlock
+Aliases: LongDescription
 
 Required: False
 Position: Named
-Default value:
-Accept pipeline input: false
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -Function
 
-The name of an existing key handler provided by PSReadLine.
-This parameter allows one to rebind existing key bindings or to bind a handler provided by PSReadLine that is currently unbound.
-
-Using the ScriptBlock parameter, one can achieve equivalent functionality by calling the method directly from the ScriptBlock.
-This parameter is preferred though - it makes it easier to determine which functions are bound and unbound.
+Specifies the name of an existing key handler provided by PSReadLine. This parameter lets you
+rebind existing key bindings, or bind a handler that is currently unbound.
 
 ```yaml
 Type: String
-Parameter Sets: Set 2
+Parameter Sets: Function
+Aliases:
+Accepted values: Abort, AcceptAndGetNext, AcceptLine, AddLine, BackwardChar, BackwardDeleteChar, BackwardDeleteLine, BackwardDeleteWord, BackwardKillLine, BackwardKillWord, BackwardWord, BeginningOfHistory, BeginningOfLine, CancelLine, CaptureScreen, CharacterSearch, CharacterSearchBackward, ClearHistory, ClearScreen, Complete, Copy, CopyOrCancelLine, Cut, DeleteChar, DeleteCharOrExit, DeleteEndOfWord, DeleteLine, DeleteLineToFirstChar, DeleteToEnd, DeleteWord, DigitArgument, EndOfHistory, EndOfLine, ExchangePointAndMark, ForwardChar, ForwardDeleteLine, ForwardSearchHistory, ForwardWord, GotoBrace, GotoColumn, GotoFirstNonBlankOfLine, HistorySearchBackward, HistorySearchForward, InsertLineAbove, InsertLineBelow, InvertCase, InvokePrompt, KillLine, KillRegion, KillWord, MenuComplete, MoveToEndOfLine, NextHistory, NextLine, NextWord, NextWordEnd, Paste, PasteAfter, PasteBefore, PossibleCompletions, PrependAndAccept, PreviousHistory, PreviousLine, Redo, RepeatLastCharSearch, RepeatLastCharSearchBackwards, RepeatLastCommand, RepeatSearch, RepeatSearchBackward, ReverseSearchHistory, RevertLine, ScrollDisplayDown, ScrollDisplayDownLine, ScrollDisplayToCursor, ScrollDisplayTop, ScrollDisplayUp, ScrollDisplayUpLine, SearchChar, SearchCharBackward, SearchCharBackwardWithBackoff, SearchCharWithBackoff, SearchForward, SelectAll, SelectBackwardChar, SelectBackwardsLine, SelectBackwardWord, SelectForwardChar, SelectForwardWord, SelectLine, SelectNextWord, SelectShellBackwardWord, SelectShellForwardWord, SelectShellNextWord, SelfInsert, SetMark, ShellBackwardKillWord, ShellBackwardWord, ShellForwardWord, ShellKillWord, ShellNextWord, ShowKeyBindings, SwapCharacters, TabCompleteNext, TabCompletePrevious, Undo, UndoAll, UnixWordRubout, ValidateAndAcceptLine, ViAcceptLine, ViAcceptLineOrExit, ViAppendLine, ViBackwardDeleteGlob, ViBackwardGlob, ViBackwardWord, ViCommandMode, ViDeleteBrace, ViDeleteEndOfGlob, ViDeleteGlob, ViDigitArgumentInChord, ViEditVisually, ViExit, ViGotoBrace, ViInsertAtBegining, ViInsertAtEnd, ViInsertLine, ViInsertMode, ViInsertWithAppend, ViInsertWithDelete, ViJoinLines, ViNextWord, ViSearchHistoryBackward, ViTabCompleteNext, ViTabCompletePrevious, ViYankBeginningOfLine, ViYankEndOfGlob, ViYankEndOfWord, ViYankLeft, ViYankLine, ViYankNextGlob, ViYankNextWord, ViYankPercent, ViYankPreviousGlob, ViYankPreviousWord, ViYankRight, ViYankToEndOfLine, ViYankToFirstChar, WhatIsKey, Yank, YankLastArg, YankNthArg, YankPop
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScriptBlock
+
+Specifies a script block value to run when the chord is entered. PSReadLine passes one or two
+parameters to this script block. The first parameter is a **ConsoleKeyInfo** object representing
+the key pressed. The second argument can be any object depending on the context.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: ScriptBlock
 Aliases:
 
 Required: True
 Position: 1
-Default value:
-Accept pipeline input: false
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -154,36 +161,47 @@ Specify which vi mode the binding applies to.
 
 Valid values are:
 
--- Insert
-
--- Command
+- Insert
+- Command
 
 ```yaml
 Type: ViMode
 Parameter Sets: (All)
 Aliases:
+Accepted values: Insert, Command
 
 Required: False
 Position: Named
-Default value:
-Accept pipeline input: false
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
 
-You cannot pipe objects to Set-PSReadLineKeyHandler
+You cannot pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
-
 ## NOTES
 
 ## RELATED LINKS
 
-[about_PSReadLine]()
+[Get-PSReadLineKeyHandler](Get-PSReadLineKeyHandler.md)
+
+[Remove-PSReadLineKeyHandler](Remove-PSReadLineKeyHandler.md)
+
+[Get-PSReadLineOption](Get-PSReadLineOption.md)
+
+[Set-PSReadLineOption](Set-PSReadLineOption.md)

--- a/docs/Set-PSReadLineOption.md
+++ b/docs/Set-PSReadLineOption.md
@@ -1,72 +1,86 @@
 ---
+external help file: Microsoft.PowerShell.PSReadLine.dll-Help.xml
+keywords: powershell,cmdlet
+locale: en-us
+Module Name: PSReadLine
+ms.date: 12/07/2018
+online version: http://go.microsoft.com/fwlink/?LinkId=821453
 schema: 2.0.0
-external help file: Microsoft.PowerShell.PSReadLine2.dll-help.xml
+title: Set-PSReadLineOption
 ---
 
 # Set-PSReadLineOption
 
 ## SYNOPSIS
-
 Customizes the behavior of command line editing in PSReadLine.
 
 ## SYNTAX
 
+### OptionsSet
+
 ```
 Set-PSReadLineOption
  [-EditMode <EditMode>]
- [-HistorySavePath <String>]
- [-HistorySaveStyle <HistorySaveStyle>]
+ [-ContinuationPrompt <String>]
  [-HistoryNoDuplicates]
- [-HistorySearchCaseSensitive]
- [-PromptText <string>]
- [-ExtraPromptLineCount <Int32>]
- [-Colors <Hashtable>]
  [-AddToHistoryHandler <Func[String, Boolean]>]
  [-CommandValidationHandler <Action[CommandAst]>]
- [-ContinuationPrompt <String>]
  [-HistorySearchCursorMovesToEnd]
  [-MaximumHistoryCount <Int32>]
  [-MaximumKillRingCount <Int32>]
  [-ShowToolTips]
+ [-ExtraPromptLineCount <Int32>]
  [-DingTone <Int32>]
  [-DingDuration <Int32>]
  [-BellStyle <BellStyle>]
  [-CompletionQueryItems <Int32>]
- [-WordDelimiters <string>]
- [-AnsiEscapeTimeout <int>]
+ [-WordDelimiters <String>]
+ [-HistorySearchCaseSensitive]
+ [-HistorySaveStyle <HistorySaveStyle>]
+ [-HistorySavePath <String>]
+ [-AnsiEscapeTimeout <Int32>]
+ [-PromptText <String>]
  [-ViModeIndicator <ViModeStyle>]
- [-ViModeChangeHandler <ScriptBlock>]
+ [-Colors <Hashtable>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The Set-PSReadLineOption cmdlet is used to customize the behavior of the PSReadLine module when editing the command line.
+The `Set-PSReadLineOption` cmdlet customizes the behavior of the PSReadLine module when you are editing the command line.
 
 ## EXAMPLES
 
-### --------------  Example 1  --------------
+### Example 1: Set color values for multiple types
 
-This example sets some different colors.
+This example shows three different methods for how to set the color of tokens displayed in PSReadLine.
 
-```
-PS C:\> Set-PSReadLineOption -Colors @{
-    # Use a ConsoleColor enum
-    "Error" = [ConsoleColor]::DarkRed
+```powershell
+Set-PSReadLineOption -Colors @{
+ # Use a ConsoleColor enum
+ "Error" = [ConsoleColor]::DarkRed
 
-    # 24 bit color escape sequence
-    "String" = "$([char]0x1b)[38;5;100m"
+ # 24 bit color escape sequence
+ "String" = "$([char]0x1b)[38;5;100m"
 
-    # RGB value
-    "Command" = "#8181f7"
+ # RGB value
+ "Command" = "#8181f7"
 }
 ```
 
-### --------------  Example 2  --------------
+### Example 2: Set bell style
 
-This example demonstrates something almost like a theme using splatting:
+This cmdlet instructs PSReadLine to respond to errors or conditions that require user attention
+by emitting an audible beep at 1221 Hz for 60 ms.
 
+```powershell
+Set-PSReadLineOption -BellStyle Audible -DingTone 1221 -DingDuration 60
 ```
-PS C:\> $PSReadLineOptions = @{
+
+### Example 3: Set multiple options
+
+```powershell
+$PSReadLineOptions = @{
     EditMode = "Emacs"
     HistoryNoDuplicates = $true
     HistorySearchCursorMovesToEnd = $true
@@ -74,128 +88,17 @@ PS C:\> $PSReadLineOptions = @{
         "Command" = "#8181f7"
     }
 }
-PS C:\> Set-PSReadLineOption @PSReadLineOptions
-```
-
-### --------------  Example 3  --------------
-
-This example emits a cursor change VT escape in response to a vi mode change:
-
-```
-PS C:\> function OnViModeChange {
-    if ($args[0] -eq 'Command') {
-        # Set the cursor to a blinking block.
-        Write-Host -NoNewLine "`e[1 q"
-    } else {
-        # Set the cursor to a blinking line.
-        Write-Host -NoNewLine "`e[5 q"
-    }
-}
-PS C:\> Set-PSReadLineOption -ViModeIndicator Script -ViModeChangeHandler OnViModeChange
+Set-PSReadLineOption @PSReadLineOptions
 ```
 
 ## PARAMETERS
 
-### -EditMode
-
-Specifies the command line editing mode.
-This will reset any key bindings set by Set-PSReadLineKeyHandler.
-
-Valid values are:
-
--- Windows: Key bindings emulate PowerShell/cmd with some bindings emulating Visual Studio.
-
--- Emacs: Key bindings emulate Bash or Emacs.
-
--- Vi: Key bindings emulate Vi.
-
-```yaml
-Type: EditMode
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: Windows
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -PromptText
-
-When there is a parse error, PSReadLine changes a part of the prompt red.
-PSReadLine analyzes your prompt function to determine how it can change just the color of part of your prompt,
-but this analysis cannot be 100% reliable.
-
-Use this option if PSReadLine is changing your prompt in surprising ways,
-be sure to include any trailing whitespace.
-
-For example, if my prompt function looked like:
-
-    function prompt { Write-Host -NoNewLine -ForegroundColor Yellow "$pwd"; return "# " }
-
-Then set:
-
-    Set-PSReadLineOption -PromptText "# "
-
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: >
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -ContinuationPrompt
-
-Specifies the string displayed at the beginning of the second and subsequent lines when multi-line input is being entered.
-Defaults to '\>\> '.
-The empty string is valid.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: >>
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -HistoryNoDuplicates
-
-Repeated commands will usually be added to history to preserve ordering during recall,
-but typically you don't want to see the same command multiple times when recalling or searching the history.
-
-This option controls the recall behavior - duplicates will are still added to the history file,
-but if this option is set, only the most recent invocation will appear when recalling commands.
-
-
-```yaml
-Type: switch
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value:
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
 ### -AddToHistoryHandler
 
-Specifies a ScriptBlock that can be used to control which commands get added to PSReadLine history.
+Specifies a **ScriptBlock** that controls which commands get added to PSReadLine history.
 
-The ScriptBlock is passed the command line.
-If the ScriptBlock returns `$true`, the command line is added to history, otherwise it is not.
+The **ScriptBlock** receives the command line as input. If the ScriptBlock returns `$true`, the
+command line is added to the history.
 
 ```yaml
 Type: Func[String, Boolean]
@@ -204,240 +107,24 @@ Aliases:
 
 Required: False
 Position: Named
-Default value:
-Accept pipeline input: false
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -CommandValidationHandler
+### -AnsiEscapeTimeout
 
-Specifies a ScriptBlock that is called from ValidateAndAcceptLine.
-If an exception is thrown, validation fails and the error is reported.
+This option is specific to Windows when input is redirected, for example, when running under `tmux`
+or `screen`.
 
-`ValidateAndAcceptLine` is used to avoid cluttering your history with commands that can't work, e.g. specifying parameters that do not exist.
+With redirected input on Windows, many keys are sent as a sequence of characters starting with the
+escape character. It's impossible to distinguish between a single escape character followed by
+more characters and a valid escape sequence.
 
-```yaml
-Type: Action[CommandAst]
-Parameter Sets: (All)
-Aliases:
+The assumption is that the terminal can send the characters faster than a user types. PSReadLine
+waits for this timeout before concluding that it has received a complete escape sequence.
 
-Required: False
-Position: Named
-Default value:
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -HistorySearchCursorMovesToEnd
-
-When using `HistorySearchBackward` and `HistorySearchForward`, the default behavior leaves the cursor at the end of the search string if any.
-
-To move the cursor to end of the line just like when there is no search string, set this option to `$true`.
-
-```yaml
-Type: switch
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value:
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -MaximumHistoryCount
-
-Specifies the maximum number of commands to save in PSReadLine history.
-
-Note that PSReadLine history is separate from PowerShell history.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 1024
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -MaximumKillRingCount
-
-Specifies the maximum number of items stored in the kill ring.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 10
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -ShowToolTips
-
-When displaying possible completions, show tooltips in the list of completions.
-
-This option was not enabled by default in earliers versions of PSReadLine, but is enabled by default now.
-To disable, set this option to `$false`.
-
-```yaml
-Type: switch
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: true
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -ExtraPromptLineCount
-
-Use this option if your prompt spans more than one line.
-
-This option is needed less than in previous version of PSReadLine, but is useful when the `InvokePrompt` function is used.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 0
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -Colors
-
-The Colors parameter is used to specify various colors used by PSReadLine.
-
-The argument is a Hashtable where the keys specify which element and the values specify the color.
-
-Colors can be either a value from ConsoleColor, e.g. [ConsoleColor]::Red, or a valid escape sequence.
-Valid escape sequences depend on your terminal, e.g. "$([char]0x1b)[91m" (Windows PowerShell) or
-"`e[91m" (PowerShell 6.0) specifies Red in most terminals.
-You can specify other escape sequences as well, including but not limited to:
-
--- 256 color
--- 24 bit color
--- Foreground, background, or both
--- Inverse, bold
-
-The valid keys include:
-
--- ContinuationPrompt: The color of the continuation prompt.
-
--- Emphasis: The emphasis color, e.g. the matching text when searching history.
-
--- Error: The error color, e.g. in the prompt.
-
--- Selection: The color to highlight the menu selection or selected text.
-
--- Default: The default token color.
-
--- Comment: The comment token color.
-
--- Keyword: The keyword token color.
-
--- String: The string token color.
-
--- Operator: The operator token color.
-
--- Variable: The variable token color.
-
--- Command: The command token color.
-
--- Parameter: The parameter token color.
-
--- Type: The type token color.
-
--- Number: The number token color.
-
--- Member: The member name token color.
-
-```yaml
-Type: Hashtable
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value:
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -DingTone
-
-When BellStyle is set to Audible, specifies the tone of the beep.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 1221
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -DingDuration
-
-When BellStyle is set to Audible, specifies the duration of the beep.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 50ms
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -BellStyle
-
-Specifies how PSReadLine should respond to various error and ambiguous conditions.
-
-Valid values are:
-
--- Audible: a short beep
-
--- Visible: a brief flash is performed
-
--- None: no feedback
-
-```yaml
-Type: BellStyle
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: Audible
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -CompletionQueryItems
-
-Specifies the maximum number of completion items that will be shown without prompting.
-
-If the number of items to show is greater than this value, PSReadLine will prompt y/n before displaying the completion items.
+If you see random or unexpected characters when you type, you can adjust this timeout.
 
 ```yaml
 Type: Int32
@@ -447,63 +134,230 @@ Aliases:
 Required: False
 Position: Named
 Default value: 100
-Accept pipeline input: false
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -WordDelimiters
+### -BellStyle
 
-Specifies the characters that delimit words for functions like ForwardWord or KillWord.
-
-```yaml
-Type: string
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: ;:,.[]{}()/\|^&*-=+
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -HistorySearchCaseSensitive
-
-Specifies the searching history is case sensitive in functions like ReverseSearchHistory or HistorySearchBackward.
-
-```yaml
-Type: switch
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value:
-Accept pipeline input: false
-Accept wildcard characters: False
-```
-
-### -HistorySaveStyle
-
-Specifies how PSReadLine should save history.
+Specifies how PSReadLine responds to various error and ambiguous conditions.
 
 Valid values are:
 
--- SaveIncrementally: save history after each command is executed - and share across multiple instances of PowerShell
-
--- SaveAtExit: append history file when PowerShell exits
-
--- SaveNothing: don't use a history file
+- Audible: A short beep
+- Visual: Text flashes briefly
+- None: No feedback
 
 ```yaml
-Type: HistorySaveStyle
+Type: BellStyle
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, Visual, Audible
+
+Required: False
+Position: Named
+Default value: Audible
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Colors
+
+The Colors parameter is used to specify various colors used by PSReadLine.
+
+The argument is a Hashtable where the keys specify which element and the values specify the color.
+
+Colors can be either a value from ConsoleColor, for example `[ConsoleColor]::Red`, or a valid
+escape sequence. Valid escape sequences depend on your terminal. In Windows PowerShell, an example
+escape sequence is `$([char]0x1b)[91m`. In PowerShell 6, the same escape sequence is `e[91m`. You
+can specify other escape sequences including:
+
+- 256 color
+- 24-bit color
+- Foreground, background, or both
+- Inverse, bold
+
+The valid keys include:
+
+- ContinuationPrompt: The color of the continuation prompt.
+- Emphasis: The emphasis color. For example, the matching text when searching history.
+- Error: The error color. For example, in the prompt.
+- Selection: The color to highlight the menu selection or selected text.
+- Default: The default token color.
+- Comment: The comment token color.
+- Keyword: The keyword token color.
+- String: The string token color.
+- Operator: The operator token color.
+- Variable: The variable token color.
+- Command: The command token color.
+- Parameter: The parameter token color.
+- Type: The type token color.
+- Number: The number token color.
+- Member: The member name token color.
+
+```yaml
+Type: Hashtable
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: SaveIncrementally
-Accept pipeline input: false
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CommandValidationHandler
+
+Specifies a **ScriptBlock** that is called from **ValidateAndAcceptLine**. If an exception is
+thrown, validation fails and the error is reported.
+
+Before throwing an exception, the validation handler can place the cursor at the point of the error
+to make it easier to fix. A validation handler can also change the command line, such as to correct
+common typographical errors.
+
+**ValidateAndAcceptLine** is used to avoid cluttering your history with commands that can't work.
+
+```yaml
+Type: Action[CommandAst]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CompletionQueryItems
+
+Specifies the maximum number of completion items that are shown without prompting.
+
+If the number of items to show is greater than this value, PSReadLine prompts "y/n" before
+displaying the completion items.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 100
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ContinuationPrompt
+
+Specifies the string displayed at the beginning of the subsequent lines when multi-line input is
+entered. Defaults to `>> `. The empty string is valid.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: >>
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DingDuration
+
+Specifies the duration of the beep when **BellStyle** is set to **Audible**.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 50ms
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DingTone
+
+Specifies the tone in Hertz (Hz) of the beep when **BellStyle** is set to **Audible**.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 1221
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EditMode
+
+Specifies the command line editing mode. Using this parameter resets any key bindings set by
+`Set-PSReadLineKeyHandler`.
+
+Valid values are:
+
+- Windows: Key bindings emulate PowerShell, cmd, and Visual Studio.
+- Emacs: Key bindings emulate Bash or Emacs.
+- Vi: Key bindings emulate Vi.
+
+```yaml
+Type: EditMode
+Parameter Sets: (All)
+Aliases:
+Accepted values: Windows, Emacs, Vi
+
+Required: False
+Position: Named
+Default value: Windows
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExtraPromptLineCount
+
+Use this option if your prompt spans more than one line.
+
+This option is needed less than in previous version of PSReadLine, but is useful when the
+`InvokePrompt` function is used.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HistoryNoDuplicates
+
+This option controls the recall behavior. Duplicate commands are still added to the history file.
+When this option is set, only the most recent invocation appears when recalling commands.
+
+Repeated commands are added to history to preserve ordering during recall. However, you
+typically don't want to see the command multiple times when recalling or searching the history.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -519,89 +373,222 @@ Aliases:
 Required: False
 Position: Named
 Default value: A file named $($host.Name)_history.txt in $env:APPDATA\Microsoft\Windows\PowerShell\PSReadLine on Windows and $env:XDG_DATA_HOME/powershell/PSReadLine or $env:HOME/.local/share/powershell/PSReadLine on non-Windows platforms
-Accept pipeline input: false
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -AnsiEscapeTimeout
+### -HistorySaveStyle
 
-This option is specific to Windows when input is redirected, e.g. when running under `tmux` or `screen`.
+Specifies how PSReadLine saves history.
 
-With redirected input on Windows, many keys are sent as a sequence of characters starting with the Escape character,
-so it is, in general, impossible to distinguish between a single Escape followed by other key presses.
+Valid values are:
 
-The assumption is the terminal sends the characters quickly, faster than a user types, so PSReadLine waits for this timeout before concluding it won't see an escape sequence.
-
-You can experiment with this timeout if you see issues or random unexpected characters when you type.
+- SaveIncrementally: Save history after each command is executed and share across multiple
+  instances of PowerShell
+- SaveAtExit: Append history file when PowerShell exits
+- SaveNothing: Don't use a history file
 
 ```yaml
-Type: int
+Type: HistorySaveStyle
+Parameter Sets: (All)
+Aliases:
+Accepted values: SaveIncrementally, SaveAtExit, SaveNothing
+
+Required: False
+Position: Named
+Default value: SaveIncrementally
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HistorySearchCaseSensitive
+
+Specifies that history searching is case-sensitive in functions like **ReverseSearchHistory** or **HistorySearchBackward**.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: 100
-Accept pipeline input: false
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HistorySearchCursorMovesToEnd
+
+Indicates that the cursor moves to the end of commands that you load from history by using a search.
+When this parameter is set to `$False`, the cursor remains at the position it was when you pressed the up or down arrows.
+
+To turn off this option, you can run either of the following commands:
+
+`Set-PSReadLineOption -HistorySearchCursorMovesToEnd:$False`
+
+`(Get-PSReadLineOption).HistorySearchCursorMovesToEnd = $False`
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaximumHistoryCount
+
+Specifies the maximum number of commands to save in PSReadLine history.
+
+PSReadLine history is separate from PowerShell history.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaximumKillRingCount
+
+Specifies the maximum number of items stored in the kill ring.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 10
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PromptText
+
+When there is a parse error, PSReadLine changes a part of the prompt red. PSReadLine analyzes your
+prompt function to determine how to change only the color of part of your prompt. This analysis is
+not 100% reliable.
+
+Use this option if PSReadLine is changing your prompt in surprising ways, be sure to include any
+trailing whitespace.
+
+For example, if my prompt function looked like:
+
+`function prompt { Write-Host -NoNewLine -ForegroundColor Yellow "$pwd"; return "# " }`
+
+Then set:
+
+`Set-PSReadLineOption -PromptText "# "`
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: >
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ShowToolTips
+
+When displaying possible completions,  tooltips are shown in the list of completions.
+
+This option is enabled by default. This option was not enabled by default in prior versions of
+PSReadLine. To disable, set this option to `$False`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -ViModeIndicator
 
-This option sets the visual indication for the current mode in Vi mode - either insert mode or command mode.
+This option sets the visual indication for the current mode in Vi mode; either insert mode or
+command mode.
 
 Valid values are:
 
--- None - there is no indication
-
--- Prompt - the prompt changes color
-
--- Cursor - the cursor changes size
-
--- Script - user-specified text is printed
+- None - there is no indication
+- Prompt - the prompt changes color
+- Cursor - the cursor changes size
 
 ```yaml
 Type: ViModeStyle
 Parameter Sets: (All)
 Aliases:
+Accepted values: None, Prompt, Cursor
 
 Required: False
 Position: Named
-Default value:
-Accept pipeline input: false
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ViModeChangeHandler
+### -WordDelimiters
 
-When the `ViModeIndicator` is set to `Script`, the script block provided will be invoked every time the mode changes. The script block is provided one argument of type `ViMode`. Example usage is shown in Example 3 in this document.
+Specifies the characters that delimit words for functions like **ForwardWord** or **KillWord**.
 
 ```yaml
-Type: ScriptBlock
+Type: String
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value:
-Accept pipeline input: false
-Accept wildcard characters: false
+Default value: ;:,.[]{}()/\|^&*-=+'"–—―
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose,
+-WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### None
 
-You cannot pipe objects to Set-PSReadLineOption
+You cannot pipe objects to this cmdlet.
 
 ## OUTPUTS
 
 ### None
 
-This cmdlet does not generate any output.
+This cmdlet does not generate output.
 
 ## NOTES
 
 ## RELATED LINKS
 
-[about_PSReadLine]()
+[Get-PSReadLineKeyHandler](Get-PSReadLineKeyHandler.md)
+
+[Remove-PSReadLineKeyHandler](Remove-PSReadLineKeyHandler.md)
+
+[Get-PSReadLineOption](Get-PSReadLineOption.md)
+
+[Set-PSReadLineKeyHandler](Set-PSReadLineKeyHandler.md)


### PR DESCRIPTION
PowerShell 6x shipped with PSReadline v2 so we had to update the documentation. This PR contains the updated docs that we published. The files have been edited and reformatted to meet our style guidelines and build requirements.