### PR TITLE
Allow SmartInsertQuote to surround keywords

### DIFF
--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -201,7 +201,8 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
     }
 
     if ($token.Extent.StartOffset -eq $cursor) {
-        if ($token.Kind -eq [TokenKind]::Generic -or $token.Kind -eq [TokenKind]::Identifier) {
+        if ($token.Kind -eq [TokenKind]::Generic -or $token.Kind -eq [TokenKind]::Identifier -or 
+            $token.TokenFlags.hasFlag([TokenFlags]::Keyword)) {
             $end = $token.Extent.EndOffset
             $len = $end - $cursor
             [Microsoft.PowerShell.PSConsoleReadLine]::Replace($cursor, $len, $quote + $line.SubString($cursor, $len) + $quote)

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -207,8 +207,8 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
             $len = $end - $cursor
             [Microsoft.PowerShell.PSConsoleReadLine]::Replace($cursor, $len, $quote + $line.SubString($cursor, $len) + $quote)
             [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($end + 2)
+            return
         }
-        return
     }
 
     # We failed to be smart, so just insert a single quote

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -202,7 +202,7 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
 
     if ($token.Extent.StartOffset -eq $cursor) {
         if ($token.Kind -eq [TokenKind]::Generic -or $token.Kind -eq [TokenKind]::Identifier -or 
-            $token.TokenFlags.hasFlag([TokenFlags]::Keyword)) {
+            $token.Kind -eq [TokenKind]::Variable -or $token.TokenFlags.hasFlag([TokenFlags]::Keyword)) {
             $end = $token.Extent.EndOffset
             $len = $end - $cursor
             [Microsoft.PowerShell.PSConsoleReadLine]::Replace($cursor, $len, $quote + $line.SubString($cursor, $len) + $quote)


### PR DESCRIPTION
Previously it wasn't possible to type an apostrophe before a keyword with SmartInsertQuote on, now keywords are surrounded correctly.
`hasFlag()` requires .net framework 4.0 or .net core