### PR TITLE
Make the history file mutext name unique across sessions

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Reflection;
@@ -648,9 +647,7 @@ namespace Microsoft.PowerShell
             get => _historySavePath;
             set
             {
-                // Normalize the path
-                var altPathChar = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '/' : '\\';
-                _historySavePath = value?.Replace(altPathChar, Path.DirectorySeparatorChar);
+                _historySavePath = GetUnresolvedProviderPathFromPSPath(value);
             }
         }
         private string _historySavePath;

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -27,16 +27,19 @@ namespace Microsoft.PowerShell
 
         internal static uint ComputeHash(string input)
         {
-            uint hash = FNV32_OFFSETBASIS;
+            char ch;
+            uint hash = FNV32_OFFSETBASIS, lowByte, highByte;
+
             for (int i = 0; i < input.Length; i++)
             {
-                char c = input[i];
-                uint lowByte = (uint)(c & 0x00FF);
+                ch = input[i];
+                lowByte = (uint)(ch & 0x00FF);
                 hash = (hash ^ lowByte) * FNV32_PRIME;
 
-                uint highByte = (uint)(c >> 8);
+                highByte = (uint)(ch >> 8);
                 hash = (hash ^ highByte) * FNV32_PRIME;
             }
+
             return hash;
         }
     }

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -15,6 +15,65 @@ using Microsoft.PowerShell.PSReadLine;
 
 namespace Microsoft.PowerShell
 {
+    /// <summary>
+    /// A simple implementation of CRC32.
+    /// See "CRC-32 algorithm" in https://en.wikipedia.org/wiki/Cyclic_redundancy_check.
+    /// </summary>
+    internal class CRC32Hash
+    {
+        // CRC-32C polynomial representations
+        private const uint polynomial = 0x1EDC6F41;
+        private static uint[] table;
+
+        static CRC32Hash()
+        {
+            uint temp = 0;
+            table = new uint[256];
+
+            for (int i = 0; i < table.Length; i++)
+            {
+                temp = (uint)i;
+                for (int j = 0; j < 8; j++)
+                {
+                    if ((temp & 1) == 1)
+                    {
+                        temp = (temp >> 1) ^ polynomial;
+                    }
+                    else
+                    {
+                        temp >>= 1;
+                    }
+                }
+
+                table[i] = temp;
+            }
+        }
+
+        private static uint Compute(byte[] buffer)
+        {
+            uint crc = 0xFFFFFFFF;
+            for (int i = 0; i < buffer.Length; ++i)
+            {
+                var index = (byte)(crc ^ buffer[i] & 0xff);
+                crc = (crc >> 8) ^ table[index];
+            }
+
+            return ~crc;
+        }
+
+        internal static byte[] ComputeHash(byte[] buffer)
+        {
+            uint crcResult = Compute(buffer);
+            return BitConverter.GetBytes(crcResult);
+        }
+
+        internal static string ComputeHash(string input)
+        {
+            byte[] hashBytes = ComputeHash(Encoding.UTF8.GetBytes(input));
+            return BitConverter.ToString(hashBytes).Replace("-", string.Empty);
+        }
+    }
+
     public partial class PSConsoleReadLine
     {
         /// <summary>
@@ -182,7 +241,7 @@ namespace Microsoft.PowerShell
         {
             // Return a reasonably unique name - it's not too important as there will rarely
             // be any contention.
-            return "PSReadLineHistoryFile_" + _options.HistorySavePath.GetHashCode();
+            return "PSReadLineHistoryFile_" + CRC32Hash.ComputeHash(_options.HistorySavePath);
         }
 
         private void IncrementalHistoryWrite()


### PR DESCRIPTION
`GetHistorySaveFileMutexName()` uses `GetHashCode()` to construct the mutex name.
`GetHashCode()` in .NET Core returns a value that is unique in the current process only, and it results in different mutex name being used for different pwsh sessions for the history file.

The `FNV-1a` hashing algorithm is used (32-bit) to provide a consistent hash code across different pwsh sessions.