### PR TITLE
Do not directly set cursor on AcceptLineImpl

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -272,8 +272,8 @@ namespace Microsoft.PowerShell
                 ClearStatusMessage(render: true);
             }
 
-            var point = ConvertOffsetToPoint(_current);
-            _console.SetCursorPosition(point.X, point.Y);
+            // Let public API set cursor to end of line incase end of line is end of buffer
+            SetCursorPosition(_current);
             _console.Write("\n");
             _inputAccepted = true;
             return true;


### PR DESCRIPTION
In `AcceptLineImpl()`, instead of `_console.SetCursorPosition()`, use public API `SetCursorPosition()` so that existing end of buffer checks can be performed.

Fixes #1181, complement to #1146.
May fix #1155.