### PR TITLE
Update the script in issue template to find out if powershell runs in Windows Terminal

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,15 +4,16 @@ Before submitting your bug report, please check for duplicates, and +1 the dupli
 There are a few common issues that are commonly reported.
 
 If there is an exception copying to/from the clipboard, it's probably the same as https://github.com/PowerShell/PSReadLine/issues/265
-
 If there is an exception shortly after resizing the console, it's probably the same as https://github.com/PowerShell/PSReadLine/issues/292
 -->
 
 Environment data
 ----------------
 
-<!-- The following script will generate the environment data that helps triage and investigate the issue.
-     Please run the script in the PowerShell session where you ran into the issue and provide the output here.
+<!--
+
+The following script will generate the environment data that helps triage and investigate the issue.
+Please run the script in the PowerShell session where you ran into the issue and provide the output here.
 
 & {
     $hostName = $Host.Name

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,10 +11,24 @@ If there is an exception shortly after resizing the console, it's probably the s
 Environment data
 ----------------
 
-<!-- provide the output of the following:
-```powershell
+<!-- The following script will generate the environment data that helps triage and investigate the issue.
+     Please run the script in the PowerShell session where you ran into the issue and provide the output here.
+
 & {
-    "PS version: $($PSVersionTable.PSVersion)"
+    $hostName = $Host.Name
+    if ($hostName -eq "ConsoleHost" -and (Get-Command Get-CimInstance)) {
+        $id = $PID
+        $inWindowsTerminal = $false
+        while ($true) {
+            $p = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId Like $id"
+            if (!$p -or !$p.Name) { break }
+            if ($p.Name -eq "WindowsTerminal.exe") { $inWindowsTerminal = $true; break }
+            $id = $p.ParentProcessId
+        }
+        if ($inWindowsTerminal) { $hostName += " (Windows Terminal)" }
+    }
+
+    "`nPS version: $($PSVersionTable.PSVersion)"
     $v = (Get-Module PSReadline).Version
     $m = Get-Content "$(Split-Path -Parent (Get-Module PSReadLine).Path)\PSReadLine.psd1" | Select-String "Prerelease = '(.*)'"
     if ($m) {
@@ -27,10 +41,11 @@ Environment data
         "os: $((dir $env:SystemRoot\System32\cmd.exe).VersionInfo.FileVersion)"
     }
     "PS file version: $($name = if ($PSVersionTable.PSEdition -eq "Core") { "pwsh.dll" } else { "powershell.exe" }; (dir $pshome\$name).VersionInfo.FileVersion)"
+    "HostName: $hostName"
     "BufferWidth: $([console]::BufferWidth)"
-    "BufferHeight: $([console]::BufferHeight)"
+    "BufferHeight: $([console]::BufferHeight)`n"
 }
-```
+
 -->
 
 Steps to reproduce or exception report

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,7 @@ Please run the script in the PowerShell session where you ran into the issue and
 
 & {
     $hostName = $Host.Name
-    if ($hostName -eq "ConsoleHost" -and (Get-Command Get-CimInstance)) {
+    if ($hostName -eq "ConsoleHost" -and (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)) {
         $id = $PID
         $inWindowsTerminal = $false
         while ($true) {


### PR DESCRIPTION
Update the script in issue template to find out if powershell runs in Windows Terminal.

Example output:
```none
PS version: 5.1.18362.145                                                                                                                             
PSReadline version: 2.0.0-beta4                                                                                                                       
os: 10.0.18362.1 (WinBuild.160101.0800)                                                                                                               
PS file version: 10.0.18362.1 (WinBuild.160101.0800)                                                                                                  
HostName: ConsoleHost (Windows Terminal)                                                                                                              
BufferWidth: 150                                                                                                                                      
BufferHeight: 42
```
```none
PS version: 7.0.0-preview.4
PSReadline version: 2.0.0-beta5
os: 10.0.18362.1 (WinBuild.160101.0800)
PS file version: 7.0.0.0
HostName: ConsoleHost
BufferWidth: 150
BufferHeight: 9001
```
```none
PS version: 6.2.0
PSReadline version: 2.0.0-beta4
os: 10.0.18362.1 (WinBuild.160101.0800)
PS file version: 6.2.0.0
HostName: Visual Studio Code Host
BufferWidth: 219
BufferHeight: 21
```
```
PS version: 7.0.0-preview.4
PSReadline version: 2.0.0-beta5
os: Linux dongbo-ub 4.15.0-64-generic #73~16.04.1-Ubuntu SMP Fri Sep 13 09:56:18 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
PS file version: 7.0.0.0
HostName: ConsoleHost
BufferWidth: 100
BufferHeight: 33
```
