### PR TITLE
Fix the conversion from ConsoleKeyInfo/PSKeyInfo to PSKeyInfo/ConsoleKeyInfo

### DIFF
--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -268,8 +268,15 @@ namespace Microsoft.PowerShell
                     break;
 
                 case '\0':
-                    // This could be a special kind of a modifier key (dead key) on a particular keyboard layout.
-                    s = key.Key.ToString();
+                    // On Windows:
+                    //   This could be a special kind of a modifier key (dead key) for a particular keyboard layout.
+                    //   We use the text form of the virtual key in such case, so the resulted PSKeyInfo can be converted back to ConsoleKeyInfo correctly later on,
+                    //   and be properly ignore during rendering.
+                    // On non-Windows:
+                    //   The dead key is not an issue when there is a tty involved.
+                    //   But the virtual key is not captured as accurately as on Windows, e.g. Ctrl+2 results in `key.Key = 0`.
+                    //   So on non-Windows, we use `@` in case `key.KeyChar = '\0'`. This is ugly but familiar.
+                    s = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? key.Key.ToString() : "@";
                     break;
 
                 case char _ when (c >= 1 && c <= 26):

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -268,8 +268,8 @@ namespace Microsoft.PowerShell
                     break;
 
                 case '\0':
-                    // This is ugly but familiar.
-                    s = "@";
+                    // This could be a special kind of a modifier key (dead key) on a particular keyboard layout.
+                    s = key.Key.ToString();
                     break;
 
                 case char _ when (c >= 1 && c <= 26):

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -125,7 +125,7 @@ namespace Microsoft.PowerShell
 
         static readonly ThreadLocal<char[]> toUnicodeBuffer = new ThreadLocal<char[]>(() => new char[2]);
         static readonly ThreadLocal<byte[]> toUnicodeStateBuffer = new ThreadLocal<byte[]>(() => new byte[256]);
-        internal static void TryGetCharFromConsoleKey(ConsoleKeyInfo key, ref char result)
+        internal static void TryGetCharFromConsoleKey(ConsoleKeyInfo key, ref char result, ref bool isDeadKey)
         {
             var modifiers = key.Modifiers;
             var virtualKey = key.Key;
@@ -149,10 +149,19 @@ namespace Microsoft.PowerShell
             }
             int charCount = ToUnicode(virtualKey, scanCode, state, chars, chars.Length, flags);
 
-            // TODO: support diacriticals (charCount == 2)
             if (charCount == 1)
             {
                 result = chars[0];
+            }
+            else if (charCount == -1 || charCount >=2)
+            {
+                // Quoted from https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-tounicode#return-value:
+                //  "Return value  -1 --
+                //     The specified virtual key is a dead-key character (accent or diacritic).
+                //   Return value >=2 --
+                //     Two or more characters were written to the buffer specified by pwszBuff. The most common cause for this is that a dead-key character 
+                //     (accent or diacritic) stored in the keyboard layout could not be combined with the specified virtual key to form a single character."
+                isDeadKey = true;
             }
         }
 
@@ -217,6 +226,7 @@ namespace Microsoft.PowerShell
             }
 
             var c = key.KeyChar;
+            var isDeadKey = false;
             if (char.IsControl(c) )
             {
                 // We have the virtual key code and Windows has a handy api to map that to the non-control
@@ -226,7 +236,7 @@ namespace Microsoft.PowerShell
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     var keySansControl = new ConsoleKeyInfo(key.KeyChar, key.Key, isShift, isAlt, control: false);
-                    TryGetCharFromConsoleKey(keySansControl, ref c);
+                    TryGetCharFromConsoleKey(keySansControl, ref c, ref isDeadKey);
                 }
             }
             else if (isAlt && isCtrl)
@@ -268,15 +278,13 @@ namespace Microsoft.PowerShell
                     break;
 
                 case '\0':
