### PR TITLE
Operator Highlight in ArgumentMode

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -663,7 +663,7 @@ namespace Microsoft.PowerShell
                 return _options._keywordColor;
             }
 
-            if ((token.TokenFlags & (TokenFlags.BinaryOperator | TokenFlags.UnaryOperator | TokenFlags.AssignmentOperator)) != 0)
+            if (token.Kind != TokenKind.Generic && (token.TokenFlags & (TokenFlags.BinaryOperator | TokenFlags.UnaryOperator | TokenFlags.AssignmentOperator)) != 0)
             {
                 return _options._operatorColor;
             }

--- a/test/RenderTest.cs
+++ b/test/RenderTest.cs
@@ -37,7 +37,7 @@ namespace Test
             TestSetup(KeyMode.Cmd);
 
             Test("", Keys(
-                "abc -def <#123#> \"hello $name\"",
+                "abc -def <#123#> \"hello $name\" 1 + (1-2)",
                 _.Home,
                 CheckThat(() =>
                     AssertScreenIs(1,
@@ -49,7 +49,14 @@ namespace Test
                         TokenClassification.None, " ",
                         TokenClassification.String, "\"hello ",
                         TokenClassification.Variable, "$name",
-                        TokenClassification.String, "\"")),
+                        TokenClassification.String, "\"",
+                        TokenClassification.None, " ",
+                        TokenClassification.Number, "1",
+                        TokenClassification.None, " + (",
+                        TokenClassification.Number, "1",
+                        TokenClassification.Operator, "-",
+                        TokenClassification.Number, "2",
+                        TokenClassification.None, ")")),
                 _.Ctrl_c,
                 InputAcceptedNow
                 ));


### PR DESCRIPTION
Operators shouldn't highlight in argument mode.

See https://github.com/PowerShell/PowerShell/issues/10348

Operators as TokenKind `Generic` are not actually operators.  This PR restricts the operator token detection to just those tokens that are not TokenKind `Generic`.

Fix #1002.