### PR TITLE
Update mac Image to 10.14 in CI as 10.13 is going to be deprecated in March

### DIFF
--- a/az-ci/azure-pipelines.yml
+++ b/az-ci/azure-pipelines.yml
@@ -8,7 +8,7 @@ jobs:
 - template: azure-devops-psreadline.yml
   parameters:
     name: macOS
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
 
 - template: azure-devops-psreadline.yml
   parameters:


### PR DESCRIPTION
https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/

Note that Azure DevOps recently added 10.15 as well, so an alternative would be to use `macOS-latest` or both images
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1343)