### PR TITLE
Make PageUp/PageDown and CtrlPageUp/CtrlPageDown windows only

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -341,7 +341,7 @@ namespace Microsoft.PowerShell
                 // API 'Console.SetWindowPosition', which throws 'PlatformNotSupportedException' on unix platforms.
                 _dispatchTable.Add(Keys.PageUp,       MakeKeyHandler(ScrollDisplayUp,       "ScrollDisplayUp"));
                 _dispatchTable.Add(Keys.PageDown,     MakeKeyHandler(ScrollDisplayDown,     "ScrollDisplayDown"));
-                _dispatchTable.Add(Keys.CtrlPageUp,   MakeKeyHandler(ScrollDisplayUpLine, "ScrollDisplayUpLine"));
+                _dispatchTable.Add(Keys.CtrlPageUp,   MakeKeyHandler(ScrollDisplayUpLine,   "ScrollDisplayUpLine"));
                 _dispatchTable.Add(Keys.CtrlPageDown, MakeKeyHandler(ScrollDisplayDownLine, "ScrollDisplayDownLine"));
             }
             else

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -236,21 +236,20 @@ namespace Microsoft.PowerShell
             };
 
             // Some bindings are not available on certain platforms
-            // For example, PageUp/PageDown and CtrlPageUp/CtrlPageDown bindings are supported on Windows only because
-            //  1. On Linux, 'Console.SetWindowPosition' throws 'PlatformNotSupportedException'.
-            //  2. On macOS, 'PageUp' and 'PageDown' get intercepted by the terminal and move the terminal window up or down for one page.
-            //     'Ctrl+PageUp' and 'Ctrl+PageDown' are also intercepted by the terminal and do the same as 'PageUp' and 'PageDown'.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                _dispatchTable.Add(Keys.CtrlSpace,  MakeKeyHandler(MenuComplete,       "MenuComplete"));
+                _dispatchTable.Add(Keys.AltF7,      MakeKeyHandler(ClearHistory,       "ClearHistory"));
+                _dispatchTable.Add(Keys.CtrlDelete, MakeKeyHandler(KillWord,           "KillWord"));
+                _dispatchTable.Add(Keys.CtrlEnd,    MakeKeyHandler(ForwardDeleteLine,  "ForwardDeleteLine"));
+                _dispatchTable.Add(Keys.CtrlH,      MakeKeyHandler(BackwardDeleteChar, "BackwardDeleteChar"));
+
+                // PageUp/PageDown and CtrlPageUp/CtrlPageDown bindings are supported on Windows only because they depend on the
+                // API 'Console.SetWindowPosition', which throws 'PlatformNotSupportedException' on unix platforms.
                 _dispatchTable.Add(Keys.PageUp,       MakeKeyHandler(ScrollDisplayUp,       "ScrollDisplayUp"));
                 _dispatchTable.Add(Keys.PageDown,     MakeKeyHandler(ScrollDisplayDown,     "ScrollDisplayDown"));
                 _dispatchTable.Add(Keys.CtrlPageUp,   MakeKeyHandler(ScrollDisplayUpLine,   "ScrollDisplayUpLine"));
                 _dispatchTable.Add(Keys.CtrlPageDown, MakeKeyHandler(ScrollDisplayDownLine, "ScrollDisplayDownLine"));
-                _dispatchTable.Add(Keys.CtrlSpace,    MakeKeyHandler(MenuComplete,          "MenuComplete"));
-                _dispatchTable.Add(Keys.AltF7,        MakeKeyHandler(ClearHistory,          "ClearHistory"));
-                _dispatchTable.Add(Keys.CtrlDelete,   MakeKeyHandler(KillWord,              "KillWord"));
-                _dispatchTable.Add(Keys.CtrlEnd,      MakeKeyHandler(ForwardDeleteLine,     "ForwardDeleteLine"));
-                _dispatchTable.Add(Keys.CtrlH,        MakeKeyHandler(BackwardDeleteChar,    "BackwardDeleteChar"));
             }
 
             _chordDispatchTable = new Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>>();
@@ -331,20 +330,19 @@ namespace Microsoft.PowerShell
             };
 
             // Some bindings are not available on certain platforms
-            // For example, PageUp/PageDown and CtrlPageUp/CtrlPageDown bindings are supported on Windows only because
-            //  1. On Linux, 'Console.SetWindowPosition' throws 'PlatformNotSupportedException'.
-            //  2. On macOS, 'PageUp' and 'PageDown' get intercepted by the terminal and move the terminal window up or down for one page.
-            //     'Ctrl+PageUp' and 'Ctrl+PageDown' are also intercepted by the terminal and do the same as 'PageUp' and 'PageDown'.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 _dispatchTable.Add(Keys.CtrlH,        MakeKeyHandler(BackwardDeleteChar,    "BackwardDeleteChar"));
                 _dispatchTable.Add(Keys.CtrlSpace,    MakeKeyHandler(MenuComplete,          "MenuComplete"));
                 _dispatchTable.Add(Keys.CtrlEnd,      MakeKeyHandler(ScrollDisplayToCursor, "ScrollDisplayToCursor"));
                 _dispatchTable.Add(Keys.CtrlHome,     MakeKeyHandler(ScrollDisplayTop,      "ScrollDisplayTop"));
