### PR TITLE
Clear the previous menu rendering correctly

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -500,6 +500,7 @@ namespace Microsoft.PowerShell
                     // from a previous menu.
                     if (cells < bufferWidth)
                     {
+                        // 'BlankRestOfLine' erases rest of the current line, but the cursor is not moved.
                         console.BlankRestOfLine();
                     }
 
@@ -515,6 +516,14 @@ namespace Microsoft.PowerShell
                 {
                     if (Rows < previousMenu.Rows + previousMenu.ToolTipLines)
                     {
+                        // Rest of the current line was erased, but the cursor was not moved to the next line.
+                        if (console.CursorLeft != 0)
+                        {
+                            // There are lines from the previous rendering that need to be cleared,
+                            // so we are sure there is no need to scroll.
+                            MoveCursorDown(1);
+                        }
+
                         Singleton.WriteBlankLines(previousMenu.Rows + previousMenu.ToolTipLines - Rows);
                     }
                 }

--- a/test/CompletionTest.cs
+++ b/test/CompletionTest.cs
@@ -147,6 +147,33 @@ namespace Test
         }
 
         [SkippableFact]
+        public void MenuCompletions()
+        {
+            TestSetup(KeyMode.Cmd, new KeyHandler("Ctrl+Spacebar", PSConsoleReadLine.MenuComplete));
+
+            _console.Clear();
+            Test("Get-Many4", Keys(
+                "Get-Many", _.Ctrl_Spacebar,
+                CheckThat(() => AssertScreenIs(4,
+                    TokenClassification.Command, "Get-Many",
+                    TokenClassification.Selection, "0", NextLine,
+                    TokenClassification.Selection, "Get-Many0   ",
+                    TokenClassification.None,
+                    "Get-Many3   Get-Many6   Get-Many9   Get-Many12", NextLine,
+                    "Get-Many1   Get-Many4   Get-Many7   Get-Many10  Get-Many13", NextLine,
+                    "Get-Many2   Get-Many5   Get-Many8   Get-Many11  Get-Many14")),
+                "4",
+                CheckThat(() => AssertScreenIs(4,
+                    TokenClassification.Command, "Get-Many4", NextLine,
+                    TokenClassification.Selection, "Get-Many4  ", NextLine,
+                    "                                                          ", NextLine,
+                    "                                                          ", NextLine)),
+                _.Enter,
+                _.Enter
+                ));
+        }
+
+        [SkippableFact]
         public void ShowTooltips()
         {
             TestSetup(KeyMode.Cmd, new KeyHandler("Ctrl+Spacebar", PSConsoleReadLine.PossibleCompletions));

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -49,6 +49,7 @@ namespace Test
         Type,
         Number,
         Member,
+        Selection,
     }
 
     public abstract partial class ReadLine
@@ -99,6 +100,7 @@ namespace Test
         /*Type*/      ConsoleColor.Yellow,
         /*Number*/    ConsoleColor.DarkBlue,
         /*Member*/    ConsoleColor.DarkMagenta,
+        /*Selection*/ ConsoleColor.Black,
         };
 
         internal static readonly ConsoleColor[] BackgroundColors = new[]
@@ -114,6 +116,7 @@ namespace Test
         /*Type*/      ConsoleColor.Black,
         /*Number*/    ConsoleColor.Gray,
         /*Member*/    ConsoleColor.Yellow,
+        /*Selection*/ ConsoleColor.Gray
         };
 
         class KeyHandler
@@ -476,7 +479,6 @@ namespace Test
                     { "ContinuationPrompt",       MakeCombinedColor(_console.ForegroundColor, _console.BackgroundColor) },
                     { "Emphasis",                 MakeCombinedColor(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor) },
                     { "Error",                    MakeCombinedColor(ConsoleColor.Red, ConsoleColor.DarkRed) },
-                    { "Selection",                MakeCombinedColor(ConsoleColor.Black, ConsoleColor.Gray)  },
                 }
             };
 
@@ -503,7 +505,7 @@ namespace Test
             var tokenTypes = new[]
             {
                 "Default", "Comment", "Keyword", "String", "Operator", "Variable",
-                "Command", "Parameter", "Type", "Number", "Member"
+                "Command", "Parameter", "Type", "Number", "Member", "Selection"
             };
             var colors = new Hashtable();
             for (var i = 0; i < tokenTypes.Length; i++)


### PR DESCRIPTION
Fix #946

This is because `BlankRestOfLine` doesn't move the cursor, so we need to move it to next line when clearing the rest of lines from previous menu rendering.
Test added.