### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,125 @@
+# Contributing to PSReadLine
+
+We welcome and appreciate contributions from the community.
+There are many ways to become involved with PSReadLine, including
+
+- Filing issues
+- Joining in design conversations
+- Writing and improving documentation
+- Contributing to the code
+
+Please read the rest of this document to ensure a smooth contribution process.
+
+## Intro to Git and GitHub
+
+* Make sure you have a [GitHub account](https://github.com/signup/free).
+* Learning Git:
+    * GitHub Help: [Good Resources for Learning Git and GitHub][good-git-resources]
+    * [Git Basics][git-basics]: install and getting started
+* [GitHub Flow Guide](https://guides.github.com/introduction/flow/):
+  step-by-step instructions of GitHub Flow
+
+## Contributor License Agreement (CLA)
+
+To speed up the acceptance of any contribution to any PowerShell repositories,
+you should sign the [Microsoft Contributor License Agreement (CLA)][cla] ahead of time.
+If you've already contributed to PowerShell or Microsoft repositories in the past, congratulations!
+You've already completed this step.
+This a one-time requirement for the PowerShell projects.
+Signing the CLA process is simple and can be done in less than a minute.
+You don't have to do this up-front.
+You can simply clone, fork, and submit your pull request as usual.
+When your pull request is created, it is checked by the CLA bot.
+If you have signed the CLA, the status check will be set to `passing`.  Otherwise, it will stay at `pending`.
+Once you sign a CLA, all your existing and future pull requests will have the status check automatically set at `passing`.
+
+## Contributing to Issues
+
+* Check if the issue you are going to file already exists in our [GitHub issues][open-issue].
+* If you can't find your issue already,
+  [open a new issue](https://github.com/PowerShell/PSReadLine/issues/new/choose),
+  making sure to follow the directions as best you can.
+* If the issue is marked as [`Up-for-Grabs`][up-for-grabs],
+  the PSReadLine Maintainers are looking for help with the issue.
+
+## Contributing to Documentation
+
+The documentation is located in the [docs][psreadline-docs] folder.
+The markdown files there are converted to the PowerShell `help.xml` file via [platyPS][platy-ps] during the build.
+
+## Contributing to Code
+
+### Forks and Pull Requests
+
+GitHub fosters collaboration through the notion of [pull requests][using-prs].
+On GitHub, anyone can [fork][fork-a-repo] an existing repository
+into their own user account, where they can make private changes to their fork.
+To contribute these changes back into the original repository,
+a user simply creates a pull request in order to "request" that the changes be taken "upstream".
+
+Additional references:
+
+* GitHub's guide on [forking](https://guides.github.com/activities/forking/)
+* GitHub's guide on [Contributing to Open Source](https://guides.github.com/activities/contributing-to-open-source/#pull-request)
+* GitHub's guide on [Understanding the GitHub Flow](https://guides.github.com/introduction/flow/)
+
+### Building and testing
+
+To build `PSReadLine` on Windows, Linux, or macOS,
+you must have [.NET Core SDK 2.1.802 or newer](https://www.microsoft.com/net/download) installed.
+
+* Bootstrap: `./build.ps1 -Bootstrap`
+* Build:
+    * Targeting .NET 4.6.1 (Windows only): `./build.ps1 -Configuration Debug -Framework net461`
+    * Targeting .NET Core: `./build.ps1 -Configuration Debug -Framework netcoreapp2.1`
+* Test:
+    * Targeting .NET 4.6.1 (Windows only): `./build.ps1 -Test -Configuration Debug -Framework net461`
+    * Targeting .NET Core: `./build.ps1 -Test -Configuration Debug -Framework netcoreapp2.1`
+
+After build, the produced artifacts can be found at `<your-local-repo-root>/bin/Debug`.
+
+### Submitting Pull Request
+
+* If your change would fix a security vulnerability,
+  first follow the [vulnerability issue reporting policy][vuln-reporting], before submitting a PR.
+* To avoid merge conflicts, make sure your branch is rebased on the `master` branch of this repository.
+* Many code changes will require new tests,
+  so make sure you've added a new test if existing tests do not effectively cover the code changed.
+* If your change adds a new source file, ensure the appropriate copyright and license headers is on top.
+  It is standard practice to have both a copyright and license notice for each source file.
+    * For `.cs` files use the copyright header with empty line after it:
+
+    ```c#
+        // Copyright (c) Microsoft Corporation.
+        // Licensed under the 2-Clause BSD License.
+        <Add empty line here>
+    ```
+
+    * For `.ps1` files use the copyright header with empty line after it:
+
+    ```powershell
+        # Copyright (c) Microsoft Corporation.
+        # Licensed under the 2-Clause BSD License.
+        <Add empty line here>
+    ```
+* If you're contributing in a way that changes the user or developer experience, you are expected to document those changes.
+* When you create a pull request,
+  use a meaningful title for the PR describing what change you want to check in.
+  Make sure you also include a summary about your changes in the PR description.
+  The description is used to create change logs,
+  so try to have the first sentence explain the benefit to end users.
+  If the changes are related to an existing GitHub issue,
+  please reference the issue in the PR description (e.g. ```Fix #11```).
+  See [this][closing-via-message] for more details.
+
+
+[good-git-resources]: https://help.github.com/articles/good-resources-for-learning-git-and-github/
+[git-basics]: https://github.com/PowerShell/PowerShell/blob/master/docs/git/basics.md
+[cla]: https://cla.microsoft.com/
+[open-issue]: https://github.com/PowerShell/PSReadLine/issues
+[psreadline-docs]: https://github.com/PowerShell/PSReadLine/tree/master/docs
+[platy-ps]: https://www.powershellgallery.com/packages/platyPS
+[using-prs]: https://help.github.com/articles/using-pull-requests/
+[fork-a-repo]: https://help.github.com/articles/fork-a-repo/
+[vuln-reporting]: https://github.com/PowerShell/PowerShell/blob/master/.github/SECURITY.md
+[closing-via-message]: https://help.github.com/articles/closing-issues-via-commit-messages/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Once you sign a CLA, all your existing and future pull requests will have the st
 * If you can't find your issue already,
   [open a new issue](https://github.com/PowerShell/PSReadLine/issues/new/choose),
   making sure to follow the directions as best you can.
-* If the issue is marked as [`Up-for-Grabs`][up-for-grabs],
+* If the issue is marked as [Up-for-Grabs][up-for-grabs],
   the PSReadLine Maintainers are looking for help with the issue.
 
 ## Contributing to Documentation
@@ -63,10 +63,15 @@ Additional references:
 * GitHub's guide on [Contributing to Open Source](https://guides.github.com/activities/contributing-to-open-source/#pull-request)
 * GitHub's guide on [Understanding the GitHub Flow](https://guides.github.com/introduction/flow/)
 
-### Building and testing
+### Bootstrap, Build and Test
 
 To build `PSReadLine` on Windows, Linux, or macOS,
-you must have [.NET Core SDK 2.1.802 or newer](https://www.microsoft.com/net/download) installed.
+you must have the following installed:
+
+* .NET Core SDK 2.1.802 or [the newer version](https://www.microsoft.com/net/download)
+* The PowerShell modules `InvokeBuild` and `platyPS`
+
+The build script `build.ps1` can be used to bootstrap, build and test the project.
 
 * Bootstrap: `./build.ps1 -Bootstrap`
 * Build:
@@ -113,6 +118,7 @@ After build, the produced artifacts can be found at `<your-local-repo-root>/bin/
   See [this][closing-via-message] for more details.
 
 
+[up-for-grabs]: https://github.com/PowerShell/PSReadLine/issues?q=is%3Aopen+is%3Aissue+label%3AUp-for-Grabs
 [good-git-resources]: https://help.github.com/articles/good-resources-for-learning-git-and-github/
 [git-basics]: https://github.com/PowerShell/PowerShell/blob/master/docs/git/basics.md
 [cla]: https://cla.microsoft.com/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Additional references:
 To build `PSReadLine` on Windows, Linux, or macOS,
 you must have the following installed:
 
-* .NET Core SDK 2.1.802 or [the newer version](https://www.microsoft.com/net/download)
+* .NET Core SDK 2.1.802 or [a newer version](https://www.microsoft.com/net/download)
 * The PowerShell modules `InvokeBuild` and `platyPS`
 
 The build script `build.ps1` can be used to bootstrap, build and test the project.

--- a/README.md
+++ b/README.md
@@ -205,31 +205,42 @@ If you want to change the command line in some unimplmented way in your custom k
     [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition
 ```
 
-## Building
+## Developing and Contributing
 
-### Prerequisites
+Please see the [Contribution Guide][] for how to develop and contribute.
 
-To build `PSReadLine` on Windows, Linux, or macOS, you must have [.NET Core SDK 2.1.802 or newer](https://www.microsoft.com/net/download) installed.
-The build script also depends on [`InvokeBuild`](https://www.powershellgallery.com/packages/InvokeBuild) which can be installed using:
+### Building
 
-```powershell
-  install-module invokebuild -scope currentuser
-```
+To build `PSReadLine` on Windows, Linux, or macOS,
+you must have [.NET Core SDK 2.1.802 or newer](https://www.microsoft.com/net/download) installed.
 
-### Building and running tests
+* Bootstrap: `./build.ps1 -Bootstrap`
+* Build:
+    * Targeting .NET 4.6.1 (Windows only): `./build.ps1 -Configuration Debug -Framework net461`
+    * Targeting .NET Core: `./build.ps1 -Configuration Debug -Framework netcoreapp2.1`
+* Test:
+    * Targeting .NET 4.6.1 (Windows only): `./build.ps1 -Test -Configuration Debug -Framework net461`
+    * Targeting .NET Core: `./build.ps1 -Test -Configuration Debug -Framework netcoreapp2.1`
 
-You can create a new build and run tests by simply running within PowerShell:
+After build, the produced artifacts can be found at `<your-local-repo-root>/bin/Debug`.
 
-```powershell
-  invoke-build
-```
-
-After a successful build, the tests are automatically run.
+[Contribution Guide]: https://github.com/PowerShell/PSReadLine/blob/master/.github/CONTRIBUTING.md
 
 ## Change Log
 
 The change log is available [here](https://github.com/PowerShell/PSReadLine/blob/master/PSReadLine/Changes.txt).
 
-## License
+## Licensing
 
-The license is available [here](https://github.com/PowerShell/PSReadLine/blob/master/PSReadLine/License.txt).
+PSReadLine is licensed under the [2-Clause BSD License][].
+
+[2-Clause BSD License]: https://github.com/PowerShell/PSReadLine/blob/master/PSReadLine/License.txt
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct][conduct-code].
+For more information see the [Code of Conduct FAQ][conduct-FAQ] or contact [opencode@microsoft.com][conduct-email] with any additional questions or comments.
+
+[conduct-code]: https://opensource.microsoft.com/codeofconduct/
+[conduct-FAQ]: https://opensource.microsoft.com/codeofconduct/faq/
+[conduct-email]: mailto:opencode@microsoft.com

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Please see the [Contribution Guide][] for how to develop and contribute.
 To build `PSReadLine` on Windows, Linux, or macOS,
 you must have the following installed:
 
-* .NET Core SDK 2.1.802 or [the newer version](https://www.microsoft.com/net/download)
+* .NET Core SDK 2.1.802 or [a newer version](https://www.microsoft.com/net/download)
 * The PowerShell modules `InvokeBuild` and `platyPS`
 
 The build script `build.ps1` can be used to bootstrap, build and test the project.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,12 @@ Please see the [Contribution Guide][] for how to develop and contribute.
 ### Building
 
 To build `PSReadLine` on Windows, Linux, or macOS,
-you must have [.NET Core SDK 2.1.802 or newer](https://www.microsoft.com/net/download) installed.
+you must have the following installed:
+
+* .NET Core SDK 2.1.802 or [the newer version](https://www.microsoft.com/net/download)
+* The PowerShell modules `InvokeBuild` and `platyPS`
+
+The build script `build.ps1` can be used to bootstrap, build and test the project.
 
 * Bootstrap: `./build.ps1 -Bootstrap`
 * Build:


### PR DESCRIPTION
Address the concerns from CELA:

1. Add `CONTRIBUTING.md` per the guidance.
2. Remove the old `PSReadLine/license.txt` to honor the MIT license at the repository root.
     - Remove `PSReadLine/license.txt`
     - Update `PSReadLine.build.ps1` to not include `PSReadLine/license.txt`
3. Correct the copyright and license headers to all the files.
4. Update `README.md` to point to `CONTRIBUTING.md` and the `LICENSE` file.

Note, the "code changes" in `Movement.vi.cs` and `YankPaste.vi.cs` are not real changes, but just line ending changes that happened automatically.
Use the URL https://github.com/PowerShell/PSReadLine/pull/1419/files?w=1 to ignore all whitespace character changes from the review.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1419)