### PR TITLE
Fix duplicate menu at end of buffer

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -471,9 +471,12 @@ namespace Microsoft.PowerShell
                 // Move cursor to the start of the first line after our input.
                 var bufferEndPoint = Singleton.ConvertOffsetToPoint(Singleton._buffer.Length);
                 console.SetCursorPosition(bufferEndPoint.X, bufferEndPoint.Y);
+                // Top must be initialized before calling AdjustForPossibleScroll, otherwise
+                // on the last line of the buffer, the scroll operation causes Top to point
+                // past the buffer, which in turn causes the menu to be printed twice.
+                this.Top = bufferEndPoint.Y + 1;
                 AdjustForPossibleScroll(1);
                 MoveCursorDown(1);
-                this.Top = bufferEndPoint.Y + 1;
 
                 var bufferWidth = console.BufferWidth;
                 var columnWidth = this.ColumnWidth;


### PR DESCRIPTION
This has been bugging me for a while, finally tracked it down. It's most apparent in tmux where the buffer and window size are always the same, but happens reliably at the end of the buffer (#598 back from the dead?).

Before the fix:
![old](https://user-images.githubusercontent.com/1094150/59295286-28ad1600-8c38-11e9-8ddf-d3444fb7fe81.png)

After the fix:
![new](https://user-images.githubusercontent.com/1094150/59295296-2f3b8d80-8c38-11e9-832d-aa1c765d91d5.png)