### PR TITLE
Preserve and clear the saved current line properly

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -74,12 +74,6 @@ namespace Microsoft.PowerShell
                 _singleton._edits[_singleton._undoEditIndex - 1].Undo();
                 _singleton._undoEditIndex--;
             }
-
-            // It's possible we just finished a history search, which saved the line when the search was triggered
-            // so that another search with the reversed order can go back to the same line.
-            // Now that we are reverting the real current line, the saved current line should be cleared since we
-            // will no longer go back to it.
-            _singleton.ClearSavedCurrentLine();
             _singleton.Render();
         }
 

--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -74,6 +74,12 @@ namespace Microsoft.PowerShell
                 _singleton._edits[_singleton._undoEditIndex - 1].Undo();
                 _singleton._undoEditIndex--;
             }
+
+            // It's possible we just finished a history search, which saved the line when the search was triggered
+            // so that another search with the reversed order can go back to the same line.
+            // Now that we are reverting the real current line, the saved current line should be cleared since we
+            // will no longer go back to it.
+            _singleton.ClearSavedCurrentLine();
             _singleton.Render();
         }
 

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell
         private int _getNextHistoryIndex;
         private int _searchHistoryCommandCount;
         private int _recallHistoryCommandCount;
-        private int _allHistoryCommandCount;
+        private int _anyHistoryCommandCount;
         private string _searchHistoryPrefix;
         // When cycling through history, the current line (not yet added to history)
         // is saved here so it can be restored.
@@ -511,7 +511,7 @@ namespace Microsoft.PowerShell
             // to check if we need to load history from another sessions now.
             MaybeReadHistoryFile();
 
-            _allHistoryCommandCount += 1;
+            _anyHistoryCommandCount += 1;
             if (_savedCurrentLine.CommandLine == null)
             {
                 _savedCurrentLine.CommandLine = _buffer.ToString();

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -113,6 +113,13 @@ namespace Microsoft.PowerShell
             "password|asplaintext|token|key|secret",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        private void ClearSavedCurrentLine()
+        {
+            _savedCurrentLine.CommandLine = null;
+            _savedCurrentLine._edits = null;
+            _savedCurrentLine._undoEditIndex = 0;
+        }
+
         private AddToHistoryOption GetAddToHistoryOption(string line)
         {
             // Whitespace only is useless, never add.
@@ -217,9 +224,7 @@ namespace Microsoft.PowerShell
             // to recall the saved line.
             if (_getNextHistoryIndex == 0)
             {
-                _savedCurrentLine.CommandLine = null;
-                _savedCurrentLine._edits = null;
-                _savedCurrentLine._undoEditIndex = 0;
+                ClearSavedCurrentLine();
             }
             return result;
         }
@@ -633,7 +638,7 @@ namespace Microsoft.PowerShell
                     continue;
                 }
 
