### PR TITLE
Fix the appveyor build badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/0xu8r817dl6qt0g4?svg=true)](https://ci.appveyor.com/project/lzybkr/PSReadLine/branch/master)
-[![Build Status](https://lzybkr.visualstudio.com/AzurePipelines/_apis/build/status/PSReadLine%20Azure%20Pipeline)](https://lzybkr.visualstudio.com/AzurePipelines/_build/latest?definitionId=6)
+[![appveyor-build-status][]][appveyor-build-site]
+[![azure-build-status][]][azure-build-site]
+
+[appveyor-build-status]: https://ci.appveyor.com/api/projects/status/github/lzybkr/PSReadLine?branch=master&svg=true
+[appveyor-build-site]: https://ci.appveyor.com/project/lzybkr/PSReadLine?branch=master
+[azure-build-status]: https://lzybkr.visualstudio.com/AzurePipelines/_apis/build/status/PSReadLine%20Azure%20Pipeline
+[azure-build-site]: https://lzybkr.visualstudio.com/AzurePipelines/_build/latest?definitionId=6
 
 # PSReadLine
 


### PR DESCRIPTION
Fix the appveyor build badge URL from 
```
https://ci.appveyor.com/api/projects/status/0xu8r817dl6qt0g4?svg=true
```
to
```
https://ci.appveyor.com/api/projects/status/github/lzybkr/PSReadLine?branch=master&svg=true
```