### PR TITLE
Don't allow InsertLineAbove unless in multiline

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -472,10 +472,13 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void InsertLineAbove(ConsoleKeyInfo? key = null, object arg = null)
         {
-            // Move the current position to the beginning of the current line and only the current line.
-            _singleton._current = GetBeginningOfLinePos(_singleton._current);
-            Insert('\n');
-            PreviousLine();
+            if (_singleton.LineIsMultiLine())
+            {
+                // Move the current position to the beginning of the current line and only the current line.
+                _singleton._current = GetBeginningOfLinePos(_singleton._current);
+                Insert('\n');
+                PreviousLine();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
When at the prompt, if you use the keyhandler (Ctrl+j default in Windows mode), it will insert a line continuation below the prompt and put your cursor back at the prompt.  So it's not inserting above (it can't since you're at the prompt) and if you do this enough to scroll it off the screen, there is an unhandled exception.  Fix is to now allow InsertLineAbove unless you are in a multiline.