### PR TITLE
Fix NullReferenceException in OnBreak

### DIFF
--- a/PSReadLine/PlatformWindows.cs
+++ b/PSReadLine/PlatformWindows.cs
@@ -88,7 +88,7 @@ static class PlatformWindows
         if (signal == ConsoleBreakSignal.Close || signal == ConsoleBreakSignal.Shutdown)
         {
             // Set the event so ReadKey throws an exception to unwind.
-            _singleton._closingWaitHandle.Set();
+            _singleton?._closingWaitHandle?.Set();
         }
 
         return false;


### PR DESCRIPTION
The Windows event log reports a NullReferenceException in
PlatformWindows.OnBreak.

It's unclear what the repro is (perhaps closing the console before it is
fully initialized) but a fix is simple - adding null checks.

Fix #1177