### PR TITLE
Simplify the way to get semantic version information

### DIFF
--- a/PSReadLine.build.ps1
+++ b/PSReadLine.build.ps1
@@ -169,24 +169,10 @@ task LayoutModule BuildMainModule, BuildMamlHelp, {
     }
 
     # Copy module manifest, but fix the version to match what we've specified in the binary module.
-    $version = (Get-ChildItem -Path $targetDir/Microsoft.PowerShell.PSReadLine2.dll).VersionInfo.FileVersion
     $moduleManifestContent = ConvertTo-CRLF (Get-Content -Path 'PSReadLine/PSReadLine.psd1' -Raw)
-
-    $getContentArgs = @{
-        Raw = $true;
-        Path = "./bin/$Configuration/PSReadLine/Microsoft.PowerShell.PSReadLine2.dll"
-    }
-    if ($PSVersionTable.PSEdition -eq 'Core')
-    {
-        $getContentArgs += @{AsByteStream = $true}
-    }
-    else
-    {
-        $getContentArgs += @{Encoding = "Byte"}
-    }
-    $b = Get-Content @getContentArgs
-    $a = [System.Reflection.Assembly]::Load($b)
-    $semVer = ($a.GetCustomAttributes([System.Reflection.AssemblyInformationalVersionAttribute], $false)).InformationalVersion
+    $versionInfo = (Get-ChildItem -Path $targetDir/Microsoft.PowerShell.PSReadLine2.dll).VersionInfo
+    $version = $versionInfo.FileVersion
+    $semVer = $versionInfo.ProductVersion
 
     if ($semVer -match "(.*)-(.*)")
     {


### PR DESCRIPTION
Instead of loading the assembly and get the `InformationalVersion`, we can use `VersionInfo.ProductVersion`, which uses the same value of the `InformationalVersion` tag in .csproj.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1324)