-                    // On Windows:
-                    //   This could be a special kind of a modifier key (dead key) for a particular keyboard layout.
-                    //   We use the text form of the virtual key in such case, so the resulted PSKeyInfo can be converted back to ConsoleKeyInfo correctly later on,
-                    //   and be properly ignore during rendering.
-                    // On non-Windows:
-                    //   The dead key is not an issue when there is a tty involved.
-                    //   But the virtual key is not captured as accurately as on Windows, e.g. Ctrl+2 results in `key.Key = 0`.
-                    //   So on non-Windows, we use `@` in case `key.KeyChar = '\0'`. This is ugly but familiar.
-                    s = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? key.Key.ToString() : "@";
+                    // This could be a dead key for a particular keyboard layout in Windows console.
+                    // The dead key is not an issue when there is tty involved, so on non-Windows, `isDeadKey` is always false.
+                    //
+                    // When we believe it's a dead key, we use the text form of the virtual key so the resulted PSKeyInfo can be
+                    // converted back to ConsoleKeyInfo correctly later on, and be properly ignore during rendering.
+                    // Otherwise, we use `@` in case `key.KeyChar = '\0'`. This is ugly but familiar.
+                    s = isDeadKey ? key.Key.ToString() : "@";
                     break;
 
                 case char _ when (c >= 1 && c <= 26):

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -282,7 +282,7 @@ namespace Microsoft.PowerShell
                     // The dead key is not an issue when there is tty involved, so on non-Windows, `isDeadKey` is always false.
                     //
                     // When we believe it's a dead key, we use the text form of the virtual key so the resulted PSKeyInfo can be
-                    // converted back to ConsoleKeyInfo correctly later on, and be properly ignore during rendering.
+                    // converted back to ConsoleKeyInfo correctly later on, and be properly ignored during rendering.
                     // Otherwise, we use `@` in case `key.KeyChar = '\0'`. This is ugly but familiar.
                     s = isDeadKey ? key.Key.ToString() : "@";
                     break;

--- a/test/DeadKeyTest.cs
+++ b/test/DeadKeyTest.cs
@@ -13,6 +13,7 @@ namespace Test
 
             Test("aa", Keys("aa", _.DeadKey_Caret));
             Test("aab", Keys("aa", _.DeadKey_Caret, 'b'));
+            Test("aaâ", Keys("aa", _.DeadKey_Caret_A));
         }
     }
 }

--- a/test/DeadKeyTest.cs
+++ b/test/DeadKeyTest.cs
@@ -1,0 +1,21 @@
+using System;
+using Xunit;
+
+namespace Test
+{
+    public partial class ReadLine
+    {
+        [SkippableFact]
+        public void DeadKeyShouldBeIgnored()
+        {
+            Skip.If(this.Fixture.Lang != "fr-FR", "The dead key test requires Keyboard layout to be set to 'fr-FR'");
+            TestSetup(KeyMode.Cmd);
+
+            Test("aa", Keys("aa", _.DeadKey_Backtick));
+            Test("aab", Keys("aa", _.DeadKey_Backtick, 'b'));
+
+            Test("aa", Keys("aa", _.DeadKey_Tilde));
+            Test("aab", Keys("aa", _.DeadKey_Tilde, 'b'));
+        }
+    }
+}

--- a/test/DeadKeyTest.cs
+++ b/test/DeadKeyTest.cs
@@ -11,11 +11,8 @@ namespace Test
             Skip.If(this.Fixture.Lang != "fr-FR", "The dead key test requires Keyboard layout to be set to 'fr-FR'");
             TestSetup(KeyMode.Cmd);
 
-            Test("aa", Keys("aa", _.DeadKey_Backtick));
-            Test("aab", Keys("aa", _.DeadKey_Backtick, 'b'));
-
-            Test("aa", Keys("aa", _.DeadKey_Tilde));
-            Test("aab", Keys("aa", _.DeadKey_Tilde, 'b'));
+            Test("aa", Keys("aa", _.DeadKey_Caret));
+            Test("aab", Keys("aa", _.DeadKey_Caret, 'b'));
         }
     }
 }

