### PR TITLE
In Vi mode, 'y$' should only yank to the end of the logical line.

### DIFF
--- a/PSReadLine/YankPaste.vi.cs
+++ b/PSReadLine/YankPaste.vi.cs
@@ -137,9 +137,13 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViYankToEndOfLine(ConsoleKeyInfo? key = null, object arg = null)
         {
-            int start = _singleton._current;
-            int length = _singleton._buffer.Length - _singleton._current;
-            _singleton.SaveToClipboard(start, length);
+            var start = _singleton._current;
+            var end = GetEndOfLogicalLinePos(_singleton._current);
+            var length = end - start + 1;
+            if (length > 0)
+            {
+                _clipboard.Record(_singleton._buffer, start, length);
+            }
         }
 
         /// <summary>

--- a/test/YankPasteTest.VI.cs
+++ b/test/YankPasteTest.VI.cs
@@ -338,6 +338,24 @@ namespace Test
         }
 
         [SkippableFact]
+        public void ViPasteAfterYankEndOfLine()
+        {
+            TestSetup(KeyMode.Vi);
+
+            var continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
+
+            Test("\"\nHello\nWorld!\n\"", Keys(
+                _.DQuote, _.Enter,
+                "Hello", _.Enter,
+                "World!", _.Enter, 
+                _.DQuote, _.Escape,
+                _.k, _.l, // move to the 'o' character of 'World!'
+                "y$P", CheckThat(() => AssertLineIs("\"\nHello\nWorld!orld!\n\"")), CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 5)),
+                "u"
+                ));
+        }
+
+        [SkippableFact]
         public void ViPasteAfterYankFirstNoneBlank()
         {
             TestSetup(KeyMode.Vi);


### PR DESCRIPTION
Currently, <kbd>y$</kbd> yanks the text from the cursor position to the end of the buffer, even when using multiple lines.
This PR fixes this and only yanks text up to the end of the current logical line.