### PR TITLE
Use '2.0.0-rc1' instead of 'rc.1' due to the PowerShellGet's limitation

### DIFF
--- a/PSReadLine/Changes.txt
+++ b/PSReadLine/Changes.txt
@@ -1,4 +1,4 @@
-### Version 2.0.0-rc.1
+### Version 2.0.0-rc1
 
 Pre-release notes:
 

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Microsoft.PowerShell.PSReadLine2</AssemblyName>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0</FileVersion>
-    <InformationalVersion>2.0.0-rc.1</InformationalVersion>
+    <InformationalVersion>2.0.0-rc1</InformationalVersion>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
PowerShellGet doesn't allow `rc.1`, it only support a prerelease version in the format `x.x.x-xxx`.
I learnt this in the hard way :(