### PR TITLE
Correct cursor jumping from line 2 to line 1 due to line 1 being empty.

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -473,25 +473,7 @@ namespace Microsoft.PowerShell
         public static void InsertLineAbove(ConsoleKeyInfo? key = null, object arg = null)
         {
             // Move the current position to the beginning of the current line and only the current line.
-            if (_singleton.LineIsMultiLine())
-            {
-                int i = Math.Max(0, _singleton._current - 1);
-                for (; i > 0; i--)
-                {
-                    if (_singleton._buffer[i] == '\n')
-                    {
-                        i += 1;
-                        break;
-                    }
-                }
-
-                _singleton._current = i;
-            }
-            else
-            {
-                _singleton._current = 0;
-            }
-
+            _singleton._current = GetBeginningOfLinePos(_singleton._current);
             Insert('\n');
             PreviousLine();
         }

--- a/PSReadLine/Position.cs
+++ b/PSReadLine/Position.cs
@@ -15,10 +15,10 @@ namespace Microsoft.PowerShell
 
             if (_singleton.LineIsMultiLine())
             {
-                int i = Math.Max(0, current - 1);
-                for (; i > 0; i--)
+                int i = Math.Max(0, current);
+                while (i > 0)
                 {
-                    if (_singleton._buffer[i] == '\n')
+                    if (_singleton._buffer[--i] == '\n')
                     {
                         i += 1;
                         break;

--- a/test/BasicEditingTest.cs
+++ b/test/BasicEditingTest.cs
@@ -292,6 +292,12 @@ namespace Test
                                           _.Ctrl_Enter, CheckThat(() => AssertCursorLeftTopIs(continutationPromptLength, 1)),
                                           _.Ctrl_Enter, CheckThat(() => AssertCursorLeftTopIs(continutationPromptLength, 1)),
                                           "9ABC"));
+
+            // Test case - create leading blank line, cursor to stay on same line
+            Test("\n\n1234", Keys("1234",
+                _.Ctrl_Enter, CheckThat(() => AssertCursorLeftTopIs(0,0)),
+                _.DownArrow, CheckThat(() => AssertCursorLeftTopIs(continutationPromptLength, 1)),
+                _.Ctrl_Enter, CheckThat(() => AssertCursorLeftTopIs(continutationPromptLength, 1))));
         }
 
         [SkippableFact]

--- a/test/MovementTest.cs
+++ b/test/MovementTest.cs
@@ -173,6 +173,12 @@ namespace Test
                 _.DownArrow, CheckThat(() => AssertCursorLeftTopIs(5 + continutationPromptLength, 4)),
                 _.DownArrow, CheckThat(() => AssertCursorLeftTopIs(6 + continutationPromptLength, 5)),
 
+                // Using the input previously entered, check for correct cursor movements when first line is blank
+                _.Home, _.Home, CheckThat(() => AssertCursorLeftTopIs(0, 0)),
+                _.DownArrow, CheckThat(() => AssertCursorLeftTopIs(8 + continutationPromptLength, 1)),
+                _.Home, CheckThat(() => AssertCursorLeftTopIs(continutationPromptLength, 1)),
+                _.Home, CheckThat(() => AssertCursorLeftTopIs(0,0)),
+
                 // Clear the input, we were just testing movement
                 _.Escape
                 ));


### PR DESCRIPTION
Correct newline search in `GetBeginningOfLinePos()` (HOME) and `InsertLineAbove()` (CTRL-ENTER) (by using `GetBeginningOfLinePos()`) to not ignore first character in the buffer which might be a new line.

Manifests as cursor jumps to line 1, because line 1 is blank, when triggered with cursor anywhere on line 2.

Fixes #1107.
Fixes #1109.