### PR TITLE
Add a -Chord param to Get-PSReadLineKeyHandler

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -809,7 +809,7 @@ namespace Microsoft.PowerShell
     [OutputType(typeof(KeyHandler))]
     public class GetKeyHandlerCommand : PSCmdlet
     {
-        [Parameter]
+        [Parameter(ParameterSetName = "FullListing")]
         public SwitchParameter Bound
         {
             get => _bound.GetValueOrDefault();
@@ -817,7 +817,7 @@ namespace Microsoft.PowerShell
         }
         private SwitchParameter? _bound;
 
-        [Parameter]
+        [Parameter(ParameterSetName = "FullListing")]
         public SwitchParameter Unbound
         {
             get => _unbound.GetValueOrDefault();
@@ -825,7 +825,8 @@ namespace Microsoft.PowerShell
         }
         private SwitchParameter? _unbound;
 
-        [Parameter]
+        [Parameter(ParameterSetName = "SpecificBindings", Position = 0, Mandatory = true)]
+        [ValidateNotNullOrEmpty]
         [Alias("Key")]
         public string[] Chord { get; set; }
 

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -825,6 +825,10 @@ namespace Microsoft.PowerShell
         }
         private SwitchParameter? _unbound;
 
+        [Parameter]
+        [Alias("Key")]
+        public string[] Chord { get; set; }
+
         [ExcludeFromCodeCoverage]
         protected override void EndProcessing()
         {
@@ -845,7 +849,7 @@ namespace Microsoft.PowerShell
                 bound = false;
                 unbound = _unbound.Value.IsPresent;
             }
-            var groups = PSConsoleReadLine.GetKeyHandlers(bound, unbound).GroupBy(k => k.Group).OrderBy(g => g.Key);
+            var groups = PSConsoleReadLine.GetKeyHandlers(bound, unbound, Chord).GroupBy(k => k.Group).OrderBy(g => g.Key);
             foreach (var bindings in groups)
             {
                 WriteObject(bindings.OrderBy(k => k.Function), true);

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -805,7 +805,8 @@ namespace Microsoft.PowerShell
         }
     }
 
