### PR TITLE
Correct highlight of replaced variables/splats with braces

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell
             {
                 if (IsQuotedVariable(s))
                 {
-                    return '$' + s.Substring(2, s.Length - 3);
+                    return s[0] + s.Substring(2, s.Length - 3);
                 }
                 return s;
             }
@@ -731,7 +731,7 @@ namespace Microsoft.PowerShell
 
         private int FindUserCompletionTextPosition(CompletionResult match, string userCompletionText)
         {
-            return match.ResultType == CompletionResultType.Variable && match.CompletionText[1] == '{'
+            return match.ResultType == CompletionResultType.Variable && userCompletionText.Length > 1 && match.CompletionText[1] == '{'
                 ? match.CompletionText.IndexOf(userCompletionText.Substring(1), StringComparison.OrdinalIgnoreCase) - 1
                 : match.CompletionText.IndexOf(userCompletionText, StringComparison.OrdinalIgnoreCase);
         }


### PR DESCRIPTION
- Prevent adjustment of `userCompletionText` in `FindUserCompletionTextPosition` when the match contains `{` in CompletionText[1] if the `userCompletionText` is not longer than 1 char
- Preserve the splat sigil at start of completions of type `Variable`.

Adjusting `userCompletionText` blindly led to `ArgumentOutOfRangeException` on incorrectly braced splats on input `@?`.
Loss of the sigil of splats led to the splat sigil always being marked as replaced, and in situations where the PowerShell completion logic returned incorrect completions of splats with braces, led to a `ArgumentOutOfRangeException`.

Fix #983.