### PR TITLE
Fix 'Shift+Backspace' to work the same as 'Backspace'

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -572,6 +572,8 @@ namespace Microsoft.PowerShell
 
         void ProcessOneKey(PSKeyInfo key, Dictionary<PSKeyInfo, KeyHandler> dispatchTable, bool ignoreIfNoAction, object arg)
         {
+            var consoleKey = key.AsConsoleKeyInfo();
+
             // Our dispatch tables are built as much as possible in a portable way, so for example,
             // we avoid depending on scan codes like ConsoleKey.Oem6 and instead look at the
             // PSKeyInfo.Key. We also want to ignore the shift state as that may differ on
@@ -585,15 +587,15 @@ namespace Microsoft.PowerShell
                 // shift hadn't be pressed.  This cleanly allows Shift+Backspace without adding a key binding.
                 if (key.Shift && !key.Control && !key.Alt)
                 {
-                    var c = key.KeyChar;
+                    var c = consoleKey.KeyChar;
                     if (c != '\0' && char.IsControl(c))
                     {
-                        key = PSKeyInfo.From(key.KeyChar);
+                        key = PSKeyInfo.From(consoleKey.Key);
                         dispatchTable.TryGetValue(key, out handler);
                     }
                 }
             }
-            var consoleKey = key.AsConsoleKeyInfo();
+
             if (handler != null)
             {
                 if (handler.ScriptBlock != null)

--- a/test/KeyBindingsTest.cs
+++ b/test/KeyBindingsTest.cs
@@ -47,5 +47,21 @@ namespace Test
             TestSetup(KeyMode.Vi);
             Test("", Keys(Enumerable.Repeat(_.Ctrl_Alt_Question, 3)));
         }
+
+        [SkippableFact]
+        public void ShiftBackspace()
+        {
+            TestSetup(KeyMode.Cmd);
+            Test("aa", Keys("aaa", _.Shift_Backspace));
+        }
+
+        [SkippableFact]
+        public void ShiftEscape()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            System.Threading.Thread.Sleep(10000);
+            Test("", Keys("aaa", _.Shift_Escape));
+        }
     }
 }

--- a/test/KeyBindingsTest.cs
+++ b/test/KeyBindingsTest.cs
@@ -59,8 +59,6 @@ namespace Test
         public void ShiftEscape()
         {
             TestSetup(KeyMode.Cmd);
-
-            System.Threading.Thread.Sleep(10000);
             Test("", Keys("aaa", _.Shift_Escape));
         }
     }

--- a/test/KeyInfo-en-US-linux.json
+++ b/test/KeyInfo-en-US-linux.json
@@ -959,6 +959,20 @@
     "Investigate": false
   },
   {
+    "Key": "Shift+Backspace",
+    "KeyChar": "\u007f",
+    "ConsoleKey": "Backspace",
+    "Modifiers": "0",
+    "Investigate": false
+  },
+  {
+    "Key": "Shift+Escape",
+    "KeyChar": "\u001b",
+    "ConsoleKey": "Escape",
+    "Modifiers": "0",
+    "Investigate": false
+  },
+  {
     "Key": "Alt+F1",
     "KeyChar": "\u0000",
     "ConsoleKey": "F12",

--- a/test/KeyInfo-en-US-windows.json
+++ b/test/KeyInfo-en-US-windows.json
@@ -1302,6 +1302,18 @@
         "Modifiers":  "Shift"
     },
     {
+        "Key":  "Shift+Backspace",
+        "KeyChar":  "\b",
+        "ConsoleKey":  "Backspace",
+        "Modifiers":  "Shift"
+    },
+    {
+        "Key":  "Shift+Escape",
+        "KeyChar":  "\u001b",
+        "ConsoleKey":  "Escape",
+        "Modifiers":  "Shift"
+    },
+    {
         "Key":  "Spacebar",
         "KeyChar":  " ",
         "ConsoleKey":  "Spacebar",

--- a/test/KeyInfo-fr-FR-windows.json
+++ b/test/KeyInfo-fr-FR-windows.json
@@ -1498,6 +1498,20 @@
         "Investigate":  false
     },
     {
+        "Key":  "Shift+Backspace",
+        "KeyChar":  "\b",
+        "ConsoleKey":  "Backspace",
+        "Modifiers":  "Shift",
+        "Investigate":  false
+    },
+    {
+        "Key":  "Shift+Escape",
+        "KeyChar":  "\u001b",
+        "ConsoleKey":  "Escape",
+        "Modifiers":  "Shift",
+        "Investigate":  false
+    },
+    {
         "Key":  "Shift+UpArrow",
         "KeyChar":  "\u0000",
         "ConsoleKey":  "UpArrow",

--- a/test/KeyInfo-pl-PL-linux.json
+++ b/test/KeyInfo-pl-PL-linux.json
@@ -280,6 +280,20 @@
     "Investigate": false
   },
   {
+    "Key": "Shift+Backspace",
+    "KeyChar": "\u007f",
+    "ConsoleKey": "Backspace",
+    "Modifiers": "0",
+    "Investigate": false
+  },
+  {
+    "Key": "Shift+Escape",
+    "KeyChar": "\u001b",
+    "ConsoleKey": "Escape",
+    "Modifiers": "0",
+    "Investigate": false
+  },
+  {
     "Key": "j",
     "KeyChar": "j",
     "ConsoleKey": "J",

--- a/test/KeyInfo-pl-PL-windows.json
+++ b/test/KeyInfo-pl-PL-windows.json
@@ -728,6 +728,20 @@
         "Investigate":  false
     },
     {
+        "Key":  "Shift+Backspace",
+        "KeyChar":  "\b",
+        "ConsoleKey":  "Backspace",
+        "Modifiers":  "Shift",
+        "Investigate":  false
+    },
+    {
+        "Key":  "Shift+Escape",
+        "KeyChar":  "\u001b",
+        "ConsoleKey":  "Escape",
+        "Modifiers":  "Shift",
+        "Investigate":  false
+    },
+    {
         "Key":  "Ctrl+y",
         "KeyChar":  "\u0019",
         "ConsoleKey":  "Y",

--- a/test/KeyInfo-ru-RU-windows.json
+++ b/test/KeyInfo-ru-RU-windows.json
@@ -742,6 +742,20 @@
         "Investigate":  false
     },
     {
+        "Key":  "Shift+Backspace",
+        "KeyChar":  "\b",
+        "ConsoleKey":  "Backspace",
+        "Modifiers":  "Shift",
+        "Investigate":  false
+    },
+    {
+        "Key":  "Shift+Escape",
+        "KeyChar":  "\u001b",
+        "ConsoleKey":  "Escape",
+        "Modifiers":  "Shift",
+        "Investigate":  false
+    },
+    {
         "Key":  "5",
         "KeyChar":  "5",
         "ConsoleKey":  "D5",


### PR DESCRIPTION
Fix #896
Make `Shift+Backspace` and `Shift+Escape` work the same as `Backsapce` and `Escape` on windows.