### PR TITLE
Fix CI badge and test failure when tests are skipped due to no supported keyboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![appveyor-build-status][]][appveyor-build-site]
 
-[appveyor-build-status]: https://ci.appveyor.com/api/projects/status/github/PowerShell/PSReadLine?branch=master&svg=true
+[appveyor-build-status]: https://ci.appveyor.com/api/projects/status/9mygtkr9fkov47xv/branch/master?svg=true
 [appveyor-build-site]: https://ci.appveyor.com/project/PowerShell/PSReadLine?branch=master
 
 <!--


### PR DESCRIPTION
Fix #913 #1070 #930

Fix CI badge and test failure when tests are skipped due to no supported keyboard layout