### PR TITLE
Fixed #998

### DIFF
--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -76,7 +76,6 @@ namespace Microsoft.PowerShell
 
             public static void SearchBackward(char keyChar, object arg, bool backoff)
             {
-                Set(keyChar, isBackward: true, isBackoff: backoff);
                 int qty = arg as int? ?? 1;
 
                 for (int i = _singleton._current - 1; i >= 0; i--)

--- a/test/MovementTest.VI.cs
+++ b/test/MovementTest.VI.cs
@@ -508,6 +508,35 @@ namespace Test
                 "dd"
                 ));
 
+            Test("", Keys(
+                "0101010",
+                CheckThat(() => AssertCursorLeftIs(7)),
+                _.Escape,
+                _.Uphat,
+                "f1",
+                CheckThat(() => AssertCursorLeftIs(1)),
+                ";",
+                CheckThat(() => AssertCursorLeftIs(3)),
+                ";",
+                CheckThat(() => AssertCursorLeftIs(5)),
+                ",",
+                CheckThat(() => AssertCursorLeftIs(3)),
+                ",",
+                CheckThat(() => AssertCursorLeftIs(1)),
+                _.Dollar,
+                "F1",
+                CheckThat(() => AssertCursorLeftIs(5)),
+                ";",
+                CheckThat(() => AssertCursorLeftIs(3)),
+                ";",
+                CheckThat(() => AssertCursorLeftIs(1)),
+                ",",
+                CheckThat(() => AssertCursorLeftIs(3)),
+                ",",
+                CheckThat(() => AssertCursorLeftIs(5)),
+                "dd"
+            ));
+
             TestMustDing("01234", Keys(
                 "01234",
                 CheckThat(() => AssertCursorLeftIs(5)),


### PR DESCRIPTION
For the ViDeleteToChar functions, subsequent RepeatLastCharSearch(Backwards) calls behave the same as for SearchChar(Backward), so the fix here addresses those scenarios as well.

Fix #998