### PR TITLE
Improve handling of color in prompts

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -321,7 +321,7 @@ namespace Microsoft.PowerShell
         /// If the prompt function is pure, this value can be inferred, e.g.
         /// the default prompt will use "> " for this value.
         /// </summary>
-        public string PromptText { get; set; }
+        public string[] PromptText { get; set; }
 
         public object DefaultTokenColor
         {
@@ -663,7 +663,7 @@ namespace Microsoft.PowerShell
 
         [Parameter]
         [ValidateNotNull]
-        public string PromptText { get; set; }
+        public string[] PromptText { get; set; }
 
         [Parameter]
         public ViModeStyle ViModeIndicator

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -761,7 +761,7 @@ namespace Microsoft.PowerShell
 
                         if (i >= 0)
                         {
-                            _options.PromptText = evaluatedPrompt.Substring(i);
+                            _options.PromptText = new [] { evaluatedPrompt.Substring(i) };
                         }
                     }
                 }

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -354,7 +354,7 @@ namespace Test
             var options = new SetPSReadLineOption {ExtraPromptLineCount = 0};
             if (string.IsNullOrEmpty(prompt))
             {
-                options.PromptText = "";
+                options.PromptText = new [] {""};
                 PSConsoleReadLine.SetOptions(options);
                 return;
             }
@@ -365,7 +365,7 @@ namespace Test
                 if (!char.IsWhiteSpace(prompt[i])) break;
             }
 
-            options.PromptText = prompt.Substring(i);
+            options.PromptText = new [] { prompt.Substring(i) };
 
             var lineCount = 1 + prompt.Count(c => c == '\n');
             if (lineCount > 1)
@@ -474,7 +474,7 @@ namespace Test
                 MaximumKillRingCount              = PSConsoleReadLineOptions.DefaultMaximumKillRingCount,
                 ShowToolTips                      = PSConsoleReadLineOptions.DefaultShowToolTips,
                 WordDelimiters                    = PSConsoleReadLineOptions.DefaultWordDelimiters,
-                PromptText                        = "",
+                PromptText                        = new [] {""},
                 Colors = new Hashtable {
                     { "ContinuationPrompt",       MakeCombinedColor(_console.ForegroundColor, _console.BackgroundColor) },
                     { "Emphasis",                 MakeCombinedColor(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor) },


### PR DESCRIPTION
This PR is one possible approach to fixing #986.

It's nice in that it doesn't require adding a new configuration option - I'm thinking this would be used very infrequently.

Here is an example of how you might configure PSReadLine and an example of it working:

```PowerShell
$esc = [char]0x1b
$pc = [char]0xe0b0
$fg = "0"
$bg = "8;2;95;158;160"
$ebg = "1"
Set-PSReadLineOption -PromptText "$esc[4${bg};3${fg}mPS$esc[4${fg};3${bg}m$pc$esc[0m","$esc[4${ebg};3${fg}mPS$esc[4${fg};3${ebg}m$pc$esc[0m"

```


![prompt](https://user-images.githubusercontent.com/2148248/68822130-f5d2d800-0644-11ea-94cd-da1f109fe4a6.gif)

If we go with this approach, I'll also need to update the docs.