### PR TITLE
Fix for a nullref thrown when PSES calls ForcePSEventHandling

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell
         private Thread _readKeyThread;
         private AutoResetEvent _readKeyWaitHandle;
         private AutoResetEvent _keyReadWaitHandle;
-        private AutoResetEvent _forceEventWaitHandle;
+        private AutoResetEvent _forceEventWaitHandle = new AutoResetEvent(false);
         private CancellationToken _cancelReadCancellationToken;
         internal ManualResetEvent _closingWaitHandle;
         private WaitHandle[] _threadProcWaitHandles;
@@ -802,7 +802,6 @@ namespace Microsoft.PowerShell
 
             _singleton._readKeyWaitHandle = new AutoResetEvent(false);
             _singleton._keyReadWaitHandle = new AutoResetEvent(false);
-            _singleton._forceEventWaitHandle = new AutoResetEvent(false);
             _singleton._closingWaitHandle = new ManualResetEvent(false);
             _singleton._requestKeyWaitHandles = new WaitHandle[] {_singleton._keyReadWaitHandle, _singleton._closingWaitHandle, _defaultCancellationToken.WaitHandle, _singleton._forceEventWaitHandle};
             _singleton._threadProcWaitHandles = new WaitHandle[] {_singleton._readKeyWaitHandle, _singleton._closingWaitHandle};

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell
         private Thread _readKeyThread;
         private AutoResetEvent _readKeyWaitHandle;
         private AutoResetEvent _keyReadWaitHandle;
-        private AutoResetEvent _forceEventWaitHandle = new AutoResetEvent(false);
+        private AutoResetEvent _forceEventWaitHandle;
         private CancellationToken _cancelReadCancellationToken;
         internal ManualResetEvent _closingWaitHandle;
         private WaitHandle[] _threadProcWaitHandles;
@@ -619,6 +619,10 @@ namespace Microsoft.PowerShell
             _statusBuffer = new StringBuilder(256);
             _savedCurrentLine = new HistoryItem();
             _queuedKeys = new Queue<PSKeyInfo>();
+
+            // Initialize this event handler early because it could be used by PowerShell
+            // Editor Services before 'DelayedOneTimeInitialize' runs.
+            _forceEventWaitHandle = new AutoResetEvent(false);
 
             string hostName = null;
             // This works mostly by luck - we're not doing anything to guarantee the constructor for our


### PR DESCRIPTION
In PowerShell Editor Services, we have a private contract with PSRL with a method called `ForcePSEventHandling` found in:

* [PSRL](https://github.com/PowerShell/PSReadLine/blob/master/PSReadLine/ReadLine.cs#L827-L836)
* [PSES](https://github.com/PowerShell/PowerShellEditorServices/blob/c744e79525566ef17c86d51c601e988188bbc9e4/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs#L199-L202)

Due to the multi-threaded nature of PSES, we are calling `ForcePSEventHanding` before the `_forceEventWaitHandle` was initialized (which happens in `DelayedOneTimeInitialize(`) thus causing a null reference exception.

This PR moves the initialization to the field declaration which fixes the issue we were seeing (PSES crashing).

This should be low risk as this is only used by PSES and they are a private contract.