### PR TITLE
In Vi mode, 'y0' should only yank up to the start of the logical line.

### DIFF
--- a/PSReadLine/YankPaste.vi.cs
+++ b/PSReadLine/YankPaste.vi.cs
@@ -252,8 +252,7 @@ namespace Microsoft.PowerShell
             if (length > 0)
             {
                 _clipboard.Record(_singleton._buffer, start, length);
-                _singleton._current = start;
-                _singleton.Render();
+                _singleton.MoveCursor(start);
             }
         }
 

--- a/PSReadLine/YankPaste.vi.cs
+++ b/PSReadLine/YankPaste.vi.cs
@@ -247,10 +247,13 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViYankBeginningOfLine(ConsoleKeyInfo? key = null, object arg = null)
         {
-            int length = _singleton._current;
+            var start = GetBeginningOfLinePos(_singleton._current);
+            var length = _singleton._current - start; 
             if (length > 0)
             {
-                _singleton.SaveToClipboard(0, length);
+                _clipboard.Record(_singleton._buffer, start, length);
+                _singleton._current = start;
+                _singleton.Render();
             }
         }
 

--- a/test/YankPasteTest.VI.cs
+++ b/test/YankPasteTest.VI.cs
@@ -324,16 +324,17 @@ namespace Test
         {
             TestSetup(KeyMode.Vi);
 
-            Test("012", Keys(
-                "012", _.Escape,
-                "y0P", CheckThat(() => AssertLineIs("01012")), CheckThat(() => AssertCursorLeftIs(3)),
-                "u"
-                ));
+            var continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
 
-            Test(" 123  ", Keys(
-                " 123  ", _.Escape,
-                "y0P", CheckThat(() => AssertLineIs(" 123  123  ")), CheckThat(() => AssertCursorLeftIs(9)),
-                "u"
+            Test("\"\nHello\n World!\n\"", Keys(
+                _.DQuote, _.Enter,
+                "Hello", _.Enter,
+                " World!", _.Enter,
+                _.DQuote, _.Escape,
+                _.k, "5l", // move the cursor to the 'd' character of "World!"
+                "y0", CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0)),
+                "P", CheckThat(() => AssertLineIs("\"\nHello\n Worl World!\n\"")), CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 4)),
+                "u", CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0))
                 ));
         }
 

--- a/test/YankPasteTest.VI.cs
+++ b/test/YankPasteTest.VI.cs
@@ -326,6 +326,12 @@ namespace Test
 
             var continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
 
+            Test("012", Keys(
+                "012", _.Escape,
+                "y0P", CheckThat(() => AssertLineIs("01012")), CheckThat(() => AssertCursorLeftIs(1)),
+                "u"
+                ));
+
             Test("\"\nHello\n World!\n\"", Keys(
                 _.DQuote, _.Enter,
                 "Hello", _.Enter,


### PR DESCRIPTION
Currently, <kbd>y0</kbd> yanks to the beginning of the buffer, even when using multiple lines.
This PR fixes this and only yanks text up to the beginning of the current logical line.