-    [Cmdlet("Get", "PSReadLineKeyHandler", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=528807")]
+    [Cmdlet("Get", "PSReadLineKeyHandler", DefaultParameterSetName = "FullListing", 
+        HelpUri = "https://go.microsoft.com/fwlink/?LinkId=528807")]
     [OutputType(typeof(KeyHandler))]
     public class GetKeyHandlerCommand : PSCmdlet
     {

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -851,7 +851,18 @@ namespace Microsoft.PowerShell
                 bound = false;
                 unbound = _unbound.Value.IsPresent;
             }
-            var groups = PSConsoleReadLine.GetKeyHandlers(bound, unbound, Chord).GroupBy(k => k.Group).OrderBy(g => g.Key);
+
+            IEnumerable<PowerShell.KeyHandler> handlers;
+            if (ParameterSetName.Equals("FullListing", StringComparison.OrdinalIgnoreCase))
+            {
+                 handlers = PSConsoleReadLine.GetKeyHandlers(bound, unbound);
+            }
+            else
+            {
+                 handlers = PSConsoleReadLine.GetKeyHandlers(Chord);
+            }
+            var groups = handlers.GroupBy(k => k.Group).OrderBy(g => g.Key);
+
             foreach (var bindings in groups)
             {
                 WriteObject(bindings.OrderBy(k => k.Function), true);

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -293,11 +293,11 @@ namespace Microsoft.PowerShell
 
             if (Chord != null)
             {
-                foreach (var Key in Chord)
+                foreach (string Key in Chord)
                 {
-                    var consoleKeyChord = ConsoleKeyChordConverter.Convert(Key);
-                    var firstKey = PSKeyInfo.FromConsoleKeyInfo(consoleKeyChord[0]);
-                    if (_singleton._dispatchTable.TryGetValue(firstKey, out var entry))
+                    ConsoleKeyInfo[] consoleKeyChord = ConsoleKeyChordConverter.Convert(Key);
+                    PSKeyInfo firstKey = PSKeyInfo.FromConsoleKeyInfo(consoleKeyChord[0]);
+                    if (_singleton._dispatchTable.TryGetValue(firstKey, out KeyHandler entry))
                     {
                         if (consoleKeyChord.Length == 1)
                         {
@@ -311,7 +311,7 @@ namespace Microsoft.PowerShell
                         }
                         else
                         {
-                            var secondKey = PSKeyInfo.FromConsoleKeyInfo(consoleKeyChord[1]);
+                            PSKeyInfo secondKey = PSKeyInfo.FromConsoleKeyInfo(consoleKeyChord[1]);
                             if (_singleton._chordDispatchTable.TryGetValue(firstKey, out var secondDispatchTable) &&
                                 secondDispatchTable.TryGetValue(secondKey, out entry))
                             {
@@ -329,7 +329,7 @@ namespace Microsoft.PowerShell
                 yield break;
             }
 
-            foreach (var entry in _singleton._dispatchTable)
+            foreach (KeyValuePair<PSKeyInfo, KeyHandler> entry in _singleton._dispatchTable)
             {
                 if (entry.Value.BriefDescription == "Ignore"
                     || entry.Value.BriefDescription == "ChordFirstKey")

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -271,21 +271,38 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static IEnumerable<PowerShell.KeyHandler> GetKeyHandlers()
         {
-            return GetKeyHandlers(includeBound: true, includeUnbound: false);
+            return GetKeyHandlers(includeBound: true, includeUnbound: false, Chord: null);
+        }
+
+        /// <summary>
+        /// Return bound/unbound key handlers without filtering.
+        /// </summary>
+        /// <returns></returns>
+        public static IEnumerable<PowerShell.KeyHandler> GetKeyHandlers(bool includeBound, bool includeUnbound)
+        {
+            return GetKeyHandlers(includeBound: includeBound, includeUnbound: includeUnbound, Chord: null);
         }
 
         /// <summary>
         /// Helper function for the Get-PSReadLineKeyHandler cmdlet.
         /// </summary>
         /// <returns></returns>
-        public static IEnumerable<PowerShell.KeyHandler> GetKeyHandlers(bool includeBound, bool includeUnbound)
+        public static IEnumerable<PowerShell.KeyHandler> GetKeyHandlers(bool includeBound, bool includeUnbound, string[] Chord)
         {
             var boundFunctions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var searchChords = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (Chord != null) { foreach (var Key in Chord) { searchChords.Add(Key); }; }
 
             foreach (var entry in _singleton._dispatchTable)
             {
                 if (entry.Value.BriefDescription == "Ignore"
                     || entry.Value.BriefDescription == "ChordFirstKey")
+                {
+                    continue;
+                }
+                if (Chord != null && !searchChords.Contains(entry.Key.ToString()))
                 {
                     continue;
                 }
@@ -309,6 +326,10 @@ namespace Microsoft.PowerShell
                 {
                     if (entry.Value.BriefDescription == "Ignore"
                         || entry.Value.BriefDescription == "ChordFirstKey")
+                    {
+                        continue;
+                    }
+                    if (Chord != null && !searchChords.Contains(entry.Key.ToString()))
                     {
                         continue;
                     }

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -291,9 +291,13 @@ namespace Microsoft.PowerShell
         {
             var boundFunctions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            var searchChords = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var searchChords = new HashSet<PSKeyInfo>();
 
-            if (Chord != null) { foreach (var Key in Chord) { searchChords.Add(Key); }; }
+            if (Chord != null) foreach (var Key in Chord)
+                {
+                    var consoleKeyChord = ConsoleKeyChordConverter.Convert(Key);
+                    searchChords.Add(PSKeyInfo.FromConsoleKeyInfo(consoleKeyChord[0])); 
+                }
 
             foreach (var entry in _singleton._dispatchTable)
             {
@@ -302,7 +306,7 @@ namespace Microsoft.PowerShell
                 {
                     continue;
                 }
-                if (Chord != null && !searchChords.Contains(entry.Key.ToString()))
+                if (Chord != null && !searchChords.Contains(entry.Key))
                 {
                     continue;
                 }
@@ -329,7 +333,7 @@ namespace Microsoft.PowerShell
                     {
                         continue;
                     }
-                    if (Chord != null && !searchChords.Contains(entry.Key.ToString()))
+                    if (Chord != null && !searchChords.Contains(entry.Key))
                     {
                         continue;
                     }
@@ -351,7 +355,7 @@ namespace Microsoft.PowerShell
             {
                 foreach( var secondEntry in entry.Value )
                 {
-                    if (Chord != null && !searchChords.Contains(entry.Key.ToString()) && !searchChords.Contains(secondEntry.Key.ToString()))
+                    if (Chord != null && !searchChords.Contains(entry.Key) && !searchChords.Contains(secondEntry.Key))
                     {
                         continue;
                     }
@@ -380,7 +384,7 @@ namespace Microsoft.PowerShell
                         {
                             continue;
                         }
-                        if (Chord != null && !searchChords.Contains(entry.Key.ToString()) && !searchChords.Contains(secondEntry.Key.ToString()))
+                        if (Chord != null && !searchChords.Contains(entry.Key) && !searchChords.Contains(secondEntry.Key))
                         {
                             continue;
                         }

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -351,6 +351,10 @@ namespace Microsoft.PowerShell
             {
                 foreach( var secondEntry in entry.Value )
                 {
+                    if (Chord != null && !searchChords.Contains(entry.Key.ToString()) && !searchChords.Contains(secondEntry.Key.ToString()))
+                    {
+                        continue;
+                    }
                     boundFunctions.Add( secondEntry.Value.BriefDescription );
                     if (includeBound)
                     {
@@ -373,6 +377,10 @@ namespace Microsoft.PowerShell
                     foreach (var secondEntry in entry.Value)
                     {
                         if (secondEntry.Value.BriefDescription == "Ignore")
+                        {
+                            continue;
+                        }
+                        if (Chord != null && !searchChords.Contains(entry.Key.ToString()) && !searchChords.Contains(secondEntry.Key.ToString()))
                         {
                             continue;
                         }

--- a/docs/Get-PSReadLineKeyHandler.md
+++ b/docs/Get-PSReadLineKeyHandler.md
@@ -63,6 +63,22 @@ Accept pipeline input: false
 Accept wildcard characters: False
 ```
 
+### -Chord
+
+Return only functions bound to specific keys or sequences.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: Key
+
+Required: False
+Position: Named
+Default value:
+Accept pipeline input: false
+Accept wildcard characters: False
+```
+
 ## INPUTS
 
 ### None

--- a/docs/Get-PSReadLineKeyHandler.md
+++ b/docs/Get-PSReadLineKeyHandler.md
@@ -37,7 +37,7 @@ Include functions that are bound.
 
 ```yaml
 Type: switch
-Parameter Sets: (All)
+Parameter Sets: Set 1
 Aliases:
 
 Required: False
@@ -53,7 +53,7 @@ Include functions that are unbound.
 
 ```yaml
 Type: switch
-Parameter Sets: (All)
+Parameter Sets: Set 1
 Aliases:
 
 Required: False
@@ -69,11 +69,11 @@ Return only functions bound to specific keys or sequences.
 
 ```yaml
 Type: String[]
-Parameter Sets: (All)
+Parameter Sets: Set 2
 Aliases: Key
 
-Required: False
-Position: Named
+Required: True
+Position: 0
 Default value:
 Accept pipeline input: false
 Accept wildcard characters: False

--- a/test/OptionsTest.VI.cs
+++ b/test/OptionsTest.VI.cs
@@ -24,9 +24,18 @@ namespace Test
                 Assert.False(string.IsNullOrWhiteSpace(handler.Description));
             }
 
-            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "home" }))
+            var handlers = PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "home" });
+            Assert.NotEmpty(handlers);
+            foreach (var handler in handlers)
             {
                 Assert.Contains("Home", handler.Key);
+            }
+
+            handlers = PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "d,0" });
+            Assert.NotEmpty(handlers);
+            foreach (var handler in handlers)
+            {
+                Assert.Equal("<d,0>", handler.Key);
             }
         }
     }

--- a/test/OptionsTest.VI.cs
+++ b/test/OptionsTest.VI.cs
@@ -23,6 +23,11 @@ namespace Test
                 Assert.False(string.IsNullOrWhiteSpace(handler.Function));
                 Assert.False(string.IsNullOrWhiteSpace(handler.Description));
             }
+
+            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(includeBound: true, includeUnbound: false, Chord: new string[] { "home" }))
+            {
+                Assert.Contains("Home", handler.Key);
+            }
         }
     }
 }

--- a/test/OptionsTest.VI.cs
+++ b/test/OptionsTest.VI.cs
@@ -24,7 +24,7 @@ namespace Test
                 Assert.False(string.IsNullOrWhiteSpace(handler.Description));
             }
 
-            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(includeBound: true, includeUnbound: false, Chord: new string[] { "home" }))
+            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "home" }))
             {
                 Assert.Contains("Home", handler.Key);
             }

--- a/test/OptionsTest.cs
+++ b/test/OptionsTest.cs
@@ -85,7 +85,12 @@ namespace Test
             TestSetup(KeyMode.Emacs);
             foreach (var handler in PSConsoleReadLine.GetKeyHandlers(includeBound: true, includeUnbound: false, Chord: new string[] { "ctrl+x" }))
             {
-                Assert.Contains("Ctrl+x", handler.Key);
+                Assert.Equal("Ctrl+x", handler.Key);
+            }
+
+            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(includeBound: true, includeUnbound: false, Chord: new string[] { "ctrl+x,ctrl+e" }))
+            {
+                Assert.Equal("Ctrl+x,Ctrl+e", handler.Key);
             }
         }
 

--- a/test/OptionsTest.cs
+++ b/test/OptionsTest.cs
@@ -76,19 +76,19 @@ namespace Test
                     Assert.False(string.IsNullOrWhiteSpace(handler.Description));
                 }
 
-                foreach (var handler in PSConsoleReadLine.GetKeyHandlers(includeBound: true, includeUnbound: false, Chord: new string[] { "home"}))
+                foreach (var handler in PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "home"}))
                 {
                     Assert.Equal("Home", handler.Key);
                 }
             }
 
             TestSetup(KeyMode.Emacs);
-            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(includeBound: true, includeUnbound: false, Chord: new string[] { "ctrl+x" }))
+            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "ctrl+x" }))
             {
                 Assert.Equal("Ctrl+x", handler.Key);
             }
 
-            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(includeBound: true, includeUnbound: false, Chord: new string[] { "ctrl+x,ctrl+e" }))
+            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "ctrl+x,ctrl+e" }))
             {
                 Assert.Equal("Ctrl+x,Ctrl+e", handler.Key);
             }

--- a/test/OptionsTest.cs
+++ b/test/OptionsTest.cs
@@ -75,6 +75,17 @@ namespace Test
                     Assert.False(string.IsNullOrWhiteSpace(handler.Function));
                     Assert.False(string.IsNullOrWhiteSpace(handler.Description));
                 }
+
+                foreach (var handler in PSConsoleReadLine.GetKeyHandlers(includeBound: true, includeUnbound: false, Chord: new string[] { "home"}))
+                {
+                    Assert.Equal("Home", handler.Key);
+                }
+            }
+
+            TestSetup(KeyMode.Emacs);
+            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(includeBound: true, includeUnbound: false, Chord: new string[] { "ctrl+x" }))
+            {
+                Assert.Contains("Ctrl+x", handler.Key);
             }
         }
 

--- a/test/OptionsTest.cs
+++ b/test/OptionsTest.cs
@@ -58,6 +58,8 @@ namespace Test
         [SkippableFact]
         public void GetKeyHandlers()
         {
+            System.Collections.Generic.IEnumerable<Microsoft.PowerShell.KeyHandler> handlers;
+
             foreach (var keymode in new[] {KeyMode.Cmd, KeyMode.Emacs})
             {
                 TestSetup(keymode);
@@ -76,19 +78,26 @@ namespace Test
                     Assert.False(string.IsNullOrWhiteSpace(handler.Description));
                 }
 
-                foreach (var handler in PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "home"}))
+                handlers = PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "home" });
+                Assert.NotEmpty(handlers);
+                foreach (var handler in handlers)
                 {
                     Assert.Equal("Home", handler.Key);
                 }
             }
 
             TestSetup(KeyMode.Emacs);
-            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "ctrl+x" }))
+            
+            handlers = PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "ctrl+x" });
+            Assert.NotEmpty(handlers);
+            foreach (var handler in handlers)
             {
                 Assert.Equal("Ctrl+x", handler.Key);
             }
 
-            foreach (var handler in PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "ctrl+x,ctrl+e" }))
+            handlers = PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "ctrl+x,ctrl+e" });
+            Assert.NotEmpty(handlers);
+            foreach (var handler in handlers)
             {
                 Assert.Equal("Ctrl+x,Ctrl+e", handler.Key);
             }


### PR DESCRIPTION
Allow filtering of results by keys used in binding.

Closes #879 