### PR TITLE
Fix the env-data script and write buffer info in case of exception

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -46,11 +46,9 @@ Please run the script in the PowerShell session where you ran into the issue and
     }
 
     "`nPS version: $($PSVersionTable.PSVersion)"
-    $v = (Get-Module PSReadline).Version
-    $m = Get-Content "$(Split-Path -Parent (Get-Module PSReadLine).Path)\PSReadLine.psd1" | Select-String "Prerelease = '(.*)'"
-    if ($m) {
-        $v = "$v-" + $m.Matches[0].Groups[1].Value
-    }
+    $m = Get-Module PSReadline
+    $v = $m.Version; $pre = $m.PrivateData.PSData.Prerelease
+    if ($pre) { $v = "$v-$pre" }
     "PSReadline version: $v"
     if ($IsLinux -or $IsMacOS) {
         "os: $(uname -a)"

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -397,14 +397,16 @@ Report on GitHub: https://github.com/PowerShell/PSReadLine/issues/new?template=B
 PSReadLine: {0}
 PowerShell: {1}
 OS: {2}
-Last {3} Keys
+BufferWidth: {3}
+BufferHeight: {4}
+Last {5} Keys
 ```
-{4}
+{6}
 ```
 
 ### Exception
 ```
-{5}
+{7}
 ```
 </value>
   </data>

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -419,9 +419,11 @@ namespace Microsoft.PowerShell
                     var psVersion = PSObject.AsPSObject(engineIntrinsics.Host.Version).ToString();
                     var ourVersion = typeof(PSConsoleReadLine).Assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().First().InformationalVersion;
                     var osInfo = RuntimeInformation.OSDescription;
+                    var bufferWidth = console.BufferWidth;
+                    var bufferHeight = console.BufferHeight;
 
                     console.WriteLine(string.Format(CultureInfo.CurrentUICulture, PSReadLineResources.OopsAnErrorMessage2,
-                        ourVersion, psVersion, osInfo,
+                        ourVersion, psVersion, osInfo, bufferWidth, bufferHeight,
                         _lastNKeys.Count, sb, e));
                     var lineBeforeCrash = _singleton._buffer.ToString();
                     _singleton.Initialize(runspace, _singleton._engineIntrinsics);


### PR DESCRIPTION
1. Fix the environment data script to write out the correct prerelease version
2. Add information about buffer width and height in case of exception.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1482)