### PR TITLE
Make `Ctrl+[` bound-able on Windows

### DIFF
--- a/PSReadLine/ConsoleKeyChordConverter.cs
+++ b/PSReadLine/ConsoleKeyChordConverter.cs
@@ -221,6 +221,9 @@ namespace Microsoft.PowerShell
                 { "UpArrow",    new KeyPair { Key = ConsoleKey.UpArrow} },
             };
 
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        static extern short VkKeyScan(char ch);
+
         static bool MapKeyChar(string input, ref ConsoleModifiers mods, out ConsoleKey key, out char keyChar)
         {
             var isCtrl = (mods & ConsoleModifiers.Control) != 0;
@@ -243,7 +246,20 @@ namespace Microsoft.PowerShell
                 else
                 {
                     key = 0;
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        short vkKeyScan = VkKeyScan(keyChar);
+                        if (vkKeyScan != -1)
+                        {
+                            int vkCode = vkKeyScan & 0xff;
+                            if (typeof(ConsoleKey).IsEnumDefined(vkCode))
+                            {
+                                key = (ConsoleKey)vkCode;
+                            }
+                        }
+                    }
                 }
+
                 if (isCtrl)
                 {
                     switch (keyChar)

--- a/test/KeyBindingsTest.cs
+++ b/test/KeyBindingsTest.cs
@@ -61,5 +61,12 @@ namespace Test
             TestSetup(KeyMode.Cmd);
             Test("", Keys("aaa", _.Shift_Escape));
         }
+
+        [SkippableFact]
+        public void ControlLBracket()
+        {
+            TestSetup(KeyMode.Cmd, new KeyHandler("Ctrl+[", PSConsoleReadLine.BackwardDeleteChar));
+            Test("aa", Keys("aaa", _.Ctrl_LBracket));
+        }
     }
 }

--- a/test/KeyBindingsTest.cs
+++ b/test/KeyBindingsTest.cs
@@ -65,6 +65,7 @@ namespace Test
         [SkippableFact]
         public void ControlLBracket()
         {
+            // 'Ctrl+[' should work for key binding.
             Skip.If(this.Fixture.Lang != "en-us", "there is no real eqivalent of 'Ctrl+[' with the French keyboard layout");
             TestSetup(KeyMode.Cmd, new KeyHandler("Ctrl+[", PSConsoleReadLine.BackwardDeleteChar));
             Test("aa", Keys("aaa", _.Ctrl_LBracket));

--- a/test/KeyBindingsTest.cs
+++ b/test/KeyBindingsTest.cs
@@ -65,6 +65,7 @@ namespace Test
         [SkippableFact]
         public void ControlLBracket()
         {
+            Skip.If(this.Fixture.Lang != "en-us", "there is no real eqivalent of 'Ctrl+[' with the French keyboard layout");
             TestSetup(KeyMode.Cmd, new KeyHandler("Ctrl+[", PSConsoleReadLine.BackwardDeleteChar));
             Test("aa", Keys("aaa", _.Ctrl_LBracket));
         }


### PR DESCRIPTION
Fix #906
When converting `PSKeyInfo` to `ConsoleKeyInfo`, use `VkKeyScan` to get the virtual key more accurately.