### PR TITLE
Fix - Incorrect links to documentation files.

### DIFF
--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -21,13 +21,16 @@
     <None Include="License.txt" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="docs\about_PSReadLine.help.txt" />
-    <None Include="docs\Get-PSReadLineKeyHandler.md" />
-    <None Include="docs\Get-PSReadLineOption.md" />
-    <None Include="docs\Set-PSReadLineKeyHandler.md" />
-    <None Include="docs\Set-PSReadLineOption.md" />
+    <None Include="..\docs\about_PSReadLine.help.txt" Link="docs\about_PSReadLine.help.txt" />
+    <None Include="..\docs\Get-PSReadLineKeyHandler.md" Link="docs\Get-PSReadLineKeyHandler.md" />
+    <None Include="..\docs\Get-PSReadLineOption.md" Link="docs\Get-PSReadLineOption.md" />
+    <None Include="..\docs\Set-PSReadLineKeyHandler.md" Link="docs\Set-PSReadLineKeyHandler.md" />
+    <None Include="..\docs\Set-PSReadLineOption.md" Link="docs\Set-PSReadLineOption.md" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsWindows)' != 'true' ">
     <Compile Remove="AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="doc\" />
   </ItemGroup>
 </Project>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -30,7 +30,4 @@
   <ItemGroup Condition=" '$(IsWindows)' != 'true' ">
     <Compile Remove="AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="doc\" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
The `PSReadLine.csproj` project file includes various text and markdown documentation files, but these are actually available from the root solution folder. This PR fixes the links to those documentation files.