### PR TITLE
Alternate: Fix IndexOutOfRangeException in GenerateRender

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -226,7 +226,7 @@ namespace Microsoft.PowerShell
                     var token = state.Tokens[state.Index];
                     while (i == token.Extent.EndOffset)
                     {
-                        if (token == state.Tokens[state.Tokens.Length - 1])
+                        if (state.Index == state.Tokens.Length - 1)
                         {
                             tokenStack.Pop();
                             if (tokenStack.Count == 0)
@@ -234,18 +234,19 @@ namespace Microsoft.PowerShell
                                 afterLastToken = true;
                                 token = null;
                                 color = defaultColor;
+                                break;
                             }
                             else
                             {
                                 state = tokenStack.Peek();
+                                // Repeat the test to see if this is the final token
+                                // in the stack incase of missing "EOS" token.
+                                continue;
                             }
                         }
 
-                        if (!afterLastToken)
-                        {
-                            color = state.Color;
-                            token = state.Tokens[++state.Index];
-                        }
+                        color = state.Color;
+                        token = state.Tokens[++state.Index];
                     }
 
                     if (!afterLastToken && i == token.Extent.StartOffset)

--- a/test/RenderTest.cs
+++ b/test/RenderTest.cs
@@ -94,6 +94,14 @@ namespace Test
                 InputAcceptedNow
                 ));
 
+            // test that rendering doesn't cause an exception in a potential missing "EOS" token case.
+            // this case could be a moving target, if the PowerShell parser is changed such as to eliminate the case.
+            Test("", Keys(
+                "process $abc\\name | out-null",
+                _.Ctrl_c,
+                InputAcceptedNow
+                ));
+
             Test("", Keys(
                 "\"$([int];\"_$(1+2)\")\"",
                 CheckThat(() =>


### PR DESCRIPTION
Offering slightly different, but really the same, fix for #911, along with a test, but with less explanation.

/cc: @daxian-dbw