### PR TITLE
Fixes - #1195

### DIFF
--- a/PSReadLine/Movement.vi.cs
+++ b/PSReadLine/Movement.vi.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell
                 i = _singleton.ViFindNextGlob(i);
             }
 
-            var newPosition = Math.Min(i, Math.Max(0, _singleton._buffer.Length - 1));
+            int newPosition = Math.Min(i, Math.Max(0, _singleton._buffer.Length - 1));
             if (newPosition != _singleton._current)
             {
                 _singleton.MoveCursor(newPosition);

--- a/PSReadLine/Movement.vi.cs
+++ b/PSReadLine/Movement.vi.cs
@@ -94,7 +94,15 @@ namespace Microsoft.PowerShell
                 i = _singleton.ViFindNextGlob(i);
             }
 
-            _singleton.MoveCursor(Math.Min(i, _singleton._buffer.Length - 1));
+            var newPosition = Math.Min(i, Math.Max(0, _singleton._buffer.Length - 1));
+            if (newPosition != _singleton._current)
+            {
+                _singleton.MoveCursor(newPosition);
+            }
+            else
+            {
+                Ding();
+            }
         }
 
         /// <summary>

--- a/test/MovementTest.VI.cs
+++ b/test/MovementTest.VI.cs
@@ -365,6 +365,16 @@ namespace Test
         }
 
         [SkippableFact]
+        public void ViGlobMovement_EmptyBuffer_Defect1195()
+        {
+            TestSetup(KeyMode.Vi);
+
+            TestMustDing("", Keys(
+                _.Escape, "W" 
+            ));
+        }
+
+        [SkippableFact]
         public void ViCursorMovement()
         {
             TestSetup(KeyMode.Vi);


### PR DESCRIPTION
Fixes a condition where the cursor could be set to [an incorrect position](https://github.com/PowerShell/PSReadLine/issues/1195#issuecomment-555864290).

Fix #1195