+
+                // PageUp/PageDown and CtrlPageUp/CtrlPageDown bindings are supported on Windows only because they depend on the
+                // API 'Console.SetWindowPosition', which throws 'PlatformNotSupportedException' on unix platforms.
                 _dispatchTable.Add(Keys.PageUp,       MakeKeyHandler(ScrollDisplayUp,       "ScrollDisplayUp"));
                 _dispatchTable.Add(Keys.PageDown,     MakeKeyHandler(ScrollDisplayDown,     "ScrollDisplayDown"));
+                _dispatchTable.Add(Keys.CtrlPageUp,   MakeKeyHandler(ScrollDisplayUpLine, "ScrollDisplayUpLine"));
                 _dispatchTable.Add(Keys.CtrlPageDown, MakeKeyHandler(ScrollDisplayDownLine, "ScrollDisplayDownLine"));
-                _dispatchTable.Add(Keys.CtrlPageUp,   MakeKeyHandler(ScrollDisplayUpLine,   "ScrollDisplayUpLine"));
             }
             else
             {

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -229,10 +229,6 @@ namespace Microsoft.PowerShell
                 { Keys.ShiftF3,                MakeKeyHandler(CharacterSearchBackward,   "CharacterSearchBackward") },
                 { Keys.F8,                     MakeKeyHandler(HistorySearchBackward,     "HistorySearchBackward") },
                 { Keys.ShiftF8,                MakeKeyHandler(HistorySearchForward,      "HistorySearchForward") },
-                { Keys.PageUp,                 MakeKeyHandler(ScrollDisplayUp,           "ScrollDisplayUp") },
-                { Keys.PageDown,               MakeKeyHandler(ScrollDisplayDown,         "ScrollDisplayDown") },
-                { Keys.CtrlPageUp,             MakeKeyHandler(ScrollDisplayUpLine,       "ScrollDisplayUpLine") },
-                { Keys.CtrlPageDown,           MakeKeyHandler(ScrollDisplayDownLine,     "ScrollDisplayDownLine") },
                 // Added for xtermjs-based terminals that send different key combinations.
                 { Keys.AltD,                   MakeKeyHandler(KillWord,                  "KillWord") },
                 { Keys.CtrlAt,                 MakeKeyHandler(MenuComplete,              "MenuComplete") },
@@ -242,11 +238,15 @@ namespace Microsoft.PowerShell
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                _dispatchTable.Add(Keys.CtrlSpace,  MakeKeyHandler(MenuComplete,      "MenuComplete"));
-                _dispatchTable.Add(Keys.AltF7,      MakeKeyHandler(ClearHistory,      "ClearHistory"));
-                _dispatchTable.Add(Keys.CtrlDelete, MakeKeyHandler(KillWord,          "KillWord"));
-                _dispatchTable.Add(Keys.CtrlEnd,    MakeKeyHandler(ForwardDeleteLine, "ForwardDeleteLine"));
-                _dispatchTable.Add(Keys.CtrlH,      MakeKeyHandler(BackwardDeleteChar,"BackwardDeleteChar"));
+                _dispatchTable.Add(Keys.PageUp,       MakeKeyHandler(ScrollDisplayUp,       "ScrollDisplayUp"));
+                _dispatchTable.Add(Keys.PageDown,     MakeKeyHandler(ScrollDisplayDown,     "ScrollDisplayDown"));
+                _dispatchTable.Add(Keys.CtrlPageUp,   MakeKeyHandler(ScrollDisplayUpLine,   "ScrollDisplayUpLine"));
+                _dispatchTable.Add(Keys.CtrlPageDown, MakeKeyHandler(ScrollDisplayDownLine, "ScrollDisplayDownLine"));
+                _dispatchTable.Add(Keys.CtrlSpace,    MakeKeyHandler(MenuComplete,          "MenuComplete"));
+                _dispatchTable.Add(Keys.AltF7,        MakeKeyHandler(ClearHistory,          "ClearHistory"));
+                _dispatchTable.Add(Keys.CtrlDelete,   MakeKeyHandler(KillWord,              "KillWord"));
+                _dispatchTable.Add(Keys.CtrlEnd,      MakeKeyHandler(ForwardDeleteLine,     "ForwardDeleteLine"));
+                _dispatchTable.Add(Keys.CtrlH,        MakeKeyHandler(BackwardDeleteChar,    "BackwardDeleteChar"));
             }
 
             _chordDispatchTable = new Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>>();
@@ -324,8 +324,6 @@ namespace Microsoft.PowerShell
                 { Keys.AltPeriod,       MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.AltUnderbar,     MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.CtrlAltY,        MakeKeyHandler(YankNthArg,           "YankNthArg") },
-                { Keys.PageUp,          MakeKeyHandler(ScrollDisplayUp,      "ScrollDisplayUp") },
-                { Keys.PageDown,        MakeKeyHandler(ScrollDisplayDown,    "ScrollDisplayDown") },
             };
 
             // Some bindings are not available on certain platforms