-                var line = newHistoryIndex == _history.Count ? _savedCurrentLine.CommandLine : _history[newHistoryIndex].CommandLine;
+                var line = _history[newHistoryIndex].CommandLine;
                 if (line.StartsWith(_searchHistoryPrefix, Options.HistoryStringComparison))
                 {
                     if (Options.HistoryNoDuplicates)

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -475,7 +475,7 @@ namespace Microsoft.PowerShell
             if (_currentHistoryIndex == _history.Count)
             {
                 line = _savedCurrentLine.CommandLine;
-                _edits = _savedCurrentLine._edits;
+                _edits = new List<EditItem>(_savedCurrentLine._edits);
                 _undoEditIndex = _savedCurrentLine._undoEditIndex;
             }
             else

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -95,6 +95,7 @@ namespace Microsoft.PowerShell
         private int _getNextHistoryIndex;
         private int _searchHistoryCommandCount;
         private int _recallHistoryCommandCount;
+        private int _allHistoryCommandCount;
         private string _searchHistoryPrefix;
         // When cycling through history, the current line (not yet added to history)
         // is saved here so it can be restored.
@@ -510,6 +511,7 @@ namespace Microsoft.PowerShell
             // to check if we need to load history from another sessions now.
             MaybeReadHistoryFile();
 
+            _allHistoryCommandCount += 1;
             if (_savedCurrentLine.CommandLine == null)
             {
                 _savedCurrentLine.CommandLine = _buffer.ToString();
@@ -687,6 +689,12 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void EndOfHistory(ConsoleKeyInfo? key = null, object arg = null)
         {
+            _singleton.SaveCurrentLine();
+            GoToEndOfHistory();
+        }
+
+        private static void GoToEndOfHistory()
+        {
             _singleton._currentHistoryIndex = _singleton._history.Count;
             _singleton.UpdateFromHistory(HistoryMoveCursor.ToEnd);
         }
@@ -844,7 +852,7 @@ namespace Microsoft.PowerShell
                 else if (function == Abort)
                 {
                     // Abort search
-                    EndOfHistory();
+                    GoToEndOfHistory();
                     break;
                 }
                 else

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -895,9 +895,6 @@ namespace Microsoft.PowerShell
             Render(); // Render prompt
             InteractiveHistorySearchLoop(direction);
 
-            _hashedHistory = null;
-            _currentHistoryIndex = _history.Count;
-
             _emphasisStart = -1;
             _emphasisLength = 0;
 

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -474,7 +474,7 @@ namespace Microsoft.PowerShell
                 var tabCommandCount = _tabCommandCount;
                 var searchHistoryCommandCount = _searchHistoryCommandCount;
                 var recallHistoryCommandCount = _recallHistoryCommandCount;
-                var allHistoryCommandCount = _allHistoryCommandCount;
+                var anyHistoryCommandCount = _anyHistoryCommandCount;
                 var yankLastArgCommandCount = _yankLastArgCommandCount;
                 var visualSelectionCommandCount = _visualSelectionCommandCount;
                 var moveToLineCommandCount = _moveToLineCommandCount;
@@ -524,15 +524,15 @@ namespace Microsoft.PowerShell
                 {
                     _recallHistoryCommandCount = 0;
                 }
-                if (allHistoryCommandCount == _allHistoryCommandCount)
+                if (anyHistoryCommandCount == _anyHistoryCommandCount)
                 {
-                    if (_allHistoryCommandCount > 0)
+                    if (_anyHistoryCommandCount > 0)
                     {
                         ClearSavedCurrentLine();
                         _hashedHistory = null;
                         _currentHistoryIndex = _history.Count;
                     }
-                    _allHistoryCommandCount = 0;
+                    _anyHistoryCommandCount = 0;
                 }
                 if (visualSelectionCommandCount == _visualSelectionCommandCount && _visualSelectionCommandCount > 0)
                 {
@@ -718,7 +718,7 @@ namespace Microsoft.PowerShell
             _yankLastArgCommandCount = 0;
             _tabCommandCount = 0;
             _recallHistoryCommandCount = 0;
-            _allHistoryCommandCount = 0;
+            _anyHistoryCommandCount = 0;
             _visualSelectionCommandCount = 0;
             _hashedHistory = null;
 

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -474,6 +474,7 @@ namespace Microsoft.PowerShell
                 var tabCommandCount = _tabCommandCount;
                 var searchHistoryCommandCount = _searchHistoryCommandCount;
                 var recallHistoryCommandCount = _recallHistoryCommandCount;
+                var allHistoryCommandCount = _allHistoryCommandCount;
                 var yankLastArgCommandCount = _yankLastArgCommandCount;
                 var visualSelectionCommandCount = _visualSelectionCommandCount;
                 var moveToLineCommandCount = _moveToLineCommandCount;
@@ -515,18 +516,22 @@ namespace Microsoft.PowerShell
                         _emphasisStart = -1;
                         _emphasisLength = 0;
                         Render();
-                        _currentHistoryIndex = _history.Count;
                     }
                     _searchHistoryCommandCount = 0;
                     _searchHistoryPrefix = null;
                 }
                 if (recallHistoryCommandCount == _recallHistoryCommandCount)
                 {
-                    if (_recallHistoryCommandCount > 0)
+                    _recallHistoryCommandCount = 0;
+                }
+                if (allHistoryCommandCount == _allHistoryCommandCount)
+                {
+                    if (_allHistoryCommandCount > 0)
                     {
+                        ClearSavedCurrentLine();
                         _currentHistoryIndex = _history.Count;
                     }
-                    _recallHistoryCommandCount = 0;
+                    _allHistoryCommandCount = 0;
                 }
                 if (searchHistoryCommandCount == _searchHistoryCommandCount &&
                     recallHistoryCommandCount == _recallHistoryCommandCount)

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -529,14 +529,10 @@ namespace Microsoft.PowerShell
                     if (_allHistoryCommandCount > 0)
                     {
                         ClearSavedCurrentLine();
+                        _hashedHistory = null;
                         _currentHistoryIndex = _history.Count;
                     }
                     _allHistoryCommandCount = 0;
-                }
-                if (searchHistoryCommandCount == _searchHistoryCommandCount &&
-                    recallHistoryCommandCount == _recallHistoryCommandCount)
-                {
-                    _hashedHistory = null;
                 }
                 if (visualSelectionCommandCount == _visualSelectionCommandCount && _visualSelectionCommandCount > 0)
                 {
@@ -722,6 +718,7 @@ namespace Microsoft.PowerShell
             _yankLastArgCommandCount = 0;
             _tabCommandCount = 0;
             _recallHistoryCommandCount = 0;
+            _allHistoryCommandCount = 0;
             _visualSelectionCommandCount = 0;
             _hashedHistory = null;
 

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -859,7 +859,7 @@ namespace Microsoft.PowerShell
                 return;
             }
 
