### PR TITLE
Handle 'PSObject' correctly so that script block handlers works for 'AddToHistoryHandler'

### DIFF
--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -137,15 +137,27 @@ namespace Microsoft.PowerShell
                 }
 
                 object value = Options.AddToHistoryHandler(line);
+                if (value is PSObject psObj)
+                {
+                    value = psObj.BaseObject;
+                }
 
-                if (LanguagePrimitives.TryConvertTo(value, out AddToHistoryOption enumValue))
+                if (value is bool boolValue)
+                {
+                    return boolValue ? AddToHistoryOption.MemoryAndFile : AddToHistoryOption.SkipAdding;
+                }
+
+                if (value is AddToHistoryOption enumValue)
                 {
                     return enumValue;
                 }
 
-                if (value is bool boolValue && !boolValue)
+                // 'TryConvertTo' incurs exception handling when the value cannot be converted to the target type.
+                // It's expensive, especially when we need to process lots of history items from file during the
+                // initialization. So do the conversion as the last resort.
+                if (LanguagePrimitives.TryConvertTo(value, out enumValue))
                 {
-                    return AddToHistoryOption.SkipAdding;
+                    return enumValue;
                 }
             }
 

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -152,6 +152,11 @@ namespace Microsoft.PowerShell
                     return enumValue;
                 }
 
+                if (value is string strValue && Enum.TryParse(strValue, out enumValue))
+                {
+                    return enumValue;
+                }
+
                 // 'TryConvertTo' incurs exception handling when the value cannot be converted to the target type.
                 // It's expensive, especially when we need to process lots of history items from file during the
                 // initialization. So do the conversion as the last resort.

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -158,9 +158,9 @@ namespace Test
                 options.HistorySavePath = newHistoryFilePath;
                 options.HistorySaveStyle = newHistorySaveStyle;
 
-                /*
-                 * Set null to the handler means we don't do the check.
-                 */
+                //
+                // Set null to the handler means we don't do the check.
+                //
                 options.AddToHistoryHandler = null;
                 SetHistory(commandInputs);
 
@@ -180,11 +180,11 @@ namespace Test
                     Assert.Equal(commandInputs[i], text[i]);
                 }
 
-                /*
-                 * Use a handler that return boolean value.
-                 *   true: Add to memory and file
-                 *   false: Skip adding to history
-                 */
+                //
+                // Use a handler that return boolean value.
+                //   true: Add to memory and file
+                //   false: Skip adding to history
+                //
                 options.AddToHistoryHandler = newAddToHistoryHandler_ReturnBool;
                 // Clear the history file.
                 File.WriteAllText(newHistoryFilePath, string.Empty);
@@ -198,9 +198,9 @@ namespace Test
                 Assert.Single(text);
                 Assert.Equal("gal dir", text[0]);
 
-                /*
-                 * Use a handler that return the expected enum type.
-                 */
+                //
+                // Use a handler that return the expected enum type.
+                //
                 options.AddToHistoryHandler = newAddToHistoryHandler_ReturnEnum;
                 File.WriteAllText(newHistoryFilePath, string.Empty);
                 SetHistory(commandInputs);
@@ -219,10 +219,10 @@ namespace Test
                     Assert.Equal(expectedSavedItems[i], text[i]);
                 }
 
-                /*
-                 * Use a handler that return unexpected value.
-                 *   - same behavior as setting the handler to null.
-                 */
+                //
+                // Use a handler that return unexpected value.
+                //   - same behavior as setting the handler to null.
+                //
                 options.AddToHistoryHandler = newAddToHistoryHandler_ReturnOther;
                 File.WriteAllText(newHistoryFilePath, string.Empty);
                 SetHistory(commandInputs);
@@ -277,7 +277,7 @@ namespace Test
                 ScriptBlock.Create(@"
                     param([string]$line)
                     if ($line.Contains('gal')) {
-                        [Microsoft.PowerShell.AddToHistoryOption]::MemoryOnly
+                        [psobject]::AsPSObject([Microsoft.PowerShell.AddToHistoryOption]::MemoryOnly)
                     } elseif ($line.Contains('gmo')) {
                         'SkipAdding'
                     } else {
@@ -311,9 +311,9 @@ namespace Test
                 options.HistorySavePath = newHistoryFilePath;
                 options.HistorySaveStyle = newHistorySaveStyle;
 
-                /*
-                 * Set null to the handler means we don't do the check.
-                 */
+                //
+                // Set null to the handler means we don't do the check.
+                //
                 options.AddToHistoryHandler = null;
                 SetHistory(commandInputs);
 
@@ -333,11 +333,11 @@ namespace Test
                     Assert.Equal(commandInputs[i], text[i]);
                 }
 
-                /*
-                 * Use a handler that return boolean value.
-                 *   true: Add to memory and file
-                 *   false: Skip adding to history
-                 */
+                //
+                // Use a handler that return boolean value.
+                //   true: Add to memory and file
+                //   false: Skip adding to history
+                //
                 options.AddToHistoryHandler = newAddToHistoryHandler_ReturnBool;
                 // Clear the history file.
                 File.WriteAllText(newHistoryFilePath, string.Empty);
@@ -351,9 +351,9 @@ namespace Test
                 Assert.Single(text);
                 Assert.Equal("gal dir", text[0]);
 
-                /*
-                 * Use a handler that return the expected enum type.
-                 */
+                //
+                // Use a handler that return the expected enum type.
+                //
                 options.AddToHistoryHandler = newAddToHistoryHandler_ReturnEnum;
                 File.WriteAllText(newHistoryFilePath, string.Empty);
                 SetHistory(commandInputs);
@@ -372,10 +372,10 @@ namespace Test
                     Assert.Equal(expectedSavedItems[i], text[i]);
                 }
 
-                /*
-                 * Use a handler that return unexpected value.
-                 *   - same behavior as setting the handler to null.
-                 */
+                //
+                // Use a handler that return unexpected value.
+                //   - same behavior as setting the handler to null.
+                //
                 options.AddToHistoryHandler = newAddToHistoryHandler_ReturnOther;
                 File.WriteAllText(newHistoryFilePath, string.Empty);
                 SetHistory(commandInputs);

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -157,7 +157,7 @@ namespace Test
                 options.HistorySavePath = newHistoryFilePath;
                 options.HistorySaveStyle = newHistorySaveStyle;
 
-                /* 
+                /*
                  * Set null to the handler means we don't do the check.
                  */
                 options.AddToHistoryHandler = null;
@@ -179,7 +179,7 @@ namespace Test
                     Assert.Equal(commandInputs[i], text[i]);
                 }
 
-                /* 
+                /*
                  * Use a handler that return boolean value.
                  *   true: Add to memory and file
                  *   false: Skip adding to history


### PR DESCRIPTION
Fix #1067

After changing the handler type to be `Func<string, object>`, PowerShell returns `PSObject` directly that wraps the true return value, which was not correctly handled.
The changes are:
- Unwrap the 'PSObject' returned from the handler call.
- Move `LanguagePrimitives.TryConvertTo` to the end, so we don't call it for Boolean values returned from the handler.
- Add a test to cover the script block handler.