@@ -335,6 +333,8 @@ namespace Microsoft.PowerShell
                 _dispatchTable.Add(Keys.CtrlSpace,    MakeKeyHandler(MenuComplete,          "MenuComplete"));
                 _dispatchTable.Add(Keys.CtrlEnd,      MakeKeyHandler(ScrollDisplayToCursor, "ScrollDisplayToCursor"));
                 _dispatchTable.Add(Keys.CtrlHome,     MakeKeyHandler(ScrollDisplayTop,      "ScrollDisplayTop"));
+                _dispatchTable.Add(Keys.PageUp,       MakeKeyHandler(ScrollDisplayUp,       "ScrollDisplayUp"));
+                _dispatchTable.Add(Keys.PageDown,     MakeKeyHandler(ScrollDisplayDown,     "ScrollDisplayDown"));
                 _dispatchTable.Add(Keys.CtrlPageDown, MakeKeyHandler(ScrollDisplayDownLine, "ScrollDisplayDownLine"));
                 _dispatchTable.Add(Keys.CtrlPageUp,   MakeKeyHandler(ScrollDisplayUpLine,   "ScrollDisplayUpLine"));
             }

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -238,11 +238,11 @@ namespace Microsoft.PowerShell
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                _dispatchTable.Add(Keys.CtrlSpace,  MakeKeyHandler(MenuComplete,       "MenuComplete"));
-                _dispatchTable.Add(Keys.AltF7,      MakeKeyHandler(ClearHistory,       "ClearHistory"));
-                _dispatchTable.Add(Keys.CtrlDelete, MakeKeyHandler(KillWord,           "KillWord"));
-                _dispatchTable.Add(Keys.CtrlEnd,    MakeKeyHandler(ForwardDeleteLine,  "ForwardDeleteLine"));
-                _dispatchTable.Add(Keys.CtrlH,      MakeKeyHandler(BackwardDeleteChar, "BackwardDeleteChar"));
+                _dispatchTable.Add(Keys.CtrlSpace,  MakeKeyHandler(MenuComplete,      "MenuComplete"));
+                _dispatchTable.Add(Keys.AltF7,      MakeKeyHandler(ClearHistory,      "ClearHistory"));
+                _dispatchTable.Add(Keys.CtrlDelete, MakeKeyHandler(KillWord,          "KillWord"));
+                _dispatchTable.Add(Keys.CtrlEnd,    MakeKeyHandler(ForwardDeleteLine, "ForwardDeleteLine"));
+                _dispatchTable.Add(Keys.CtrlH,      MakeKeyHandler(BackwardDeleteChar,"BackwardDeleteChar"));
 
                 // PageUp/PageDown and CtrlPageUp/CtrlPageDown bindings are supported on Windows only because they depend on the
                 // API 'Console.SetWindowPosition', which throws 'PlatformNotSupportedException' on unix platforms.

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -236,6 +236,10 @@ namespace Microsoft.PowerShell
             };
 
             // Some bindings are not available on certain platforms
+            // For example, PageUp/PageDown and CtrlPageUp/CtrlPageDown bindings are supported on Windows only because
+            //  1. On Linux, 'Console.SetWindowPosition' throws 'PlatformNotSupportedException'.
+            //  2. On macOS, 'PageUp' and 'PageDown' get intercepted by the terminal and move the terminal window up or down for one page.
+            //     'Ctrl+PageUp' and 'Ctrl+PageDown' are also intercepted by the terminal and do the same as 'PageUp' and 'PageDown'.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 _dispatchTable.Add(Keys.PageUp,       MakeKeyHandler(ScrollDisplayUp,       "ScrollDisplayUp"));
@@ -327,6 +331,10 @@ namespace Microsoft.PowerShell
             };
 
             // Some bindings are not available on certain platforms
+            // For example, PageUp/PageDown and CtrlPageUp/CtrlPageDown bindings are supported on Windows only because
+            //  1. On Linux, 'Console.SetWindowPosition' throws 'PlatformNotSupportedException'.
+            //  2. On macOS, 'PageUp' and 'PageDown' get intercepted by the terminal and move the terminal window up or down for one page.
+            //     'Ctrl+PageUp' and 'Ctrl+PageDown' are also intercepted by the terminal and do the same as 'PageUp' and 'PageDown'.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 _dispatchTable.Add(Keys.CtrlH,        MakeKeyHandler(BackwardDeleteChar,    "BackwardDeleteChar"));


### PR DESCRIPTION
Make PageUp/PageDown and CtrlPageUp/CtrlPageDown windows only because
1. On Linux and macOS, `Console.SetWindowPosition` throw `PlatformNotSupportedException`.
2. On macOS, <kbd>PageUp</kbd> and <kbd>PageDown</kbd> get intercepted by the terminal and perform the same behavior as moving one page up or down.
    <kbd>Ctrl+PageUp</kbd> and <kbd>Ctrl+PageDown</kbd> are also intercepted by the terminal and do the same as <kbd>PageUp</kbd> and <kbd>PageDown</kbd>

Fix #1016