### PR TITLE
Allow SmartInsertQuote after InsertPairedBraces

### DIFF
--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -187,7 +187,7 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
         }
     }
 
-    if ($null -eq $token) {
+    if ($null -eq $token -or $token.Kind -eq [TokenKind]::RParen -or $token.Kind -eq [TokenKind]::RCurly) {
         if ($line[0..$cursor].Where{$_ -eq $quote}.Count % 2 -eq 1) {
             # Odd number of quotes before the cursor, insert a single quote
             [Microsoft.PowerShell.PSConsoleReadLine]::Insert($quote)

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -207,8 +207,8 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
             $len = $end - $cursor
             [Microsoft.PowerShell.PSConsoleReadLine]::Replace($cursor, $len, $quote + $line.SubString($cursor, $len) + $quote)
             [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($end + 2)
-            return
         }
+        return
     }
 
     # We failed to be smart, so just insert a single quote

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -187,7 +187,8 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
         }
     }
 
-    if ($null -eq $token -or $token.Kind -eq [TokenKind]::RParen -or $token.Kind -eq [TokenKind]::RCurly) {
+    if ($null -eq $token -or $token.Kind -eq [TokenKind]::RParen -or $token.Kind -eq [TokenKind]::RCurly -or 
+        $token.Kind -eq [TokenKind]::RBracket) {
         if ($line[0..$cursor].Where{$_ -eq $quote}.Count % 2 -eq 1) {
             # Odd number of quotes before the cursor, insert a single quote
             [Microsoft.PowerShell.PSConsoleReadLine]::Insert($quote)

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -187,8 +187,8 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
         }
     }
 
-    if ($null -eq $token -or $token.Kind -eq [TokenKind]::RParen -or $token.Kind -eq [TokenKind]::RCurly -or 
-        $token.Kind -eq [TokenKind]::RBracket) {
+    if ($null -eq $token -or
+        $token.Kind -eq [TokenKind]::RParen -or $token.Kind -eq [TokenKind]::RCurly -or $token.Kind -eq [TokenKind]::RBracket) {
         if ($line[0..$cursor].Where{$_ -eq $quote}.Count % 2 -eq 1) {
             # Odd number of quotes before the cursor, insert a single quote
             [Microsoft.PowerShell.PSConsoleReadLine]::Insert($quote)
@@ -207,8 +207,8 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
             $len = $end - $cursor
             [Microsoft.PowerShell.PSConsoleReadLine]::Replace($cursor, $len, $quote + $line.SubString($cursor, $len) + $quote)
             [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($end + 2)
+            return
         }
-        return
     }
 
     # We failed to be smart, so just insert a single quote


### PR DESCRIPTION
Previously SmartInsertQuote would not insert a quote if a closing paren/curly was the highlighted token, eg if InsertPairedBraces had just inserted a closer - SmartInsertQuote will now handle this situation for parenthesis and curly brackets.
This commit does not allow SmartInsertQuote on a closing square bracket - that still makes it through to the "We failed to be smart, so just insert a single quote" part at the bottom.