### PR TITLE
Fixes #1197

### DIFF
--- a/PSReadLine/ViRegister.cs
+++ b/PSReadLine/ViRegister.cs
@@ -60,7 +60,10 @@ namespace Microsoft.PowerShell
             /// <param name="count"></param>
             public void Record(StringBuilder buffer, int offset, int count)
             {
-                System.Diagnostics.Debug.Assert(offset >= 0 && offset < buffer.Length);
+                System.Diagnostics.Debug.Assert(
+                    offset >= 0 &&
+                    (buffer.Length == 0 || offset < buffer.Length)
+                );
                 System.Diagnostics.Debug.Assert(offset + count <= buffer.Length);
 
                 HasLinewiseText = false;

--- a/test/YankPasteTest.VI.cs
+++ b/test/YankPasteTest.VI.cs
@@ -189,6 +189,16 @@ namespace Test
                 ));
         }
 
+        [SkippableFact()]
+        public void ViDeleteLine_EmptyBuffer_Defect1197()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("", Keys(
+                _.Escape, "dd", CheckThat(() => AssertLineIs(""))
+            ));
+        }
+
         [SkippableFact]
         public void ViPasteAfterDeleteLine()
         {


### PR DESCRIPTION
An incorrect condition in an `Assert` statement crashed a Debug build when using <kbd>dd</kbd> on an empty line in Vi mode. This did not have any negative effect in Release builds.

Fix #1197