--- a/test/KeyInfo-en-US-windows.json
+++ b/test/KeyInfo-en-US-windows.json
@@ -1414,17 +1414,5 @@
         "KeyChar":  "z",
         "ConsoleKey":  "Z",
         "Modifiers":  "0"
-    },
-    {
-        "Key":  "DeadKey_Backtick",
-        "KeyChar":  "\u0000",
-        "ConsoleKey":  "Oem3",
-        "Modifiers":  "0"
-    },
-    {
-        "Key":  "DeadKey_Tilde",
-        "KeyChar":  "\u0000",
-        "ConsoleKey":  "Oem3",
-        "Modifiers":  "Shift"
     }
 ]

--- a/test/KeyInfo-en-US-windows.json
+++ b/test/KeyInfo-en-US-windows.json
@@ -1414,5 +1414,17 @@
         "KeyChar":  "z",
         "ConsoleKey":  "Z",
         "Modifiers":  "0"
+    },
+    {
+        "Key":  "DeadKey_Backtick",
+        "KeyChar":  "\u0000",
+        "ConsoleKey":  "Oem3",
+        "Modifiers":  "0"
+    },
+    {
+        "Key":  "DeadKey_Tilde",
+        "KeyChar":  "\u0000",
+        "ConsoleKey":  "Oem3",
+        "Modifiers":  "Shift"
     }
 ]

--- a/test/KeyInfo-fr-FR-windows.json
+++ b/test/KeyInfo-fr-FR-windows.json
@@ -1636,5 +1636,19 @@
         "ConsoleKey":  "Z",
         "Modifiers":  "0",
         "Investigate":  false
+    },
+    {
+        "Key":  "DeadKey_Backtick",
+        "KeyChar":  "\u0000",
+        "ConsoleKey":  "D7",
+        "Modifiers":  "Alt",
+        "Investigate":  false
+    },
+    {
+        "Key":  "DeadKey_Tilde",
+        "KeyChar":  "\u0000",
+        "ConsoleKey":  "D2",
+        "Modifiers":  "Alt",
+        "Investigate":  false
     }
 ]

--- a/test/KeyInfo-fr-FR-windows.json
+++ b/test/KeyInfo-fr-FR-windows.json
@@ -1643,5 +1643,12 @@
         "ConsoleKey":  "Oem6",
         "Modifiers":  "0",
         "Investigate":  false
+    },
+    {
+        "Key":  "DeadKey_Caret+A",
+        "KeyChar":  "\u00e2",
+        "ConsoleKey":  "A",
+        "Modifiers":  "0",
+        "Investigate":  false
     }
 ]

--- a/test/KeyInfo-fr-FR-windows.json
+++ b/test/KeyInfo-fr-FR-windows.json
@@ -1638,17 +1638,10 @@
         "Investigate":  false
     },
     {
-        "Key":  "DeadKey_Backtick",
+        "Key":  "DeadKey_Caret",
         "KeyChar":  "\u0000",
-        "ConsoleKey":  "D7",
-        "Modifiers":  "Alt",
-        "Investigate":  false
-    },
-    {
-        "Key":  "DeadKey_Tilde",
-        "KeyChar":  "\u0000",
-        "ConsoleKey":  "D2",
-        "Modifiers":  "Alt",
+        "ConsoleKey":  "Oem6",
+        "Modifiers":  "0",
         "Investigate":  false
     }
 ]

--- a/test/KeyboardLayouts.cs
+++ b/test/KeyboardLayouts.cs
@@ -87,7 +87,7 @@ namespace Test
                 }
                 var key = (alt != null)
                     ? Key.Substring(0, Key.Length - 1) + alt
-                  : Key;
+                    : Key;
                 return key.Replace('+', '_');
             }
 


### PR DESCRIPTION
Fix #914

Fix the conversion from `ConsoleKeyInfo`/`PSKeyInfo` to `PSKeyInfo`/`ConsoleKeyInfo`, so that the dead keys of a particular keyboard layout can be properly ignored.

I have verified the fix with US International keyboard layout and French keyboard layout.