-            _singleton._allHistoryCommandCount++;
+            _singleton._anyHistoryCommandCount++;
             _singleton.HistorySearch();
         }
 

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -835,6 +835,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViSearchHistoryBackward(ConsoleKeyInfo? key = null, object arg = null)
         {
+            _singleton.SaveCurrentLine();
             _singleton.StartSearch(backward: true);
         }
 
@@ -843,6 +844,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void SearchForward(ConsoleKeyInfo? key = null, object arg = null)
         {
+            _singleton.SaveCurrentLine();
             _singleton.StartSearch(backward: false);
         }
 
@@ -857,6 +859,7 @@ namespace Microsoft.PowerShell
                 return;
             }
 
+            _singleton._allHistoryCommandCount++;
             _singleton.HistorySearch();
         }
 

--- a/test/HistoryTest.VI.cs
+++ b/test/HistoryTest.VI.cs
@@ -110,6 +110,38 @@ namespace Test
         }
 
         [SkippableFact]
+        public void ViHistoryCommandMix()
+        {
+            TestSetup(KeyMode.Vi);
+
+            // Clear history in case the above added some history (but it shouldn't)
+            SetHistory();
+            Test( " ", Keys( ' ', _.UpArrow, _.DownArrow ) );
+
+            // Mix history search, repeat, and recall.
+            // Mix different history commands to verify that the saved current line and
+            // the history index stay the same while in a series of history commands.
+
+            SetHistory("bar1", "bar2", "bar3", "bar4", "bar5");
+            Test("first", Keys(
+                "first", _.Escape, _.Slash, "bar", _.Enter,
+                CheckThat(() => AssertLineIs("bar5")),
+                _.DownArrow, CheckThat(() => AssertLineIs("first")),
+                _.Slash, "bar", _.Enter,
+                CheckThat(() => AssertLineIs("bar5")),
+                "nn", CheckThat(() => AssertLineIs("bar3")),
+                "N", CheckThat(() => AssertLineIs("bar4")),
+                "N", CheckThat(() => AssertLineIs("bar5")),
+                "nnn", CheckThat(() => AssertLineIs("bar2")),
+                _.UpArrow, CheckThat(() => AssertLineIs("bar1")),
+                _.DownArrow, CheckThat(() => AssertLineIs("bar2")),
+                _.DownArrow, CheckThat(() => AssertLineIs("bar3")),
+                _.DownArrow, CheckThat(() => AssertLineIs("bar4")),
+                _.DownArrow, CheckThat(() => AssertLineIs("bar5")),
+                _.DownArrow));
+        }
+
+        [SkippableFact]
         public void ViMovementAfterHistory()
         {
             TestSetup(KeyMode.Vi);

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -411,6 +411,8 @@ namespace Test
 
             SetHistory("echo foo", "echo bar");
             Test("ec", Keys("ec", _.UpArrow, _.UpArrow, _.DownArrow, _.DownArrow));
+            Test("get", Keys("ec", _.UpArrow, _.DownArrow, _.Escape, "get", _.UpArrow, _.DownArrow));
+            Test("", Keys("ec", _.UpArrow, _.DownArrow, _.Escape, "get", _.UpArrow, _.DownArrow, _.Escape));
         }
 
         [SkippableFact]
