### PR TITLE
Fix arrow-up when the cursor is at the end of a wrapped line in a multiple-line text

### DIFF
--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -82,7 +82,8 @@ namespace Microsoft.PowerShell
             //  - If the cursor is at the end of a logical line, then 'UpArrow' (or 'DownArrow') moves the cursor up (or down)
             //    'lineOffset' numbers of logical lines, and the cursor is always put at the end of the new logical line.
             //  - If the cursor is NOT at the end of a logical line, then 'UpArrow' (or 'DownArrow') moves the cursor up (or down)
-            //    'lineOffset' numbers of physical lines, and the cursor is always placed at the same column as is now.
+            //    'lineOffset' numbers of physical lines, and the cursor is always placed at the same column as is now, or at the
+            //    end of line if that physical line is shorter than the targeted column.
 
             const int endOfLine = int.MaxValue;
 

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -78,6 +78,12 @@ namespace Microsoft.PowerShell
 
         private void MoveToLine(int lineOffset)
         {
+            // Behavior description:
+            //  - If the cursor is at the end of a logical line, then 'UpArrow' (or 'DownArrow') moves the cursor up (or down)
+            //    'lineOffset' numbers of logical lines, and the cursor is always put at the end of the new logical line.
+            //  - If the cursor is NOT at the end of a logical line, then 'UpArrow' (or 'DownArrow') moves the cursor up (or down)
+            //    'lineOffset' numbers of physical lines, and the cursor is always placed at the same column as is now.
+
             const int endOfLine = int.MaxValue;
 
             Point? point = null;

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -76,18 +76,18 @@ namespace Microsoft.PowerShell
             }
         }
 
-        private void MoveToLine(int numericArg)
+        private void MoveToLine(int lineOffset)
         {
             const int endOfLine = int.MaxValue;
 
             // Actually not moving the line.
-            if (numericArg == 0)
+            if (lineOffset == 0)
             {
                 return;
             }
 
             // Moving the line down when it's actually at the end of the last line.
-            if (numericArg > 0 && _current == _buffer.Length)
+            if (lineOffset > 0 && _current == _buffer.Length)
             {
                 return;
             }
@@ -107,10 +107,10 @@ namespace Microsoft.PowerShell
             {
                 newCurrent = _current;
 
-                if (numericArg > 0)
+                if (lineOffset > 0)
                 {
-                    // Moving to a subsequent line.
-                    for (int i = 0; i < numericArg; i++)
+                    // Moving to the end of a subsequent logical line.
+                    for (int i = 0; i < lineOffset; i++)
                     {
                         for (newCurrent++; newCurrent < _buffer.Length && _buffer[newCurrent] != '\n'; newCurrent++) ;
 
@@ -122,9 +122,9 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    // Moving to a previous line.
+                    // Moving to the end of a previous logical line.
                     int lastEndOfLineIndex = _current;
-                    for (int i = 0; i < -numericArg; i++)
+                    for (int i = 0; i < -lineOffset; i++)
                     {
                         for (newCurrent--; newCurrent >= 0 && _buffer[newCurrent] != '\n'; newCurrent--) ;
 
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                int newY = point.Y + numericArg;
+                int newY = point.Y + lineOffset;
                 point.Y = Math.Max(newY, _initialY);
                 point.X = _moveToLineDesiredColumn;
 


### PR DESCRIPTION
Fix #1020

When the cursor is at the end of a wrapped line, <kbd>Up</kbd> key sets the potential new cursor position to the previous physical line, and then calculates the end of the logical line rendered in that physical line, and eventually ends up in the same old cursor position.
That's why <kbd>Up</kbd> at the end of a warped line doesn't work.
The fix is to not depend on the physical line position when the original cursor is at the end of line, but directly search back (for <kbd>Up</kbd>) and search forward (for <kbd>Down</kbd>) for new line characters.