### PR TITLE
Update .csproj files to depend on 'netcoreapp 2.1.12' and 'Microsoft.PowerShell.SDK 6.2.2'

### DIFF
--- a/MockPSConsole/MockPSConsole.csproj
+++ b/MockPSConsole/MockPSConsole.csproj
@@ -9,12 +9,16 @@
     <ApplicationManifest>Program.manifest</ApplicationManifest>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <RuntimeFrameworkVersion>2.1.12</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Xml.XDocument" version="4.3.0" />
     <PackageReference Include="System.Data.DataSetExtensions" version="4.5.0" />
     <PackageReference Include="Microsoft.CSharp" version="4.5.0" />
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0-*" Condition="'$(TargetFramework)' == 'net461'" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" version="6.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" version="6.2.2" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -9,6 +9,11 @@
     <InformationalVersion>2.0.0-beta4</InformationalVersion>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <RuntimeFrameworkVersion>2.1.12</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0-*" />
     <PackageReference Include="Microsoft.CSharp" version="4.5.0-*" />

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -12,13 +12,17 @@
     <TestProjectType>UnitTest</TestProjectType>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <RuntimeFrameworkVersion>2.1.12</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Xml.XDocument" version="4.3.0" />
     <PackageReference Include="System.Data.DataSetExtensions" version="4.5.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" version="4.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.2" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0-*" Condition="'$(TargetFramework)' == 'net461'" />
   </ItemGroup>
 

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -1,5 +1,5 @@
 
-$MinimalSDKVersion = '2.1.300'
+$MinimalSDKVersion = '2.1.801'
 $IsWindowsEnv = [System.Environment]::OSVersion.Platform -eq "Win32NT"
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $LocalDotnetDirPath = if ($IsWindowsEnv) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }
@@ -68,7 +68,7 @@ function Install-Dotnet
     [CmdletBinding()]
     param(
         [string]$Channel = 'release',
-        [string]$Version = '2.1.505'
+        [string]$Version = '2.1.801'
     )
 
     try {
@@ -77,9 +77,9 @@ function Install-Dotnet
     } catch { }
 
     $logMsg = if (Get-Command 'dotnet' -ErrorAction Ignore) {
-        "dotent SDK is not present. Installing dotnet SDK."
-    } else {
         "dotnet SDK out of date. Require '$MinimalSDKVersion' but found '$dotnetSDKVersion'. Updating dotnet."
+    } else {
+        "dotent SDK is not present. Installing dotnet SDK."
     }
     Write-Log $logMsg -Warning
 


### PR DESCRIPTION
## Summary

Update .csproj files to depend on `netcoreapp 2.1.12` and `Microsoft.PowerShell.SDK 6.2.2`.
This is to address the compliance issues reported by Azure DevOps.