@@ -422,6 +424,8 @@ namespace Test
 
             SetHistory("echo foo", "echo bar");
             Test("ec", Keys("ec", _.UpArrow, _.UpArrow, _.DownArrow, _.DownArrow));
+            Test("echo ", Keys("ec", _.UpArrow, _.DownArrow, _.Escape, "echo ", _.UpArrow, _.DownArrow));
+            Test("", Keys("ec", _.UpArrow, _.DownArrow, _.Escape, "echo ", _.UpArrow, _.DownArrow, _.Escape));
         }
 
         [SkippableFact]

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -410,9 +410,34 @@ namespace Test
             TestSetup(KeyMode.Cmd);
 
             SetHistory("echo foo", "echo bar");
-            Test("ec", Keys("ec", _.UpArrow, _.UpArrow, _.DownArrow, _.DownArrow));
-            Test("get", Keys("ec", _.UpArrow, _.DownArrow, _.Escape, "get", _.UpArrow, _.DownArrow));
-            Test("", Keys("ec", _.UpArrow, _.DownArrow, _.Escape, "get", _.UpArrow, _.DownArrow, _.Escape));
+            Test("ec", Keys(
+                "ec",
+                _.UpArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.UpArrow, CheckThat(() => AssertLineIs("echo foo")),
+                _.DownArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.DownArrow));
+
+            SetHistory("echo foo", "echo bar");
+            Test("get", Keys(
+                "ec", _.UpArrow,
+                _.DownArrow, CheckThat(() => AssertLineIs("ec")),
+                _.Escape, "get", _.UpArrow, _.DownArrow));
+
+            SetHistory("echo foo", "echo bar");
+            Test("ge", Keys(
+                "ec", _.UpArrow,
+                _.DownArrow, CheckThat(() => AssertLineIs("ec")),
+                _.Backspace, _.Backspace, "ge", CheckThat(() => AssertLineIs("ge")),
+                _.UpArrow, _.DownArrow));
+
+            SetHistory("echo foo", "echo bar");
+            Test("", Keys(
+                "ec", _.UpArrow,
+                _.DownArrow, CheckThat(() => AssertLineIs("ec")),
+                "h", CheckThat(() => AssertLineIs("ech")),
+                _.UpArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.DownArrow, CheckThat(() => AssertLineIs("ech")),
+                _.Escape));
         }
 
         [SkippableFact]
@@ -423,40 +448,106 @@ namespace Test
                       new KeyHandler("DownArrow", PSConsoleReadLine.HistorySearchForward));
 
             SetHistory("echo foo", "echo bar");
