### PR TITLE
Prioritize highlight of command names, prevent bleed from aligned nested tokens

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -215,7 +215,7 @@ namespace Microsoft.PowerShell
                     // use the tokens color otherwise use the initial color.
                     var state = tokenStack.Peek();
                     var token = state.Tokens[state.Index];
-                    if (i == token.Extent.EndOffset)
+                    while (i == token.Extent.EndOffset)
                     {
                         if (token == state.Tokens[state.Tokens.Length - 1])
                         {

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -630,6 +630,11 @@ namespace Microsoft.PowerShell
 
         private string GetTokenColor(Token token)
         {
+            if ((token.TokenFlags & TokenFlags.CommandName) != 0)
+            {
+                return _options._commandColor;
+            }
+
             switch (token.Kind)
             {
             case TokenKind.Comment:
@@ -651,11 +656,6 @@ namespace Microsoft.PowerShell
 
             case TokenKind.Number:
                 return _options._numberColor;
-            }
-
-            if ((token.TokenFlags & TokenFlags.CommandName) != 0)
-            {
-                return _options._commandColor;
             }
 
             if ((token.TokenFlags & TokenFlags.Keyword) != 0)

--- a/test/RenderTest.cs
+++ b/test/RenderTest.cs
@@ -54,6 +54,39 @@ namespace Test
                 InputAcceptedNow
                 ));
 
+            // This tests for priority to highlight a command regardless of token kind and nested tokens potential to bleed the parent token color to the next token
+            Test("", Keys(
+                ". -abc def;. abc$name -def",
+                _.Home,
+                CheckThat(() =>
+                    AssertScreenIs(1,
+                        TokenClassification.None, ". ",
+                        TokenClassification.Command, "-abc",
+                        TokenClassification.None, " def;. ",
+                        TokenClassification.Command, "abc",
+                        TokenClassification.Variable, "$name",
+                        TokenClassification.None, " ",
+                        TokenClassification.Parameter, "-def")),
+                _.Ctrl_c,
+                InputAcceptedNow
+                ));
+
+            // Additional test for priority to highlight a command regardless of token kind and nested tokens potential to bleed the parent token color to the next token
+            Test("", Keys(
+                ". ++ abc$name -def",
+                _.Home,
+                CheckThat(() =>
+                    AssertScreenIs(1,
+                        TokenClassification.None, ". ",
+                        TokenClassification.Command, "++",
+                        TokenClassification.None, " abc",
+                        TokenClassification.Variable, "$name",
+                        TokenClassification.None, " ",
+                        TokenClassification.Parameter, "-def")),
+                _.Ctrl_c,
+                InputAcceptedNow
+                ));
+
             Test("", Keys(
                 "\"$([int];\"_$(1+2)\")\"",
                 CheckThat(() =>


### PR DESCRIPTION
Referencing #836, 
- Prioritize the selection of the command color when a token is flagged as 'CommandName'. (to handle a parameter token that is flagged as a command name, it is really a command name)  
- Prevent the bleed of a token with nested tokens in to the rest of the statement.