### PR TITLE
Fixed some unit-tests that were relying on an implicit definition of "_" at the top of the file.

### DIFF
--- a/test/MovementTest.VI.Multiline.cs
+++ b/test/MovementTest.VI.Multiline.cs
@@ -87,7 +87,7 @@ namespace Test
             const string buffer = "\"\n\n\"";
 
             Test(buffer, Keys(
-                _.DQuote, _.Enter, _.Enter, _.DQuote, _.Escape, _.K,
+                _.DQuote, _.Enter, _.Enter, _.DQuote, _.Escape, _.k,
                 CheckThat(() => AssertCursorLeftTopIs(continuationPrefixLength + 0, 1)),
                 _.Underbar, CheckThat(() => AssertCursorLeftTopIs(continuationPrefixLength + 0, 1))
             ));
@@ -103,7 +103,7 @@ namespace Test
             const string buffer = "\"\n\n\"";
 
             Test(buffer, Keys(
-                _.DQuote, _.Enter, _.Enter, _.DQuote, _.Escape, _.K,
+                _.DQuote, _.Enter, _.Enter, _.DQuote, _.Escape, _.k,
                 CheckThat(() => AssertCursorLeftTopIs(continuationPrefixLength + 0, 1)),
                 _.Dollar, CheckThat(() => AssertCursorLeftTopIs(continuationPrefixLength + 0, 1))
             ));

--- a/test/MovementTest.VI.Multiline.cs
+++ b/test/MovementTest.VI.Multiline.cs
@@ -58,7 +58,7 @@ namespace Test
             ViJumpMustDing(buffer, keys);
         }
 
-        [Fact]
+        [SkippableFact]
         public void ViMoveToFirstNonBlankOfLogicalLineThenJumpToEndOfLogicalLine()
         {
             TestSetup(KeyMode.Vi);
@@ -77,7 +77,7 @@ namespace Test
                 ));
         }
 
-        [Fact]
+        [SkippableFact]
         public void ViMoveToFirstNonBlankOfLogicalLine_NoOp_OnEmptyLine()
         {
             TestSetup(KeyMode.Vi);
@@ -93,7 +93,7 @@ namespace Test
             ));
         }
 
-        [Fact]
+        [SkippableFact]
         public void ViMoveToEndOfLine_NoOp_OnEmptyLine()
         {
             TestSetup(KeyMode.Vi);


### PR DESCRIPTION
Previously, sequence of keys were interpreted using a language hack at the top of the file.

`using _ = Keys;`

The statement defaulted to a class that contained both `K` and `ucK` for lower-case `K` and upper-case `K` respectively.
Now, `_` is a member of the class that points to a `KbdLayout` class with members `k` and `K` respectively.

Therefore, the unit-test was broken when the definition of `_` changed.