### PR TITLE
Update docs to reflect the new `-Chord` parameter to `Get-PSReadLineKeyHandler`

### DIFF
--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -408,7 +408,10 @@ namespace Microsoft.PowerShell
         {
             var boundFunctions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            if (Chord == null) yield break;
+            if (Chord == null || Chord.Length == 0)
+            {
+                yield break;
+            }
 
             foreach (string Key in Chord)
             {
@@ -445,16 +448,20 @@ namespace Microsoft.PowerShell
                 }
 
                 // If in Vi mode, also check Vi's command mode list.
-                if (PSConsoleReadLine.GetOptions().EditMode == EditMode.Vi)
+                if (_singleton._options.EditMode == EditMode.Vi)
                 {
                     if (_viCmdKeyMap.TryGetValue(firstKey, out entry))
                     {
                         if (consoleKeyChord.Length == 1)
                         {
-                            if (entry.BriefDescription == "Ignore") continue;
+                            if (entry.BriefDescription == "Ignore")
+                            {
+                                continue;
+                            }
+
                             yield return new PowerShell.KeyHandler
                             {
-                                Key = '<' + firstKey.KeyStr + '>',
+                                Key = "<" + firstKey.KeyStr + ">",
                                 Function = entry.BriefDescription,
                                 Description = entry.LongDescription,
                                 Group = GetDisplayGrouping(entry.BriefDescription),
@@ -466,10 +473,14 @@ namespace Microsoft.PowerShell
                             if (_viCmdChordTable.TryGetValue(firstKey, out var secondDispatchTable) &&
                                 secondDispatchTable.TryGetValue(secondKey, out entry))
                             {
-                                if (entry.BriefDescription == "Ignore") continue;
+                                if (entry.BriefDescription == "Ignore")
+                                {
+                                    continue;
+                                }
+
                                 yield return new PowerShell.KeyHandler
                                 {
-                                    Key = '<' + firstKey.KeyStr + "," + secondKey.KeyStr + '>',
+                                    Key = "<" + firstKey.KeyStr + "," + secondKey.KeyStr + ">",
                                     Function = entry.BriefDescription,
                                     Description = entry.LongDescription,
                                     Group = GetDisplayGrouping(entry.BriefDescription),
@@ -479,8 +490,6 @@ namespace Microsoft.PowerShell
                     }
                 }
             }
-            yield break;
-            
         }
     }
 }

--- a/docs/Get-PSReadLineKeyHandler.md
+++ b/docs/Get-PSReadLineKeyHandler.md
@@ -14,7 +14,7 @@ Gets the key bindings for the PSReadLine module.
 ```
 Get-PSReadLineKeyHandler [-Bound] [-Unbound]
 
-Get-PSReadLineKeyHandler [-Chord] <string[]>
+Get-PSReadLineKeyHandler [-Chord] <String[]>
 ```
 
 ## DESCRIPTION

--- a/docs/Get-PSReadLineKeyHandler.md
+++ b/docs/Get-PSReadLineKeyHandler.md
@@ -13,19 +13,23 @@ Gets the key bindings for the PSReadLine module.
 
 ```
 Get-PSReadLineKeyHandler [-Bound] [-Unbound]
+
+Get-PSReadLineKeyHandler [-Chord] <string[]>
 ```
 
 ## DESCRIPTION
 
 Gets the key bindings for the PSReadLine module.
 
-If neither -Bound nor -Unbound is specified, returns all bound keys functions.
+If no parameter is specified, returns all bound keys functions.
 
-If -Bound is specified and -Unbound is not specified, only bound keys are returned.
+If '-Bound' is specified and '-Unbound' is not specified, only bound keys are returned.
 
-If -Unbound is specified and -Bound is not specified, only unbound keys are returned.
+If '-Unbound' is specified and '-Bound' is not specified, only unbound keys are returned.
 
-If both -Bound and -Unbound are specified, returns all bound keys and unbound functions.
+If both '-Bound' and '-Unbound' are specified, returns all bound keys and unbound functions.
+
+If '-Chord' is specified, returns the specific bound keys.
 
 ## EXAMPLES
 
@@ -58,7 +62,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: True
+Default value: False
 Accept pipeline input: false
 Accept wildcard characters: False
 ```

--- a/docs/about_PSReadLine.help.txt
+++ b/docs/about_PSReadLine.help.txt
@@ -107,9 +107,10 @@ LONG DESCRIPTION
         second is used if your binding is doing something more advanced with the Ast.
 
     IEnumerable[Microsoft.PowerShell.KeyHandler] GetKeyHandlers(bool includeBound, bool includeUnbound)
+    IEnumerable[Microsoft.PowerShell.KeyHandler] GetKeyHandlers(string[] Chord)
 
-        This function is used by Get-PSReadLineKeyHandler and probably isn't useful in a custom
-        key binding.
+        These two functions are used by Get-PSReadLineKeyHandler. The first is used to get all
+        key bindings. The second is used to get specific key bindings.
 
     Microsoft.PowerShell.PSConsoleReadLineOptions GetOptions()
 


### PR DESCRIPTION
This PR includes the following changes:
- Some minor style updates to the code that adds `-Chord` to `Get-PSReadLineKeyHandler`
- Update the docs to reflect the change.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1438)