### PR TITLE
Fix an 'IndexOutOfRangeException' when error prompt contains CJK

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -430,10 +430,6 @@ namespace Microsoft.PowerShell
                 if (!promptText.Contains('\x1b'))
                 {
                     string color = renderData.errorPrompt ? _options._errorColor : defaultColor;
-                    if (renderData.errorPrompt && promptBufferCells != promptText.Length)
-                    {
-                        promptText = promptText.Substring(promptText.Length - promptBufferCells);
-                    }
                     _console.Write(color);
                 }
                 _console.Write(promptText);


### PR DESCRIPTION
The line `promptText = promptText.Substring(promptText.Length - promptBufferCells);` causes the index out-of-range exception because `promptBufferCells` might be larger than the length of the prompt text when it contains CJK characters.
This line doesn't make sense after a series of changes to the prompt rendering code and should be removed.

```none
PS E:\pscore-test> Set-PSReadLineOption -PromptText "你好吗你？"
PS E:\pscore-test>
PS E:\pscore-test> i
Oops, something went wrong.  Please report this bug with the details below.
Report on GitHub: https://github.com/PowerShell/PSReadLine/issues/new
### Environment
PSReadLine: 2.0.0-beta5
PowerShell: 7.0.0-preview.5
OS: Microsoft Windows 10.0.18363
Last 21 Keys

"""
 Enter
 f a Backspace Backspace Backspace Ctrl+r s e t ` Escape Enter
 Enter
 f a Backspace Backspace Backspace i f
"""

### Exception

System.ArgumentOutOfRangeException: StartIndex cannot be less than zero. (Parameter 'startIndex')
   at System.String.Substring(Int32 startIndex, Int32 length)
   at System.String.Substring(Int32 startIndex)
   at Microsoft.PowerShell.PSConsoleReadLine.RenderErrorPrompt(RenderData renderData, String defaultColor)
   at Microsoft.PowerShell.PSConsoleReadLine.ReallyRender(RenderData renderData, String defaultColor)
   at Microsoft.PowerShell.PSConsoleReadLine.ForceRender()
   at Microsoft.PowerShell.PSConsoleReadLine.Render()
   at Microsoft.PowerShell.PSConsoleReadLine.Insert(Char c)
   at Microsoft.PowerShell.PSConsoleReadLine.SelfInsert(Nullable`1 key, Object arg)
   at Microsoft.PowerShell.PSConsoleReadLine.ProcessOneKey(PSKeyInfo key, Dictionary`2 dispatchTable, Boolean ignoreIfNoAction, Object arg)
   at Microsoft.PowerShell.PSConsoleReadLine.InputLoop()
   at Microsoft.PowerShell.PSConsoleReadLine.ReadLine(Runspace runspace, EngineIntrinsics engineIntrinsics, CancellationToken cancellationToken)
```