### PR TITLE
Name the `ReadKey` thread for debug purpose

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -844,7 +844,7 @@ namespace Microsoft.PowerShell
                 };
             }
 
-            _singleton._readKeyThread = new Thread(_singleton.ReadKeyThreadProc) {IsBackground = true};
+            _singleton._readKeyThread = new Thread(_singleton.ReadKeyThreadProc) {IsBackground = true, Name = "PSReadLine ReadKey Thread"};
             _singleton._readKeyThread.Start();
         }
 


### PR DESCRIPTION
When debugging a powershell dump, it's not very straightforward to know if this thread is a threadpool thread, so naming the thread to make it easy to tell.

The changes in `if (moveToLineCommandCount == _moveToLineCommandCount)` block is caused by line ending I believe.
A reviewer can use this link to ignore those line ending changes: https://github.com/PowerShell/PSReadLine/pull/1313/files?w=1

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1313)