### PR TITLE
create TestResults folder if missing #930

### DIFF
--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -227,6 +227,11 @@ function Start-TestRun
         $env:PSREADLINE_TESTRUN = 1
         Push-Location "$RepoRoot/test"
 
+        if (!(Test-Path -Path $testResultFolder))
+        {
+            New-Item -ItemType Directory -Force $testResultFolder
+        }
+
         if ($IsWindowsEnv)
         {
             if ($env:APPVEYOR -or $env:TF_BUILD)


### PR DESCRIPTION
This addresses #930 by creating the folder if missing. Somebody should double check if the missing folder isn't a side-effect of something else going wrong.