### PR TITLE
Fix correct way to get substring based on buffercells when encountering CJK chars

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -805,7 +805,7 @@ namespace Microsoft.PowerShell
             }
             else if (spacesNeeded < 0)
             {
-                item = item.Substring(0, columnWidth - 3) + "...";
+                item = SubstringByCells(item, columnWidth - 2) + ELLIPSIS + ' ';
             }
 
             return item;

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -805,7 +805,7 @@ namespace Microsoft.PowerShell
             }
             else if (spacesNeeded < 0)
             {
-                item = SubstringByCells(item, columnWidth - 2) + ELLIPSIS + ' ';
+                item = SubstringByCells(item, columnWidth - 3) + "...";
             }
 
             return item;

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -51,7 +51,6 @@ namespace Microsoft.PowerShell
             public RenderedLineData[] lines;
         }
 
-        private const char ELLIPSIS = '\u2026';
         private const int COMMON_WIDEST_CONSOLE_WIDTH = 160;
         private readonly List<StringBuilder> _consoleBufferLines = new List<StringBuilder>(1) {new StringBuilder(COMMON_WIDEST_CONSOLE_WIDTH)};
         private static readonly string[] _spaces = new string[80];

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -880,7 +880,6 @@ namespace Microsoft.PowerShell
         {
             int length = 0;
             int index = 0;
-            string substring = string.Empty;
 
             foreach (char c in text)
             {
@@ -893,7 +892,7 @@ namespace Microsoft.PowerShell
                 index++;
             }
 
-            return substring;
+            return string.Empty;
         }
 
         private string GetTokenColor(Token token)

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -51,6 +51,7 @@ namespace Microsoft.PowerShell
             public RenderedLineData[] lines;
         }
 
+        private const char ELLIPSIS = '\u2026';
         private const int COMMON_WIDEST_CONSOLE_WIDTH = 160;
         private readonly List<StringBuilder> _consoleBufferLines = new List<StringBuilder>(1) {new StringBuilder(COMMON_WIDEST_CONSOLE_WIDTH)};
         private static readonly string[] _spaces = new string[80];
@@ -371,7 +372,7 @@ namespace Microsoft.PowerShell
 
             if (string.IsNullOrEmpty(promptText) || _initialY < 0)
             {
-                // No need to flip the prompt color if either the error prompt is not defined 
+                // No need to flip the prompt color if either the error prompt is not defined
                 // or the initial cursor point has already been scrolled off the buffer.
                 return false;
             }
@@ -873,6 +874,26 @@ namespace Microsoft.PowerShell
                   // (c >= 0x20000 && c <= 0x2fffd) ||
                   // (c >= 0x30000 && c <= 0x3fffd)
             return 1 + (isWide ? 1 : 0);
+        }
+
+        private static string SubstringByCells(string text, int countOfCells)
+        {
+            int length = 0;
+            int index = 0;
+            string substring = string.Empty;
+
+            foreach (char c in text)
+            {
+                if (length >= countOfCells)
+                {
+                    return text.Substring(0, index);
+                }
+
+                length += LengthInBufferCells(c);
+                index++;
+            }
+
+            return substring;
         }
 
         private string GetTokenColor(Token token)


### PR DESCRIPTION
Code was correctly calculating the number of buffer cells for CJK chars, but then used substring() to get a substring which failed as the number of cells is > number of chars.  Fix is to have a SubstringByCells() method that understands how to return substring based on cells.  Also using unicode ellipsis char instead of `...` to save screen space.

Tried to add a unittest, but couldn't get the CJK char to work with KeyboardLayout.

Fix https://github.com/PowerShell/PSReadLine/issues/847