### PR TITLE
Fix a few VI edit mode issues

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -164,8 +164,6 @@ namespace Microsoft.PowerShell
 
         private void DeleteCharImpl(int qty, bool orExit)
         {
-            qty = Math.Min(qty, _singleton._buffer.Length + 1 + ViEndOfLineFactor - _singleton._current);
-
             if (_visualSelectionCommandCount > 0)
             {
                 GetRegion(out var start, out var length);
@@ -177,6 +175,8 @@ namespace Microsoft.PowerShell
             {
                 if (_current < _buffer.Length)
                 {
+                    qty = Math.Min(qty, _singleton._buffer.Length - _singleton._current);
+
                     SaveEditItem(EditItemDelete.Create(_buffer.ToString(_current, qty), _current, DeleteChar, qty));
                     SaveToClipboard(_current, qty);
                     _buffer.Remove(_current, qty);

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -114,9 +114,11 @@ namespace Microsoft.PowerShell
                     _singleton.MoveCursor(newCurrent);
                 }
             }
-            else
+            else if (_singleton._current < _singleton._buffer.Length)
             {
-                var end = GetEndOfLogicalLinePos(_singleton._current);
+                // when in the VI command mode, 'end' is the position of the last character;
+                // when in the VI insert mode, 'end' is 1 char beyond the last character.
+                var end = GetEndOfLogicalLinePos(_singleton._current) + 1 + ViEndOfLineFactor;
                 var newCurrent = Math.Min(end, _singleton._current + count);
                 if (_singleton._current != newCurrent)
                 {

--- a/PSReadLine/Position.cs
+++ b/PSReadLine/Position.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell
         {
             var newCurrent = current;
 
-            for (var position = newCurrent; position < _singleton._buffer.Length; position++)
+            for (var position = current; position < _singleton._buffer.Length; position++)
             {
                 if (_singleton._buffer[position] == '\n')
                 {

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -589,14 +589,8 @@ namespace Microsoft.PowerShell
         {
             _singleton._groupUndoHelper.StartGroup(ViInsertWithDelete, arg);
 
-            var isEOL = _singleton._current == _singleton._buffer.Length + ViEndOfLineFactor;
-
-            DeleteChar(key, arg);
-            if(isEOL && _singleton._buffer.Length > 0)
-            {
-                _singleton._current++;
-            }
             ViInsertMode(key, arg);
+            DeleteChar(key, arg);
         }
 
         /// <summary>

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -592,7 +592,7 @@ namespace Microsoft.PowerShell
             var isEOL = _singleton._current == _singleton._buffer.Length + ViEndOfLineFactor;
 
             DeleteChar(key, arg);
-            if(isEOL)
+            if(isEOL && _singleton._buffer.Length > 0)
             {
                 _singleton._current++;
             }

--- a/PSReadLine/Replace.vi.cs
+++ b/PSReadLine/Replace.vi.cs
@@ -213,8 +213,8 @@ namespace Microsoft.PowerShell
         private static void ReplaceChar(ConsoleKeyInfo? key, object arg)
         {
             _singleton._groupUndoHelper.StartGroup(ReplaceChar, arg);
-            DeleteChar(key, arg);
             ViInsertMode(key, arg);
+            DeleteChar(key, arg);
         }
 
         /// <summary>

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -256,6 +256,12 @@ namespace Test
             TestSetup(KeyMode.Vi);
 
             Test("", Keys(
+                "a", _.Escape, CheckThat(() => AssertLineIs("a")),
+                "s", CheckThat(() => AssertLineIs("")),
+                "bc", CheckThat(() => AssertLineIs("bc"))
+                ));
+
+            Test("", Keys(
                 "0123456789", _.Escape, CheckThat(() => AssertCursorLeftIs(9)),
                 "x", CheckThat(() => AssertLineIs("012345678")), CheckThat(() => AssertCursorLeftIs(8)),
                 "X", CheckThat(() => AssertLineIs("01234568")), CheckThat(() => AssertCursorLeftIs(7)),

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -898,6 +898,7 @@ namespace Test
                 "ab", CheckThat(() => AssertCursorLeftIs(2)),
                 _.LeftArrow, CheckThat(() => AssertCursorLeftIs(1)),
                 _.RightArrow, CheckThat(() => AssertCursorLeftIs(2)),
+                _.RightArrow, // 'RightArrow' again does nothing, but doesn't crash
                 "c"));
         }
     }

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -256,7 +256,9 @@ namespace Test
             TestSetup(KeyMode.Vi);
 
             Test("bc", Keys(
-                "a", _.Escape, CheckThat(() => AssertLineIs("a")),
+                "a", _.Escape,
+                CheckThat(() => AssertLineIs("a")),
+                CheckThat(() => AssertCursorLeftIs(0)),
                 "s", CheckThat(() => AssertLineIs("")),
                 "bc"));
 
@@ -885,6 +887,18 @@ namespace Test
                 _.Escape, "hCig", _.Tab, CheckThat(() => AssertLineIs("ambiguous")),
                 _.Escape, "Csness"
                 ));
+        }
+
+        [SkippableFact]
+        public void ViInsertModeMoveCursor()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("abc", Keys(
+                "ab", CheckThat(() => AssertCursorLeftIs(2)),
+                _.LeftArrow, CheckThat(() => AssertCursorLeftIs(1)),
+                _.RightArrow, CheckThat(() => AssertCursorLeftIs(2)),
+                "c"));
         }
     }
 }

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -255,11 +255,10 @@ namespace Test
         {
             TestSetup(KeyMode.Vi);
 
-            Test("", Keys(
+            Test("bc", Keys(
                 "a", _.Escape, CheckThat(() => AssertLineIs("a")),
                 "s", CheckThat(() => AssertLineIs("")),
-                "bc", CheckThat(() => AssertLineIs("bc"))
-                ));
+                "bc"));
 
             Test("", Keys(
                 "0123456789", _.Escape, CheckThat(() => AssertCursorLeftIs(9)),

--- a/test/BasicEditingTest.cs
+++ b/test/BasicEditingTest.cs
@@ -159,6 +159,18 @@ namespace Test
         }
 
         [SkippableFact]
+        public void DeleteCharAfterDigitArgument()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            Test("abc", Keys(
+                "ab", _.LeftArrow, _.Alt_2, _.Delete, _.Delete,
+                CheckThat(() => AssertLineIs("a")),
+                CheckThat(() => AssertCursorLeftIs(1)),
+                "bc"));
+        }
+
+        [SkippableFact]
         public void DeleteCharOrExit()
         {
             TestSetup(KeyMode.Emacs);

--- a/test/BasicEditingTest.cs
+++ b/test/BasicEditingTest.cs
@@ -164,7 +164,10 @@ namespace Test
             TestSetup(KeyMode.Cmd);
 
             Test("abc", Keys(
-                "ab", _.LeftArrow, _.Alt_2, _.Delete, _.Delete,
+                "ab", _.LeftArrow, _.Alt_2, _.Delete,
+                CheckThat(() => AssertLineIs("a")),
+                CheckThat(() => AssertCursorLeftIs(1)),
+                _.Delete, // 'Delete' again does nothing, but doesn't crash
                 CheckThat(() => AssertLineIs("a")),
                 CheckThat(() => AssertCursorLeftIs(1)),
                 "bc"));


### PR DESCRIPTION
Fix #1258
`ViInsertWithDelete` changes the VI mode from command mode to insert mode. It should make the mode change before calling `DeleteChar`, so the handling of `ViEndOfLineFactor` in `DeleteCharImpl` would be correct.

Fix #1278
Fix the calculation of how many characters to be deleted in `DeleteCharImpl`.

Fix #1279 
Fix `ViForwardChar` so that `RightArrow` works as expected in VI insert mode.

~Tests to be added~ Tests are added.