-            Test("ec", Keys("ec", _.UpArrow, _.UpArrow, _.DownArrow, _.DownArrow));
-            Test("echo ", Keys("ec", _.UpArrow, _.DownArrow, _.Escape, "echo ", _.UpArrow, _.DownArrow));
-            Test("", Keys("ec", _.UpArrow, _.DownArrow, _.Escape, "echo ", _.UpArrow, _.DownArrow, _.Escape));
+            Test("ec", Keys(
+                "ec",
+                _.UpArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.UpArrow, CheckThat(() => AssertLineIs("echo foo")),
+                _.DownArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.DownArrow));
+
+            SetHistory("echo foo", "echo bar");
+            Test("echo ", Keys(
+                "ec", _.UpArrow,
+                _.DownArrow, CheckThat(() => AssertLineIs("ec")),
+                _.Escape, "echo ",
+                _.UpArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.DownArrow));
+
+            SetHistory("echo foo", "echo bar");
+            Test("echo", Keys(
+                "ec", _.UpArrow, _.DownArrow,
+                "ho", CheckThat(() => AssertLineIs("echo")),
+                _.UpArrow, _.DownArrow));
+
+            SetHistory("echo foo", "echo bar");
+            Test("e", Keys(
+                "ec", _.UpArrow, _.DownArrow,
+                _.Backspace, CheckThat(() => AssertLineIs("e")),
+                _.UpArrow, _.DownArrow));
+
+            SetHistory("echo foo", "echo bar");
+            Test("", Keys(
+                "ec", _.UpArrow, _.DownArrow, "ho f",
+                _.UpArrow, CheckThat(() => AssertLineIs("echo foo")),
+                _.DownArrow, CheckThat(() => AssertLineIs("echo f")),
+                _.Escape));
         }
 
         [SkippableFact]
         public void HistorySavedCurrentLine()
         {
+            // while (!System.Diagnostics.Debugger.IsAttached)
+            // {
+            //     System.Threading.Thread.Sleep(100);
+            // }
+            // System.Diagnostics.Debugger.Break();
+
             TestSetup(KeyMode.Cmd,
                       new KeyHandler("F3", PSConsoleReadLine.BeginningOfHistory),
                       new KeyHandler("Shift+F3", PSConsoleReadLine.EndOfHistory));
 
             SetHistory("echo foo", "echo bar");
-            Test("echo bar", Keys("ec", _.UpArrow));
-            Test("echo foo", Keys("ec", _.UpArrow, _.F3));
-            Test("echo bar", Keys("ec", _.UpArrow, _.F3, _.DownArrow));
-            Test("ec", Keys("ec", _.UpArrow, _.F3, _.Shift_F3));
-            Test("ec", Keys("ec", _.UpArrow, _.F3, _.DownArrow, _.DownArrow));
+            Test("ec", Keys(
+                "ec",
+                _.UpArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.F3, CheckThat(() => AssertLineIs("echo foo")),
+                _.DownArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.DownArrow));
 
-            Test("echo foo", Keys("e", _.UpArrow, _.UpArrow));
-            Test("e", Keys("e", _.UpArrow, _.UpArrow, _.Shift_F3));
+            SetHistory("echo foo", "get zoo", "echo bar");
+            Test("ec", Keys(
+                "ec",
+                _.UpArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.F3, CheckThat(() => AssertLineIs("echo foo")),
+                _.Shift_F3));
 
-            Test("echo bar", Keys("ech", _.F8));
-            Test("echo foo", Keys("ech", _.F8, _.F3));
-            Test("echo bar", Keys("ech", _.F8, _.F3, _.DownArrow));
-            Test("ech", Keys("ech", _.F8, _.F3, _.DownArrow, _.DownArrow));
-            Test("ech", Keys("ech", _.F8, _.F8, _.Shift_F3));
+            SetHistory("echo foo", "get zoo", "echo bar");
+            Test("e", Keys(
+                "e",
+                _.UpArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.UpArrow, CheckThat(() => AssertLineIs("get zoo")),
+                _.Shift_F3));
 
-            SetHistory("echo foo", "echo f");
-            Test("echo f", Keys("ec", _.UpArrow));
-            Test("echo foo", Keys("ec", _.UpArrow, _.F8));
-            Test("echo f", Keys("ec", _.UpArrow, _.F8, _.Shift_F8));
-            Test("ec", Keys("ec", _.UpArrow, _.F8, _.DownArrow, _.DownArrow));
-            Test("ec", Keys("ec", _.UpArrow, _.F8, _.Shift_F8, _.Shift_F3));
+            SetHistory("echo foo", "get zoo", "echo bar");
+            Test("ech", Keys(
+                "ech",
+                _.F8, CheckThat(() => AssertLineIs("echo bar")),
+                _.F3, CheckThat(() => AssertLineIs("echo foo")),
+                _.DownArrow, CheckThat(() => AssertLineIs("get zoo")),
+                _.DownArrow, CheckThat(() => AssertLineIs("echo bar")),
+                _.DownArrow));
+
+            SetHistory("echo foo", "get zoo", "echo bar");
+            Test("ech", Keys(
+                "ech",
+                _.F8, CheckThat(() => AssertLineIs("echo bar")),
+                _.F8, CheckThat(() => AssertLineIs("echo foo")),
+                _.Shift_F3));
+
+            SetHistory("echo foo", "get bar", "echo f");
+            Test("ec", Keys(
+                "ec",
+                _.UpArrow, CheckThat(() => AssertLineIs("echo f")),
+                _.F8, CheckThat(() => AssertLineIs("echo foo")),
+                _.Shift_F8, CheckThat(() => AssertLineIs("echo f")),
+                _.DownArrow));
+
+            SetHistory("echo foo", "get bar", "echo f");
+            Test("ec", Keys(
+                "ec", _.UpArrow, _.F8,
+                _.DownArrow, CheckThat(() => AssertLineIs("get bar")),
+                _.DownArrow, CheckThat(() => AssertLineIs("echo f")),
+                _.Shift_F3));
         }
 
         [SkippableFact]

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -429,6 +429,37 @@ namespace Test
         }
 
         [SkippableFact]
