### PR TITLE
Correct the default foreground/background colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ PSReadline.zip
 # Build Folders (you can keep bin if you'd like, to store dlls and pdbs)
 [Bb]in/
 [Oo]bj/
+.ionide/
 
 # VSCode directories that are not at the repository root
 /**/.vscode/

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -443,8 +443,8 @@ namespace Microsoft.PowerShell
             if (fg == VTColorUtils.UnknownColor || bg == VTColorUtils.UnknownColor)
             {
                 // TODO: light vs. dark
-                fg = ConsoleColor.Black;
-                bg = ConsoleColor.Gray;
+                fg = ConsoleColor.Gray;
+                bg = ConsoleColor.Black;
             }
 
             SelectionColor = VTColorUtils.AsEscapeSequence(bg, fg);

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -34,10 +34,10 @@ namespace Microsoft.PowerShell
             {
                 ch = input[i];
                 lowByte = (uint)(ch & 0x00FF);
-                hash = (hash ^ lowByte) * FNV32_PRIME;
+                hash = unchecked((hash ^ lowByte) * FNV32_PRIME);
 
                 highByte = (uint)(ch >> 8);
-                hash = (hash ^ highByte) * FNV32_PRIME;
+                hash = unchecked((hash ^ highByte) * FNV32_PRIME);
             }
 
             return hash;

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -7,6 +7,7 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0</FileVersion>
     <InformationalVersion>2.0.0</InformationalVersion>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
A couple of minor fixes
- Correct the default foreground/background colors, so the default color for selection text on macOS can be fixed. Fix #1411
- Add `CheckForOverflowUnderflow` property to enable arithmetic overflow checking
- Ignore `.ionide` folders. They are folders to hold the symbol caches for VSCode C# extension

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1435)