### PR TITLE
Fix GenerateRender

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -242,8 +242,8 @@ namespace Microsoft.PowerShell
 
                                 // It's possible that a 'StringExpandableToken' is the last available token, for example:
                                 //   'begin $a\abc def', 'process $a\abc | blah' and 'end $a\abc; hello'
-                                // due to the special handling of the keywords 'begin', 'process' and 'end', all the above 3 script input
-                                // generates 2 tokens only by parser -- A KeywordToken, and a StringExpandableToken '$a\abc'. Text after
+                                // due to the special handling of the keywords 'begin', 'process' and 'end', all the above 3 script inputs
+                                // generate only 2 tokens by the parser -- A KeywordToken, and a StringExpandableToken '$a\abc'. Text after
                                 // '$a\abc' is not tokenized at all.
                                 // We repeat the test to see if we fall into this case ('token' is the final one in the stack).
                                 continue;

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -238,10 +238,28 @@ namespace Microsoft.PowerShell
                             else
                             {
                                 state = tokenStack.Peek();
+                                if (state.Index == state.Tokens.Length - 1)
+                                {
+                                    // It's possible that a 'StringExpandableToken' is the last available token, for example:
+                                    //   'begin $a\abc def', 'process $a\abc | blah' and 'end $a\abc; hello'
+                                    // due to the special handling of the keywords 'begin', 'process' and 'end', all the above 3 script input
+                                    // generates 2 tokens only by parser -- A KeywordToken, and a StringExpandableToken '$a\abc'. Text after
+                                    // '$a\abc' is not tokenized at all.
+                                    //
+                                    // In this case, we assign the StringExpandableToken to 'token' variable again, so we can get in this loop
+                                    // again and pop the next token group from the stack.
+                                    color = state.Color;
+                                    token = state.Tokens[state.Index];
+                                    continue;
+                                }
                             }
                         }
 
-                        if (!afterLastToken)
+                        if (afterLastToken)
+                        {
+                            break;
+                        }
+                        else
                         {
                             color = state.Color;
                             token = state.Tokens[++state.Index];

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -226,7 +226,7 @@ namespace Microsoft.PowerShell
                     var token = state.Tokens[state.Index];
                     while (i == token.Extent.EndOffset)
                     {
-                        if (token == state.Tokens[state.Tokens.Length - 1])
+                        if (state.Index == state.Tokens.Length - 1)
                         {
                             tokenStack.Pop();
                             if (tokenStack.Count == 0)
@@ -234,36 +234,24 @@ namespace Microsoft.PowerShell
                                 afterLastToken = true;
                                 token = null;
                                 color = defaultColor;
+                                break;
                             }
                             else
                             {
                                 state = tokenStack.Peek();
-                                if (state.Index == state.Tokens.Length - 1)
-                                {
-                                    // It's possible that a 'StringExpandableToken' is the last available token, for example:
-                                    //   'begin $a\abc def', 'process $a\abc | blah' and 'end $a\abc; hello'
-                                    // due to the special handling of the keywords 'begin', 'process' and 'end', all the above 3 script input
-                                    // generates 2 tokens only by parser -- A KeywordToken, and a StringExpandableToken '$a\abc'. Text after
-                                    // '$a\abc' is not tokenized at all.
-                                    //
-                                    // In this case, we assign the StringExpandableToken to 'token' variable again, so we can get in this loop
-                                    // again and pop the next token group from the stack.
-                                    color = state.Color;
-                                    token = state.Tokens[state.Index];
-                                    continue;
-                                }
+
+                                // It's possible that a 'StringExpandableToken' is the last available token, for example:
+                                //   'begin $a\abc def', 'process $a\abc | blah' and 'end $a\abc; hello'
+                                // due to the special handling of the keywords 'begin', 'process' and 'end', all the above 3 script input
+                                // generates 2 tokens only by parser -- A KeywordToken, and a StringExpandableToken '$a\abc'. Text after
+                                // '$a\abc' is not tokenized at all.
+                                // We repeat the test to see if we fall into this case ('token' is the final one in the stack).
+                                continue;
                             }
                         }
 
-                        if (afterLastToken)
-                        {
-                            break;
-                        }
-                        else
-                        {
-                            color = state.Color;
-                            token = state.Tokens[++state.Index];
-                        }
+                        color = state.Color;
+                        token = state.Tokens[++state.Index];
                     }
 
                     if (!afterLastToken && i == token.Extent.StartOffset)

--- a/test/RenderTest.cs
+++ b/test/RenderTest.cs
@@ -94,6 +94,30 @@ namespace Test
                 InputAcceptedNow
                 ));
 
+            // test that rendering doesn't cause an exception in a potential missing "EOS" token case.
+            // this case could be a moving target, if the PowerShell parser is changed such as to eliminate the case.
+            Test("", Keys(
+                "process $abc\\name | def",
+                CheckThat(() =>
+                    AssertScreenIs(1,
+                        TokenClassification.Keyword, "process",
+                        TokenClassification.None, " ",
+                        TokenClassification.Variable, "$abc",
+                        TokenClassification.None, "\\name | def")),
+                _.Ctrl_c,
+                InputAcceptedNow
+                ));
+
+            Test("", Keys(
+                "process out put",
+                CheckThat(() =>
+                    AssertScreenIs(1,
+                        TokenClassification.Keyword, "process",
+                        TokenClassification.None, " out put")),
+                _.Ctrl_c,
+                InputAcceptedNow
+                ));
+
             Test("", Keys(
                 "\"$([int];\"_$(1+2)\")\"",
                 CheckThat(() =>


### PR DESCRIPTION
Fix #911

Fix two issues:
1. `process $a\b ` results in `IndexOutOfRangeException`. Fixed by the `continue` change.
2. `process out ` results in `NullReferenceException`. Fixed by the `break` change.

/cc @msftrncs 