+        public void HistorySavedCurrentLine()
+        {
+            TestSetup(KeyMode.Cmd,
+                      new KeyHandler("F3", PSConsoleReadLine.BeginningOfHistory),
+                      new KeyHandler("Shift+F3", PSConsoleReadLine.EndOfHistory));
+
+            SetHistory("echo foo", "echo bar");
+            Test("echo bar", Keys("ec", _.UpArrow));
+            Test("echo foo", Keys("ec", _.UpArrow, _.F3));
+            Test("echo bar", Keys("ec", _.UpArrow, _.F3, _.DownArrow));
+            Test("ec", Keys("ec", _.UpArrow, _.F3, _.Shift_F3));
+            Test("ec", Keys("ec", _.UpArrow, _.F3, _.DownArrow, _.DownArrow));
+
+            Test("echo foo", Keys("e", _.UpArrow, _.UpArrow));
+            Test("e", Keys("e", _.UpArrow, _.UpArrow, _.Shift_F3));
+
+            Test("echo bar", Keys("ech", _.F8));
+            Test("echo foo", Keys("ech", _.F8, _.F3));
+            Test("echo bar", Keys("ech", _.F8, _.F3, _.DownArrow));
+            Test("ech", Keys("ech", _.F8, _.F3, _.DownArrow, _.DownArrow));
+            Test("ech", Keys("ech", _.F8, _.F8, _.Shift_F3));
+
+            SetHistory("echo foo", "echo f");
+            Test("echo f", Keys("ec", _.UpArrow));
+            Test("echo foo", Keys("ec", _.UpArrow, _.F8));
+            Test("echo f", Keys("ec", _.UpArrow, _.F8, _.Shift_F8));
+            Test("ec", Keys("ec", _.UpArrow, _.F8, _.DownArrow, _.DownArrow));
+            Test("ec", Keys("ec", _.UpArrow, _.F8, _.Shift_F8, _.Shift_F3));
+        }
+
+        [SkippableFact]
         public void SearchHistory()
         {
             TestSetup(KeyMode.Cmd,

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -409,6 +409,7 @@ namespace Test
         {
             TestSetup(KeyMode.Cmd);
 
+            // Recall history backward and forward.
             SetHistory("echo foo", "echo bar");
             Test("ec", Keys(
                 "ec",
@@ -417,12 +418,15 @@ namespace Test
                 _.DownArrow, CheckThat(() => AssertLineIs("echo bar")),
                 _.DownArrow));
 
+            // Verify that the saved current line gets reset when the line gets edited.
+            // Recall history, then edit the line, and recall again.
             SetHistory("echo foo", "echo bar");
             Test("get", Keys(
                 "ec", _.UpArrow,
                 _.DownArrow, CheckThat(() => AssertLineIs("ec")),
                 _.Escape, "get", _.UpArrow, _.DownArrow));
 
+            // Recall history, then edit the line, and recall again.
             SetHistory("echo foo", "echo bar");
             Test("ge", Keys(
                 "ec", _.UpArrow,
@@ -430,6 +434,7 @@ namespace Test
                 _.Backspace, _.Backspace, "ge", CheckThat(() => AssertLineIs("ge")),
                 _.UpArrow, _.DownArrow));
 
+            // Recall history, then edit the line, and recall again.
             SetHistory("echo foo", "echo bar");
             Test("", Keys(
                 "ec", _.UpArrow,
@@ -447,6 +452,7 @@ namespace Test
                       new KeyHandler("UpArrow", PSConsoleReadLine.HistorySearchBackward),
                       new KeyHandler("DownArrow", PSConsoleReadLine.HistorySearchForward));
 
+            // Search history backward and forward.
             SetHistory("echo foo", "echo bar");
             Test("ec", Keys(
                 "ec",
@@ -455,6 +461,8 @@ namespace Test
                 _.DownArrow, CheckThat(() => AssertLineIs("echo bar")),
                 _.DownArrow));
 
+            // Verify that the saved current line gets reset when the line gets edited.
+            // Search history, then edit the line, and search again.
             SetHistory("echo foo", "echo bar");
             Test("echo ", Keys(
                 "ec", _.UpArrow,
@@ -463,18 +471,21 @@ namespace Test
                 _.UpArrow, CheckThat(() => AssertLineIs("echo bar")),
                 _.DownArrow));
 
+            // Search history, then edit the line, and search again.
             SetHistory("echo foo", "echo bar");
             Test("echo", Keys(
                 "ec", _.UpArrow, _.DownArrow,
                 "ho", CheckThat(() => AssertLineIs("echo")),
                 _.UpArrow, _.DownArrow));
 
+            // Search history, then edit the line, and search again.
             SetHistory("echo foo", "echo bar");
             Test("e", Keys(
                 "ec", _.UpArrow, _.DownArrow,
                 _.Backspace, CheckThat(() => AssertLineIs("e")),
                 _.UpArrow, _.DownArrow));
 
+            // Search history, then edit the line, and search again.
             SetHistory("echo foo", "echo bar");
             Test("", Keys(
                 "ec", _.UpArrow, _.DownArrow, "ho f",
@@ -486,15 +497,12 @@ namespace Test
         [SkippableFact]
         public void HistorySavedCurrentLine()
         {
-            // while (!System.Diagnostics.Debugger.IsAttached)
-            // {
-            //     System.Threading.Thread.Sleep(100);
-            // }
-            // System.Diagnostics.Debugger.Break();
-
             TestSetup(KeyMode.Cmd,
                       new KeyHandler("F3", PSConsoleReadLine.BeginningOfHistory),
                       new KeyHandler("Shift+F3", PSConsoleReadLine.EndOfHistory));
+
+            // Mix different history commands to verify that the saved current line and
+            // the history index stay the same while in a series of history commands.
 
             SetHistory("echo foo", "echo bar");
             Test("ec", Keys(
@@ -548,6 +556,17 @@ namespace Test
                 _.DownArrow, CheckThat(() => AssertLineIs("get bar")),
                 _.DownArrow, CheckThat(() => AssertLineIs("echo f")),
                 _.Shift_F3));
+
+            SetHistory("echo kv", "get bar", "echo f");
+            Test("e", Keys(
+                "e",
+                _.UpArrow, CheckThat(() => AssertLineIs("echo f")),
+                _.Ctrl_r, "v", _.Escape,
+                CheckThat(() => AssertLineIs("echo kv")),
+                _.Ctrl_s, "f", _.Escape,
+                CheckThat(() => AssertLineIs("echo f")),
+                _.UpArrow, CheckThat(() => AssertLineIs("get bar")),
+                _.DownArrow, _.DownArrow));
         }
 
         [SkippableFact]


### PR DESCRIPTION
Fix #1257

Major changes:
1. Preserve the saved current line and the history index while in a series of history commands.
    So when switching between different history command, such as from `F8`/`Shift+F8` (`HistorySearchBackward` and `HistorySearchForward`) to `UpArrow`/`DownArrow`  (recall history) or from `Ctrl+r`/`Ctrl+s` to `UpArrow`/`DownArrow`, the history command can continue to work as expected.
2. Clear the saved current line when we are out of a series of history commands.
    So the saved line will not leak to another unrelated history search.