### PR TITLE
Add basic support for inline predictive suggestion

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -31,20 +31,26 @@ namespace Microsoft.PowerShell
             {
                 if (count <= 0)
                     return;
-            }
-            else
-            {
-                count = 1;
+                if (count > 1)
+                {
+                    var toInsert = new string(keyChar, count);
+                    if (_singleton._visualSelectionCommandCount > 0)
+                    {
+                        _singleton.GetRegion(out var start, out var length);
+                        Replace(start, length, toInsert);
+                    }
+                    else
+                    {
+                        Insert(toInsert);
+                    }
+                    return;
+                }
             }
 
             if (_singleton._visualSelectionCommandCount > 0)
             {
                 _singleton.GetRegion(out var start, out var length);
-                Replace(start, length, new string(keyChar, count));
-            }
-            else if (count > 1)
-            {
-                Insert(new string(keyChar, count));
+                Replace(start, length, new string(keyChar, 1));
             }
             else
             {

--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -274,7 +274,7 @@ namespace Microsoft.PowerShell
             SetCursorPosition(_current);
             if (_suggestionText != null)
             {
-                _suggestionText = null;
+                ResetSuggestion();
                 _console.BlankRestOfLine();
             }
 

--- a/PSReadLine/Changes.txt
+++ b/PSReadLine/Changes.txt
@@ -1,3 +1,26 @@
+### Version 2.1.0-beta1
+
+Pre-release notes:
+
+#### Prototype to support the fish-like auto-suggestion in PSReadLine
+
+Currently:
+
+- The only suggestion source is the PSReadLine history file.
+  The ultimate goal is to call into a prediction API in PowerShell engine that is powered by a prediction plugin.
+- By default, the suggestion text is rendered with the `dark black` color `\x1b[38;5;238m`, which works OK with a black background.
+  You can change it by running `Set-PSReadLineOption -Colors @{ Prediction = '<your-choice-of-color>' }`.
+- VI mode - now the suggestion is disabled when switching to the command mode, and enabled when switching to insert mode.
+- Very limited efforts have been spent on the VI/Emacs experience, so it could be pretty raw for them, and feedback is very welcome.
+
+When using this PSReadLine, please add the following key binding to your profile:
+
+    Set-PSReadLineKeyHandler -Key "Ctrl+f" -Function ForwardWord
+
+- Pressing `RightArrow` at the end of current typing will accept the suggestion text
+- Pressing `Ctrl+f` at the end of current typing will accept a word from the suggestion text
+- Pressing `Ctrl+z` will get you back to where you were before accepting all or part of the suggestion
+
 ### Version 2.0.1
 
 Bug fixes:

--- a/PSReadLine/Changes.txt
+++ b/PSReadLine/Changes.txt
@@ -2,24 +2,7 @@
 
 Pre-release notes:
 
-#### Prototype to support the fish-like auto-suggestion in PSReadLine
-
-Currently:
-
-- The only suggestion source is the PSReadLine history file.
-  The ultimate goal is to call into a prediction API in PowerShell engine that is powered by a prediction plugin.
-- By default, the suggestion text is rendered with the `dark black` color `\x1b[38;5;238m`, which works OK with a black background.
-  You can change it by running `Set-PSReadLineOption -Colors @{ Prediction = '<your-choice-of-color>' }`.
-- VI mode - now the suggestion is disabled when switching to the command mode, and enabled when switching to insert mode.
-- Very limited efforts have been spent on the VI/Emacs experience, so it could be pretty raw for them, and feedback is very welcome.
-
-When using this PSReadLine, please add the following key binding to your profile:
-
-    Set-PSReadLineKeyHandler -Key "Ctrl+f" -Function ForwardWord
-
-- Pressing `RightArrow` at the end of current typing will accept the suggestion text
-- Pressing `Ctrl+f` at the end of current typing will accept a word from the suggestion text
-- Pressing `Ctrl+z` will get you back to where you were before accepting all or part of the suggestion
+* Experimental support for fish-like suggestions in PSReadLine.
 
 ### Version 2.0.1
 

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -63,10 +63,15 @@ namespace Microsoft.PowerShell
         MemoryAndFile
     }
 
-    public enum PredictionStyle
+    public enum PredictionSource
     {
         None,
-        Concise,
+        History,
+    }
+
+    public enum PredictionViewStyle
+    {
+        Default,
     }
 
     public class PSConsoleReadLineOptions
@@ -138,7 +143,12 @@ namespace Microsoft.PowerShell
 
         public const HistorySaveStyle DefaultHistorySaveStyle = HistorySaveStyle.SaveIncrementally;
 
-        public const PredictionStyle DefaultPredictionStyle = PredictionStyle.Concise;
+        /// <summary>
+        /// The predictive suggestion feature is disabled by default.
+        /// </summary>
+        public const PredictionSource DefaultPredictionSource = PredictionSource.None;
+
+        public const PredictionViewStyle DefaultPredictionViewStyle = PredictionViewStyle.Default;
 
         /// <summary>
         /// How long in milliseconds should we wait before concluding
@@ -167,7 +177,8 @@ namespace Microsoft.PowerShell
             HistorySearchCaseSensitive = DefaultHistorySearchCaseSensitive;
             HistorySaveStyle = DefaultHistorySaveStyle;
             AnsiEscapeTimeout = DefaultAnsiEscapeTimeout;
-            PredictionStyle = DefaultPredictionStyle;
+            PredictionSource = DefaultPredictionSource;
+            PredictionViewStyle = DefaultPredictionViewStyle;
 
             var historyFileName = hostName + "_history.txt";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -323,9 +334,14 @@ namespace Microsoft.PowerShell
         public HistorySaveStyle HistorySaveStyle { get; set; }
 
         /// <summary>
+        /// Sets the source to get predictive suggestions.
+        /// </summary>
+        public PredictionSource PredictionSource { get; set; }
+
+        /// <summary>
         /// How the predictive suggestion is rendered.
         /// </summary>
-        public PredictionStyle PredictionStyle { get; set; }
+        public PredictionViewStyle PredictionViewStyle { get; set; }
 
         /// <summary>
         /// How long in milliseconds should we wait before concluding
@@ -708,12 +724,20 @@ namespace Microsoft.PowerShell
         public ScriptBlock ViModeChangeHandler { get; set; }
 
         [Parameter]
-        public PredictionStyle PredictionStyle
+        public PredictionSource PredictionSource
         {
-            get => _predictionStyle.GetValueOrDefault();
-            set => _predictionStyle = value;
+            get => _predictionSource.GetValueOrDefault();
+            set => _predictionSource = value;
         }
-        internal PredictionStyle? _predictionStyle;
+        internal PredictionSource? _predictionSource;
+
+        [Parameter]
+        public PredictionViewStyle PredictionViewStyle
+        {
+            get => _predictionViewStyle.GetValueOrDefault();
+            set => _predictionViewStyle = value;
+        }
+        internal PredictionViewStyle? _predictionViewStyle;
 
         [Parameter]
         public Hashtable Colors { get; set; }

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -69,11 +69,6 @@ namespace Microsoft.PowerShell
         History,
     }
 
-    public enum PredictionViewStyle
-    {
-        Default,
-    }
-
     public class PSConsoleReadLineOptions
     {
         public const ConsoleColor DefaultCommentColor   = ConsoleColor.DarkGreen;
@@ -148,8 +143,6 @@ namespace Microsoft.PowerShell
         /// </summary>
         public const PredictionSource DefaultPredictionSource = PredictionSource.None;
 
-        public const PredictionViewStyle DefaultPredictionViewStyle = PredictionViewStyle.Default;
-
         /// <summary>
         /// How long in milliseconds should we wait before concluding
         /// the input is not an escape sequence?
@@ -178,7 +171,6 @@ namespace Microsoft.PowerShell
             HistorySaveStyle = DefaultHistorySaveStyle;
             AnsiEscapeTimeout = DefaultAnsiEscapeTimeout;
             PredictionSource = DefaultPredictionSource;
-            PredictionViewStyle = DefaultPredictionViewStyle;
 
             var historyFileName = hostName + "_history.txt";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -337,11 +329,6 @@ namespace Microsoft.PowerShell
         /// Sets the source to get predictive suggestions.
         /// </summary>
         public PredictionSource PredictionSource { get; set; }
-
-        /// <summary>
-        /// How the predictive suggestion is rendered.
-        /// </summary>
-        public PredictionViewStyle PredictionViewStyle { get; set; }
 
         /// <summary>
         /// How long in milliseconds should we wait before concluding
@@ -730,14 +717,6 @@ namespace Microsoft.PowerShell
             set => _predictionSource = value;
         }
         internal PredictionSource? _predictionSource;
-
-        [Parameter]
-        public PredictionViewStyle PredictionViewStyle
-        {
-            get => _predictionViewStyle.GetValueOrDefault();
-            set => _predictionViewStyle = value;
-        }
-        internal PredictionViewStyle? _predictionViewStyle;
 
         [Parameter]
         public Hashtable Colors { get; set; }

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -217,6 +217,9 @@ namespace Microsoft.PowerShell
                 ViInsertWithAppend();
             }
 
+            // Do not show suggestion text during tab completion.
+            using var _ = PredictionOff();
+
             var completions = GetCompletions();
             if (completions == null || completions.CompletionMatches.Count == 0)
                 return;

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -679,13 +679,18 @@ namespace Microsoft.PowerShell
             }
         }
 
+        /// <summary>
+        /// Currently we only select single-line history that is prefixed with the user input,
+        /// but it can be improved to not strictly use the user input as a prefix, but a hint
+        /// to extract a partial pipeline or statement from a single-line or multiple-line
+        /// history entry.
+        /// </summary>
         private string GetHistorySuggestion(string text)
         {
             for (int index = _history.Count - 1; index >= 0; index --)
             {
                 var line = _history[index].CommandLine.TrimEnd();
-                if (line.Length > text.Length && !LineIsMultiLine(line) &&
-                    line.StartsWith(text, Options.HistoryStringComparison))
+                if (line.Length > text.Length && !LineIsMultiLine(line) && line.StartsWith(text, Options.HistoryStringComparison))
                 {
                     return line;
                 }

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -185,14 +185,13 @@ namespace Microsoft.PowerShell
             bool fromDifferentSession = false,
             bool fromInitialRead = false)
         {
-            var cmdLine = result.TrimEnd();
-            var addToHistoryOption = GetAddToHistoryOption(cmdLine);
+            var addToHistoryOption = GetAddToHistoryOption(result);
             if (addToHistoryOption != AddToHistoryOption.SkipAdding)
             {
                 var fromHistoryFile = fromDifferentSession || fromInitialRead;
                 _previousHistoryItem = new HistoryItem
                 {
-                    CommandLine = cmdLine,
+                    CommandLine = result,
                     _edits = edits,
                     _undoEditIndex = undoEditIndex,
                     _saved = fromHistoryFile,
@@ -684,8 +683,9 @@ namespace Microsoft.PowerShell
         {
             for (int index = _history.Count - 1; index >= 0; index --)
             {
-                var line = _history[index].CommandLine;
-                if (line.Length > text.Length && !LineIsMultiLine(line) && line.StartsWith(text, Options.HistoryStringComparison))
+                var line = _history[index].CommandLine.TrimEnd();
+                if (line.Length > text.Length && !LineIsMultiLine(line) &&
+                    line.StartsWith(text, Options.HistoryStringComparison))
                 {
                     return line;
                 }

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -690,9 +690,13 @@ namespace Microsoft.PowerShell
             for (int index = _history.Count - 1; index >= 0; index --)
             {
                 var line = _history[index].CommandLine.TrimEnd();
-                if (line.Length > text.Length && !LineIsMultiLine(line) && line.StartsWith(text, Options.HistoryStringComparison))
+                if (line.Length > text.Length)
                 {
-                    return line;
+                    bool isMultiLine = line.Contains('\n');
+                    if (!isMultiLine && line.StartsWith(text, Options.HistoryStringComparison))
+                    {
+                        return line;
+                    }
                 }
             }
 

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -549,6 +549,8 @@ namespace Microsoft.PowerShell
             case nameof(ViExit):
             case nameof(ViInsertMode):
             case nameof(WhatIsKey):
+            case nameof(AcceptSuggestion):
+            case nameof(AcceptNextSuggestionWord):
                 return KeyHandlerGroup.Miscellaneous;
 
             case nameof(CharacterSearch):

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -61,7 +61,14 @@ namespace Microsoft.PowerShell
         {
             if (TryGetArgAsInt(arg, out var numericArg, 1))
             {
-                SetCursorPosition(_singleton._current + numericArg);
+                if (_singleton._current == _singleton._buffer.Length && numericArg > 0)
+                {
+                    AcceptSuggestion();
+                }
+                else
+                {
+                    SetCursorPosition(_singleton._current + numericArg);
+                }
             }
         }
 
@@ -308,6 +315,12 @@ namespace Microsoft.PowerShell
         {
             if (!TryGetArgAsInt(arg, out var numericArg, 1))
             {
+                return;
+            }
+
+            if (_singleton._current == _singleton._buffer.Length && numericArg > 0)
+            {
+                AcceptNextSuggestionWord(numericArg);
                 return;
             }
 

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell
             {
                 if (_singleton._current == _singleton._buffer.Length && numericArg > 0)
                 {
-                    AcceptSuggestion();
+                    AcceptSuggestion(key, arg);
                 }
                 else
                 {

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -135,6 +135,10 @@ namespace Microsoft.PowerShell
             {
                 Options.PromptText = options.PromptText;
             }
+            if (options._predictionStyle.HasValue)
+            {
+                Options.PredictionStyle = options.PredictionStyle;
+            }
             if (options.Colors != null)
             {
                 IDictionaryEnumerator e = options.Colors.GetEnumerator();

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -137,11 +137,11 @@ namespace Microsoft.PowerShell
             }
             if (options._predictionSource.HasValue)
             {
+                if (_console is PlatformWindows.LegacyWin32Console && options.PredictionSource != PredictionSource.None)
+                {
+                    throw new ArgumentException(PSReadLineResources.PredictiveSuggestionNotSupported);
+                }
                 Options.PredictionSource = options.PredictionSource;
-            }
-            if (options._predictionViewStyle.HasValue)
-            {
-                Options.PredictionViewStyle = options.PredictionViewStyle;
             }
             if (options.Colors != null)
             {

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -135,9 +135,13 @@ namespace Microsoft.PowerShell
             {
                 Options.PromptText = options.PromptText;
             }
-            if (options._predictionStyle.HasValue)
+            if (options._predictionSource.HasValue)
             {
-                Options.PredictionStyle = options.PredictionStyle;
+                Options.PredictionSource = options.PredictionSource;
+            }
+            if (options._predictionViewStyle.HasValue)
+            {
+                Options.PredictionViewStyle = options.PredictionViewStyle;
             }
             if (options.Colors != null)
             {

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -4,11 +4,12 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.PSReadLine</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.PSReadLine2</AssemblyName>
-    <AssemblyVersion>2.0.1.0</AssemblyVersion>
-    <FileVersion>2.0.1</FileVersion>
-    <InformationalVersion>2.0.1</InformationalVersion>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0</FileVersion>
+    <InformationalVersion>2.1.0-beta1</InformationalVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">

--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -159,7 +159,10 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                 <PropertyName>AnsiEscapeTimeout</PropertyName>
               </ListItem>
               <ListItem>
-                <PropertyName>PredictionStyle</PropertyName>
+                <PropertyName>PredictionSource</PropertyName>
+              </ListItem>
+              <ListItem>
+                <PropertyName>PredictionViewStyle</PropertyName>
               </ListItem>
               <ListItem>
                 <Label>CommandColor</Label>

--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -159,6 +159,9 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                 <PropertyName>AnsiEscapeTimeout</PropertyName>
               </ListItem>
               <ListItem>
+                <PropertyName>PredictionStyle</PropertyName>
+              </ListItem>
+              <ListItem>
                 <Label>CommandColor</Label>
                 <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.CommandColor)</ScriptBlock>
               </ListItem>
@@ -201,6 +204,10 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
               <ListItem>
                 <Label>ParameterColor</Label>
                 <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.ParameterColor)</ScriptBlock>
+              </ListItem>
+              <ListItem>
+                <Label>PredictionColor</Label>
+                <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.PredictionColor)</ScriptBlock>
               </ListItem>
               <ListItem>
                 <Label>SelectionColor</Label>

--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -162,9 +162,6 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                 <PropertyName>PredictionSource</PropertyName>
               </ListItem>
               <ListItem>
-                <PropertyName>PredictionViewStyle</PropertyName>
-              </ListItem>
-              <ListItem>
                 <Label>CommandColor</Label>
                 <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.CommandColor)</ScriptBlock>
               </ListItem>

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -638,7 +638,34 @@ namespace Microsoft.PowerShell.PSReadLine {
                 return ResourceManager.GetString("InsertLineBelowDescription", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Accept the current inline or selected suggestion.
+        /// </summary>
+        internal static string AcceptSuggestionDescription {
+            get {
+                return ResourceManager.GetString("AcceptSuggestionDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Accept the next word of the inline or selected suggestion.
+        /// </summary>
+        internal static string AcceptNextSuggestionWordDescription {
+            get {
+                return ResourceManager.GetString("AcceptNextSuggestionWordDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The predictive suggestion feature cannot be enabled because the console output doesn't support virtual terminal processing or it's redirected.
+        /// </summary>
+        internal static string PredictiveSuggestionNotSupported {
+            get {
+                return ResourceManager.GetString("PredictiveSuggestionNotSupported", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid color property.
         /// </summary>

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -741,6 +741,12 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
   <data name="InsertLineBelowDescription" xml:space="preserve">
     <value>Inserts a new empty line below the current line without attempting to execute the input</value>
   </data>
+  <data name="AcceptSuggestionDescription" xml:space="preserve">
+    <value>Accept the current inline or selected suggestion</value>
+  </data>
+  <data name="AcceptNextSuggestionWordDescription" xml:space="preserve">
+    <value>Accept the next word of the inline or selected suggestion</value>
+  </data>
   <data name="HistoryFileErrorMessage" xml:space="preserve">
     <value>Error reading or writing history file '{0}': {1}</value>
   </data>

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -789,4 +789,7 @@ Or not saving history with:
   <data name="InvalidColorProperty" xml:space="preserve">
     <value>'{0}' is not a valid color property</value>
   </data>
+  <data name="PredictiveSuggestionNotSupported" xml:space="preserve">
+    <value>The predictive suggestion feature cannot be enabled because the console output doesn't support virtual terminal processing or it's redirected.</value>
+  </data>
 </root>

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -235,34 +235,5 @@ namespace Microsoft.PowerShell
             numericArg = 0;
             return false;
         }
-
-        /// <summary>
-        /// Accept the suggestion text if there is one.
-        /// </summary>
-        public static void AcceptSuggestion()
-        {
-            if (_singleton._suggestionText != null)
-            {
-                using var _ = _singleton.PredictionOff();
-                Replace(0, _singleton._buffer.Length, _singleton._suggestionText);
-            }
-        }
-
-        /// <summary>
-        /// Accept the current or the next suggestion text word.
-        /// </summary>
-        public static void AcceptNextSuggestionWord(int numericArg)
-        {
-            if (_singleton._suggestionText != null)
-            {
-                int index = _singleton._buffer.Length;
-                while (numericArg-- > 0 && index < _singleton._suggestionText.Length)
-                {
-                    index = _singleton.FindForwardSuggestionWordPoint(index, _singleton.Options.WordDelimiters);
-                }
-
-                Replace(0, _singleton._buffer.Length, _singleton._suggestionText.Substring(0, index));
-            }
-        }
     }
 }

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -235,5 +235,34 @@ namespace Microsoft.PowerShell
             numericArg = 0;
             return false;
         }
+
+        /// <summary>
+        /// Accept the suggestion text if there is one.
+        /// </summary>
+        public static void AcceptSuggestion()
+        {
+            if (_singleton._suggestionText != null)
+            {
+                using var _ = _singleton.PredictionOff();
+                Replace(0, _singleton._buffer.Length, _singleton._suggestionText);
+            }
+        }
+
+        /// <summary>
+        /// Accept the current or the next suggestion text word.
+        /// </summary>
+        public static void AcceptNextSuggestionWord(int numericArg)
+        {
+            if (_singleton._suggestionText != null)
+            {
+                int index = _singleton._buffer.Length;
+                while (numericArg-- > 0 && index < _singleton._suggestionText.Length)
+                {
+                    index = _singleton.FindForwardSuggestionWordPoint(index, _singleton.Options.WordDelimiters);
+                }
+
+                Replace(0, _singleton._buffer.Length, _singleton._suggestionText.Substring(0, index));
+            }
+        }
     }
 }

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -522,6 +522,9 @@ namespace Microsoft.PowerShell
 
         private void ViIndicateCommandMode()
         {
+            // Show suggestion in 'InsertMode' but not 'CommandMode'.
+            _showSuggestion = false;
+
             if (_options.ViModeIndicator == ViModeStyle.Cursor)
             {
                 _console.CursorSize = _normalCursorSize < 50 ? 100 : 25;
@@ -541,6 +544,9 @@ namespace Microsoft.PowerShell
 
         private void ViIndicateInsertMode()
         {
+            // Show suggestion in 'InsertMode' but not 'CommandMode'.
+            _showSuggestion = true;
+
             if (_options.ViModeIndicator == ViModeStyle.Cursor)
             {
                 _console.CursorSize = _normalCursorSize;

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -173,13 +173,52 @@ namespace Microsoft.PowerShell
                 }
             }
 
-            void MaybeEmphasize(int i, string currColor)
+            void RenderOneChar(char charToRender, bool toEmphasize)
             {
-                if (i >= _emphasisStart && i < (_emphasisStart + _emphasisLength))
+                if (charToRender == '\n')
                 {
-                    currColor = _options._emphasisColor;
+                    if (inSelectedRegion)
+                    {
+                        // Turn off inverse before end of line, turn on after continuation prompt
+                        _consoleBufferLines[currentLogicalLine].Append("\x1b[0m");
+                    }
+
+                    currentLogicalLine += 1;
+                    if (currentLogicalLine == _consoleBufferLines.Count)
+                    {
+                        _consoleBufferLines.Add(new StringBuilder(COMMON_WIDEST_CONSOLE_WIDTH));
+                    }
+
+                    // Reset the color for continuation prompt so the color sequence will always be explicitly
+                    // specified for continuation prompt in the generated render strings.
+                    // This is necessary because we will likely not rewrite all texts during rendering, and thus
+                    // we cannot assume the continuation prompt can continue to use the active color setting from
+                    // the previous rendering string.
+                    activeColor = string.Empty;
+
+                    UpdateColorsIfNecessary(Options._continuationPromptColor);
+                    _consoleBufferLines[currentLogicalLine].Append(Options.ContinuationPrompt);
+
+                    if (inSelectedRegion)
+                    {
+                        // Turn off inverse before end of line, turn on after continuation prompt
+                        _consoleBufferLines[currentLogicalLine].Append(Options.SelectionColor);
+                    }
+
+                    return;
                 }
-                UpdateColorsIfNecessary(currColor);
+
+                UpdateColorsIfNecessary(toEmphasize ? _options._emphasisColor : color);
+
+                if (char.IsControl(charToRender))
+                {
+                    _consoleBufferLines[currentLogicalLine].Append('^');
+                    _consoleBufferLines[currentLogicalLine].Append((char)('@' + charToRender));
+                }
+                else
+                {
+                    _consoleBufferLines[currentLogicalLine].Append(charToRender);
+                }
             }
 
             foreach (var buf in _consoleBufferLines)
@@ -289,80 +328,23 @@ namespace Microsoft.PowerShell
                 }
 
                 var charToRender = text[i];
-                if (charToRender == '\n')
-                {
-                    if (inSelectedRegion)
-                    {
-                        // Turn off inverse before end of line, turn on after continuation prompt
-                        _consoleBufferLines[currentLogicalLine].Append("\x1b[0m");
-                    }
+                var toEmphasize = i >= _emphasisStart && i < (_emphasisStart + _emphasisLength);
 
-                    currentLogicalLine += 1;
-                    if (currentLogicalLine == _consoleBufferLines.Count)
-                    {
-                        _consoleBufferLines.Add(new StringBuilder(COMMON_WIDEST_CONSOLE_WIDTH));
-                    }
-
-                    // Reset the color for continuation prompt so the color sequence will always be explicitly
-                    // specified for continuation prompt in the generated render strings.
-                    // This is necessary because we will likely not rewrite all texts during rendering, and thus
-                    // we cannot assume the continuation prompt can continue to use the active color setting from
-                    // the previous rendering string.
-                    activeColor = string.Empty;
-
-                    UpdateColorsIfNecessary(Options._continuationPromptColor);
-                    _consoleBufferLines[currentLogicalLine].Append(Options.ContinuationPrompt);
-
-                    if (inSelectedRegion)
-                    {
-                        // Turn off inverse before end of line, turn on after continuation prompt
-                        _consoleBufferLines[currentLogicalLine].Append(Options.SelectionColor);
-                    }
-                }
-                else if (char.IsControl(charToRender))
-                {
-                    MaybeEmphasize(i, color);
-                    _consoleBufferLines[currentLogicalLine].Append('^');
-                    _consoleBufferLines[currentLogicalLine].Append((char)('@' + charToRender));
-                }
-                else
-                {
-                    MaybeEmphasize(i, color);
-                    _consoleBufferLines[currentLogicalLine].Append(charToRender);
-                }
+                RenderOneChar(charToRender, toEmphasize);
             }
 
             if (inSelectedRegion)
             {
                 _consoleBufferLines[currentLogicalLine].Append("\x1b[0m");
+                inSelectedRegion = false;
             }
 
-            inSelectedRegion = false;
             if (suggestion != null)
             {
                 color = _options._predictionColor;
-                UpdateColorsIfNecessary(color);
-
                 foreach (char charToRender in suggestion)
                 {
-                    if (charToRender == '\n')
-                    {
-                        currentLogicalLine += 1;
-                        if (currentLogicalLine == _consoleBufferLines.Count)
-                        {
-                            _consoleBufferLines.Add(new StringBuilder(COMMON_WIDEST_CONSOLE_WIDTH));
-                        }
-                        _consoleBufferLines[currentLogicalLine].Append(Options.ContinuationPrompt);
-                    }
-                    else if (char.IsControl(charToRender))
-                    {
-                        _consoleBufferLines[currentLogicalLine].Append('^');
-                        _consoleBufferLines[currentLogicalLine].Append((char)('@' + charToRender));
-                    }
-                    else
-                    {
-                        _consoleBufferLines[currentLogicalLine].Append(charToRender);
-                    }
+                    RenderOneChar(charToRender, toEmphasize: false);
                 }
             }
 

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -1200,16 +1200,6 @@ namespace Microsoft.PowerShell
             return false;
         }
 
-        private bool LineIsMultiLine(string text)
-        {
-            for (int i = 0; i < text.Length; i++)
-            {
-                if (text[i] == '\n')
-                    return true;
-            }
-            return false;
-        }
-
         private int GetStatusLineCount()
         {
             if (_statusLinePrompt == null)

--- a/PSReadLine/Suggestion.cs
+++ b/PSReadLine/Suggestion.cs
@@ -5,7 +5,7 @@ namespace Microsoft.PowerShell
     public partial class PSConsoleReadLine
     {
         private string _suggestionText;
-        private string _userInputText;
+        private string _lastUserInput;
         private bool _showSuggestion = true;
 
         private bool IsPredictionOn => _options.PredictionSource != PredictionSource.None && _showSuggestion;
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell
         private void ResetSuggestion()
         {
             _suggestionText = null;
-            _userInputText = null;
+            _lastUserInput = null;
         }
 
         private string GetSuggestion(string text)
@@ -41,9 +41,9 @@ namespace Microsoft.PowerShell
             try
             {
                 if (_suggestionText == null || _suggestionText.Length <= text.Length ||
-                    text.Length < _userInputText.Length || !_suggestionText.StartsWith(text, _options.HistoryStringComparison))
+                    text.Length < _lastUserInput.Length || !_suggestionText.StartsWith(text, _options.HistoryStringComparison))
                 {
-                    _userInputText = text;
+                    _lastUserInput = text;
                     _suggestionText = GetHistorySuggestion(text);
                 }
             }
@@ -59,19 +59,6 @@ namespace Microsoft.PowerShell
         /// Accept the suggestion text if there is one.
         /// </summary>
         public static void AcceptSuggestion(ConsoleKeyInfo? key = null, object arg = null)
-        {
-            if (!TryGetArgAsInt(arg, out var numericArg, 1))
-            {
-                return;
-            }
-
-            if (numericArg > 0)
-            {
-                AcceptSuggestion();
-            }
-        }
-
-        private static void AcceptSuggestion()
         {
             if (_singleton._suggestionText != null)
             {

--- a/PSReadLine/Suggestion.cs
+++ b/PSReadLine/Suggestion.cs
@@ -4,49 +4,46 @@ namespace Microsoft.PowerShell
 {
     public partial class PSConsoleReadLine
     {
-        private class SuggestionModeRestore : IDisposable
-        {
-            private bool oldSuggestionMode;
-
-            internal SuggestionModeRestore(bool showSuggestion)
-            {
-                oldSuggestionMode = _singleton._showSuggestion;
-                _singleton._showSuggestion = showSuggestion;
-            }
-
-            public void Dispose()
-            {
-                _singleton._showSuggestion = oldSuggestionMode;
-            }
-        }
-
         private string _suggestionText;
-        private uint _lastRenderedTextHash;
+        private string _userInputText;
         private bool _showSuggestion = true;
+
+        private bool IsPredictionOn => _options.PredictionSource != PredictionSource.None && _showSuggestion;
+        private bool IsPredictionOff => _options.PredictionSource == PredictionSource.None || !_showSuggestion;
 
         /// <summary>
         /// Turn off the prediction feature for the scope of the calling method.
         /// Note: the calling method need to use this method with the 'using' statement/variable,
         /// so that the suggestion feature can be properly restored.
         /// </summary>
-        private SuggestionModeRestore PredictionOff() => new SuggestionModeRestore(false);
+        private IDisposable PredictionOff()
+        {
+            var oldSuggestionMode = _singleton._showSuggestion;
+            _singleton._showSuggestion = false;
+
+            return new Disposable(() => _singleton._showSuggestion = oldSuggestionMode);
+        }
+
+        private void ResetSuggestion()
+        {
+            _suggestionText = null;
+            _userInputText = null;
+        }
 
         private string GetSuggestion(string text)
         {
-            if (_options.PredictionStyle == PredictionStyle.None || !_showSuggestion ||
-                LineIsMultiLine() || string.IsNullOrWhiteSpace(text))
+            if (IsPredictionOff || LineIsMultiLine() || string.IsNullOrWhiteSpace(text))
             {
-                _suggestionText = null;
-                _lastRenderedTextHash = 0;
+                ResetSuggestion();
                 return null;
             }
 
             try
             {
-                uint textHash = _lastRenderedTextHash;
-                _lastRenderedTextHash = FNV1a32Hash.ComputeHash(text);
-                if (textHash != _lastRenderedTextHash)
+                if (_suggestionText == null || _suggestionText.Length <= text.Length ||
+                    text.Length < _userInputText.Length || !_suggestionText.StartsWith(text, _options.HistoryStringComparison))
                 {
+                    _userInputText = text;
                     _suggestionText = GetHistorySuggestion(text);
                 }
             }
@@ -56,6 +53,67 @@ namespace Microsoft.PowerShell
             }
 
             return _suggestionText?.Substring(text.Length);
+        }
+
+        /// <summary>
+        /// Accept the suggestion text if there is one.
+        /// </summary>
+        public static void AcceptSuggestion(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            if (!TryGetArgAsInt(arg, out var numericArg, 1))
+            {
+                return;
+            }
+
+            if (numericArg > 0)
+            {
+                AcceptSuggestion();
+            }
+        }
+
+        private static void AcceptSuggestion()
+        {
+            if (_singleton._suggestionText != null)
+            {
+                // Ignore the visual selection.
+                _singleton._visualSelectionCommandCount = 0;
+
+                using var _ = _singleton.PredictionOff();
+                Replace(0, _singleton._buffer.Length, _singleton._suggestionText);
+            }
+        }
+
+        /// <summary>
+        /// Accept the current or the next suggestion text word.
+        /// </summary>
+        public static void AcceptNextSuggestionWord(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            if (!TryGetArgAsInt(arg, out var numericArg, 1))
+            {
+                return;
+            }
+
+            if (numericArg > 0)
+            {
+                AcceptNextSuggestionWord(numericArg);
+            }
+        }
+
+        private static void AcceptNextSuggestionWord(int numericArg)
+        {
+            if (_singleton._suggestionText != null)
+            {
+                // Ignore the visual selection.
+                _singleton._visualSelectionCommandCount = 0;
+
+                int index = _singleton._buffer.Length;
+                while (numericArg-- > 0 && index < _singleton._suggestionText.Length)
+                {
+                    index = _singleton.FindForwardSuggestionWordPoint(index, _singleton.Options.WordDelimiters);
+                }
+
+                Replace(0, _singleton._buffer.Length, _singleton._suggestionText.Substring(0, index));
+            }
         }
     }
 }

--- a/PSReadLine/Suggestion.cs
+++ b/PSReadLine/Suggestion.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace Microsoft.PowerShell
+{
+    public partial class PSConsoleReadLine
+    {
+        private class SuggestionModeRestore : IDisposable
+        {
+            private bool oldSuggestionMode;
+
+            internal SuggestionModeRestore(bool showSuggestion)
+            {
+                oldSuggestionMode = _singleton._showSuggestion;
+                _singleton._showSuggestion = showSuggestion;
+            }
+
+            public void Dispose()
+            {
+                _singleton._showSuggestion = oldSuggestionMode;
+            }
+        }
+
+        private string _suggestionText;
+        private uint _lastRenderedTextHash;
+        private bool _showSuggestion = true;
+
+        /// <summary>
+        /// Turn off the prediction feature for the scope of the calling method.
+        /// Note: the calling method need to use this method with the 'using' statement/variable,
+        /// so that the suggestion feature can be properly restored.
+        /// </summary>
+        private SuggestionModeRestore PredictionOff() => new SuggestionModeRestore(false);
+
+        private string GetSuggestion(string text)
+        {
+            if (_options.PredictionStyle == PredictionStyle.None || !_showSuggestion ||
+                LineIsMultiLine() || string.IsNullOrWhiteSpace(text))
+            {
+                _suggestionText = null;
+                _lastRenderedTextHash = 0;
+                return null;
+            }
+
+            try
+            {
+                uint textHash = _lastRenderedTextHash;
+                _lastRenderedTextHash = FNV1a32Hash.ComputeHash(text);
+                if (textHash != _lastRenderedTextHash)
+                {
+                    _suggestionText = GetHistorySuggestion(text);
+                }
+            }
+            catch
+            {
+                _suggestionText = null;
+            }
+
+            return _suggestionText?.Substring(text.Length);
+        }
+    }
+}

--- a/PSReadLine/Words.cs
+++ b/PSReadLine/Words.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell
         {
             System.Diagnostics.Debug.Assert(
                 _suggestionText != null && _suggestionText.Length > _buffer.Length,
-                "Caller needs to make srue the suggestion text exist.");
+                "Caller needs to make sure the suggestion text exist.");
 
             if (currentIndex >= _suggestionText.Length)
             {

--- a/PSReadLine/Words.cs
+++ b/PSReadLine/Words.cs
@@ -91,12 +91,11 @@ namespace Microsoft.PowerShell
         private bool InWord(int index, string wordDelimiters)
         {
             char c = _buffer[index];
-            return !char.IsWhiteSpace(c) && wordDelimiters.IndexOf(c) < 0;
+            return InWord(c, wordDelimiters);
         }
 
-        private bool InWord(string text, int index, string wordDelimiters)
+        private bool InWord(char c, string wordDelimiters)
         {
-            char c = text[index];
             return !char.IsWhiteSpace(c) && wordDelimiters.IndexOf(c) < 0;
         }
 
@@ -112,12 +111,12 @@ namespace Microsoft.PowerShell
             }
 
             int i = currentIndex;
-            if (!InWord(_suggestionText, i, wordDelimiters))
+            if (!InWord(_suggestionText[i], wordDelimiters))
             {
                 // Scan to end of current non-word region
                 while (++i < _suggestionText.Length)
                 {
-                    if (InWord(_suggestionText, i, wordDelimiters))
+                    if (InWord(_suggestionText[i], wordDelimiters))
                     {
                         break;
                     }
@@ -128,7 +127,7 @@ namespace Microsoft.PowerShell
             {
                 while (++i < _suggestionText.Length)
                 {
-                    if (!InWord(_suggestionText, i, wordDelimiters))
+                    if (!InWord(_suggestionText[i], wordDelimiters))
                     {
                         if (_suggestionText[i] == ' ')
                         {

--- a/PSReadLine/Words.cs
+++ b/PSReadLine/Words.cs
@@ -94,6 +94,57 @@ namespace Microsoft.PowerShell
             return !char.IsWhiteSpace(c) && wordDelimiters.IndexOf(c) < 0;
         }
 
+        private bool InWord(string text, int index, string wordDelimiters)
+        {
+            char c = text[index];
+            return !char.IsWhiteSpace(c) && wordDelimiters.IndexOf(c) < 0;
+        }
+
+        private int FindForwardSuggestionWordPoint(int currentIndex, string wordDelimiters)
+        {
+            System.Diagnostics.Debug.Assert(
+                _suggestionText != null && _suggestionText.Length > _buffer.Length,
+                "Caller needs to make srue the suggestion text exist.");
+
+            if (currentIndex >= _suggestionText.Length)
+            {
+                return _suggestionText.Length;
+            }
+
+            int i = currentIndex;
+            if (!InWord(_suggestionText, i, wordDelimiters))
+            {
+                // Scan to end of current non-word region
+                while (++i < _suggestionText.Length)
+                {
+                    if (InWord(_suggestionText, i, wordDelimiters))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (i < _suggestionText.Length)
+            {
+                while (++i < _suggestionText.Length)
+                {
+                    if (!InWord(_suggestionText, i, wordDelimiters))
+                    {
+                        if (_suggestionText[i] == ' ')
+                        {
+                            // If the end of this suggestion word is a space, then we consider the word
+                            // is complete and include the space in the accepted suggestion word.
+                            i++;
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            return i;
+        }
+
         /// <summary>
         /// Find the end of the current/next word as defined by wordDelimiters and whitespace.
         /// </summary>

--- a/docs/Set-PSReadLineOption.md
+++ b/docs/Set-PSReadLineOption.md
@@ -36,7 +36,7 @@ Set-PSReadLineOption
  [-AnsiEscapeTimeout <int>]
  [-ViModeIndicator <ViModeStyle>]
  [-ViModeChangeHandler <ScriptBlock>]
- [-PredictionStyle <PredictionStyle>]
+ [-PredictionSource <PredictionSource>]
 ```
 
 ## DESCRIPTION
@@ -626,33 +626,13 @@ Valid values are:
 -- History: get predictive suggestions from history only.
 
 ```yaml
-Type: PredictionStyle
+Type: PredictionSource
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: false
-Accept wildcard characters: false
-```
-
-### -PredictionViewStyle
-
-Specifies how PSReadLine should render the predictive suggestions.
-
-Valid values are:
-
--- Default: Render the suggestion in an inline manner.
-
-```yaml
-Type: PredictionStyle
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: Default
 Accept pipeline input: false
 Accept wildcard characters: false
 ```

--- a/docs/Set-PSReadLineOption.md
+++ b/docs/Set-PSReadLineOption.md
@@ -36,6 +36,7 @@ Set-PSReadLineOption
  [-AnsiEscapeTimeout <int>]
  [-ViModeIndicator <ViModeStyle>]
  [-ViModeChangeHandler <ScriptBlock>]
+ [-PredictionStyle <PredictionStyle>]
 ```
 
 ## DESCRIPTION
@@ -389,6 +390,8 @@ The valid keys include:
 
 -- Member: The member name token color.
 
+-- Prediction: The color for the suggestion text that comes from the prediction API.
+
 ```yaml
 Type: Hashtable
 Parameter Sets: (All)
@@ -608,6 +611,28 @@ Aliases:
 Required: False
 Position: Named
 Default value:
+Accept pipeline input: false
+Accept wildcard characters: false
+```
+
+### -PredictionStyle
+
+Specifies how PSReadLine should render the predictive suggestions.
+
+Valid values are:
+
+-- None: disable the predictive suggestion feature
+
+-- Concise: render the predictive suggestion in a concise view
+
+```yaml
+Type: PredictionStyle
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Concise
 Accept pipeline input: false
 Accept wildcard characters: false
 ```

--- a/docs/Set-PSReadLineOption.md
+++ b/docs/Set-PSReadLineOption.md
@@ -615,15 +615,15 @@ Accept pipeline input: false
 Accept wildcard characters: false
 ```
 
-### -PredictionStyle
+### -PredictionSource
 
-Specifies how PSReadLine should render the predictive suggestions.
+Specifies the source for PSReadLine to get predictive suggestions.
 
 Valid values are:
 
--- None: disable the predictive suggestion feature
+-- None: disable the predictive suggestion feature.
 
--- Concise: render the predictive suggestion in a concise view
+-- History: get predictive suggestions from history only.
 
 ```yaml
 Type: PredictionStyle
@@ -632,7 +632,27 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: Concise
+Default value: None
+Accept pipeline input: false
+Accept wildcard characters: false
+```
+
+### -PredictionViewStyle
+
+Specifies how PSReadLine should render the predictive suggestions.
+
+Valid values are:
+
+-- Default: Render the suggestion in an inline manner.
+
+```yaml
+Type: PredictionStyle
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Default
 Accept pipeline input: false
 Accept wildcard characters: false
 ```

--- a/test/SuggestionTest.cs
+++ b/test/SuggestionTest.cs
@@ -1,0 +1,110 @@
+using Microsoft.PowerShell;
+using System;
+using System.Collections;
+using Xunit;
+
+namespace Test
+{
+    public partial class ReadLine
+    {
+        [SkippableFact]
+        public void RenderSuggestion()
+        {
+            TestSetup(KeyMode.Cmd,
+                      new KeyHandler("Ctrl+f", PSConsoleReadLine.ForwardWord));
+
+            // No matching history entry
+            SetHistory("echo -bar", "eca -zoo");
+            Test("a", Keys(
+                'a', CheckThat(() => AssertScreenIs(1, TokenClassification.Command, 'a')),
+                _.Ctrl_f, CheckThat(() => AssertScreenIs(1, TokenClassification.Command, 'a')),
+                _.RightArrow, CheckThat(() => AssertScreenIs(1, TokenClassification.Command, 'a')),
+                CheckThat(() => AssertCursorLeftIs(1))));
+
+            // Different matches as more input coming
+            SetHistory("echo -bar", "eca -zoo");
+            Test("ech", Keys(
+                'e', CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, 'e',
+                        TokenClassification.Prediction, "ca -zoo")),
+                'c', CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, "ec",
+                        TokenClassification.Prediction, "a -zoo")),
+                'h', CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, "ech",
+                        TokenClassification.Prediction, "o -bar")),
+                // Once accepted, the suggestion text should be blanked out.
+                _.Enter, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "ech"))
+            ));
+
+            // Accept all or partial suggestion text with 'ForwardChar' and 'ForwardWord'
+            SetHistory("echo -bar", "eca -zoo");
+            Test("eca ", Keys(
+                'e', CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, 'e',
+                        TokenClassification.Prediction, "ca -zoo")),
+                _.RightArrow, CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, "eca",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Parameter, "-zoo")),
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, 'e',
+                        TokenClassification.Prediction, "ca -zoo")),
+                _.Ctrl_f, CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, "eca",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Prediction, "-zoo")),
+                CheckThat(() => AssertCursorLeftIs(4)),
+                _.Ctrl_f, CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, "eca",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Parameter, "-zoo")),
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, "eca",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Prediction, "-zoo"))
+            ));
+        }
+
+        [SkippableFact]
+        public void DisablePrediction()
+        {
+            TestSetup(KeyMode.Cmd);
+            SetHistory("echo -bar", "eca -zoo");
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {PredictionStyle = PredictionStyle.None});
+
+            Test("ech", Keys(
+                'e', CheckThat(() => AssertScreenIs(1, TokenClassification.Command, 'e')),
+                'c', CheckThat(() => AssertScreenIs(1, TokenClassification.Command, "ec")),
+                'h', CheckThat(() => AssertScreenIs(1, TokenClassification.Command, "ech")),
+                _.Enter, CheckThat(() => AssertScreenIs(1, TokenClassification.Command, "ech"))
+            ));
+        }
+
+        [SkippableFact]
+        public void SetPredictionColor()
+        {
+            TestSetup(KeyMode.Cmd);
+            var predictionColor = MakeCombinedColor(ConsoleColor.DarkYellow, ConsoleColor.Yellow);
+            var predictionColorToCheck = Tuple.Create(ConsoleColor.DarkYellow, ConsoleColor.Yellow);
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {Colors = new Hashtable(){{"Prediction", predictionColor}}});
+
+            SetHistory("echo -bar", "eca -zoo");
+            Test("ech", Keys(
+                'e', CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, 'e',
+                        predictionColorToCheck, "ca -zoo")),
+                'c', CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, "ec",
+                        predictionColorToCheck, "a -zoo")),
+                'h', CheckThat(() => AssertScreenIs(1, 
+                        TokenClassification.Command, "ech",
+                        predictionColorToCheck, "o -bar")),
+                // Once accepted, the suggestion text should be blanked out.
+                _.Enter, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "ech"))
+            ));
+        }
+    }
+}

--- a/test/SuggestionTest.cs
+++ b/test/SuggestionTest.cs
@@ -19,7 +19,8 @@ namespace Test
                 'a', CheckThat(() => AssertScreenIs(1, TokenClassification.Command, 'a')),
                 _.Ctrl_f, CheckThat(() => AssertScreenIs(1, TokenClassification.Command, 'a')),
                 _.RightArrow, CheckThat(() => AssertScreenIs(1, TokenClassification.Command, 'a')),
-                CheckThat(() => AssertCursorLeftIs(1))));
+                CheckThat(() => AssertCursorLeftIs(1))
+            ));
 
             // Different matches as more input coming
             SetHistory("echo -bar", "eca -zoo");
@@ -127,6 +128,41 @@ namespace Test
                         TokenClassification.None, ' ',
                         TokenClassification.Prediction, "-zoo")),
                 CheckThat(() => AssertCursorLeftIs(4))
+            ));
+        }
+
+        [SkippableFact]
+        public void AcceptNextSuggestionWordCanAcceptMoreThanOneWords()
+        {
+            TestSetup(KeyMode.Cmd,
+                      new KeyHandler("Ctrl+f", PSConsoleReadLine.ForwardWord),
+                      new KeyHandler("Alt+f", PSConsoleReadLine.AcceptNextSuggestionWord));
+
+            SetHistory("abc def ghi jkl");
+            Test("abc def ghi jkl", Keys(
+                'a', CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, 'a',
+                        TokenClassification.Prediction, "bc def ghi jkl")),
+                _.Alt_3, _.Ctrl_f,
+                CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "abc",
+                        TokenClassification.None, " def ghi ",
+                        TokenClassification.Prediction, "jkl")),
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, 'a',
+                        TokenClassification.Prediction, "bc def ghi jkl")),
+                _.Alt_3, _.Alt_f,
+                CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "abc",
+                        TokenClassification.None, " def ghi ",
+                        TokenClassification.Prediction, "jkl")),
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, 'a',
+                        TokenClassification.Prediction, "bc def ghi jkl")),
+                _.Alt_8, _.Alt_f,
+                CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "abc",
+                        TokenClassification.None, " def ghi jkl"))
             ));
         }
 

--- a/test/SuggestionTest.cs
+++ b/test/SuggestionTest.cs
@@ -24,13 +24,13 @@ namespace Test
             // Different matches as more input coming
             SetHistory("echo -bar", "eca -zoo");
             Test("ech", Keys(
-                'e', CheckThat(() => AssertScreenIs(1, 
+                'e', CheckThat(() => AssertScreenIs(1,
                         TokenClassification.Command, 'e',
                         TokenClassification.Prediction, "ca -zoo")),
-                'c', CheckThat(() => AssertScreenIs(1, 
+                'c', CheckThat(() => AssertScreenIs(1,
                         TokenClassification.Command, "ec",
                         TokenClassification.Prediction, "a -zoo")),
-                'h', CheckThat(() => AssertScreenIs(1, 
+                'h', CheckThat(() => AssertScreenIs(1,
                         TokenClassification.Command, "ech",
                         TokenClassification.Prediction, "o -bar")),
                 // Once accepted, the suggestion text should be blanked out.
@@ -41,29 +41,145 @@ namespace Test
             // Accept all or partial suggestion text with 'ForwardChar' and 'ForwardWord'
             SetHistory("echo -bar", "eca -zoo");
             Test("eca ", Keys(
-                'e', CheckThat(() => AssertScreenIs(1, 
+                'e', CheckThat(() => AssertScreenIs(1,
                         TokenClassification.Command, 'e',
                         TokenClassification.Prediction, "ca -zoo")),
-                _.RightArrow, CheckThat(() => AssertScreenIs(1, 
+                _.RightArrow, CheckThat(() => AssertScreenIs(1,
                         TokenClassification.Command, "eca",
                         TokenClassification.None, ' ',
                         TokenClassification.Parameter, "-zoo")),
-                _.Ctrl_z, CheckThat(() => AssertScreenIs(1, 
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
                         TokenClassification.Command, 'e',
                         TokenClassification.Prediction, "ca -zoo")),
-                _.Ctrl_f, CheckThat(() => AssertScreenIs(1, 
+                _.Ctrl_f, CheckThat(() => AssertScreenIs(1,
                         TokenClassification.Command, "eca",
                         TokenClassification.None, ' ',
                         TokenClassification.Prediction, "-zoo")),
                 CheckThat(() => AssertCursorLeftIs(4)),
-                _.Ctrl_f, CheckThat(() => AssertScreenIs(1, 
+                _.Ctrl_f, CheckThat(() => AssertScreenIs(1,
                         TokenClassification.Command, "eca",
                         TokenClassification.None, ' ',
                         TokenClassification.Parameter, "-zoo")),
-                _.Ctrl_z, CheckThat(() => AssertScreenIs(1, 
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
                         TokenClassification.Command, "eca",
                         TokenClassification.None, ' ',
                         TokenClassification.Prediction, "-zoo"))
+            ));
+        }
+
+        [SkippableFact]
+        public void CustomKeyBindingsToAcceptSuggestion()
+        {
+            TestSetup(KeyMode.Cmd,
+                      new KeyHandler("Alt+g", PSConsoleReadLine.AcceptSuggestion),
+                      new KeyHandler("Alt+f", PSConsoleReadLine.AcceptNextSuggestionWord));
+
+            SetHistory("echo -bar", "eca -zoo");
+            Test("eca ", Keys(
+                "ec", CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "ec",
+                        TokenClassification.Prediction, "a -zoo")),
+                CheckThat(() => AssertCursorLeftIs(2)),
+                _.Alt_g, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "eca",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Parameter, "-zoo")),
+                CheckThat(() => AssertCursorLeftIs(8)),
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "ec",
+                        TokenClassification.Prediction, "a -zoo")),
+                CheckThat(() => AssertCursorLeftIs(2)),
+                _.Alt_f, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "eca",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Prediction, "-zoo")),
+                CheckThat(() => AssertCursorLeftIs(4)),
+                _.Alt_f, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "eca",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Parameter, "-zoo")),
+                CheckThat(() => AssertCursorLeftIs(8)),
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "eca",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Prediction, "-zoo")),
+                CheckThat(() => AssertCursorLeftIs(4)),
+
+                // Revert back to 'ec'.
+                _.Ctrl_z, CheckThat(() => AssertCursorLeftIs(2)),
+                // Move cursor to column 0.
+                _.LeftArrow, _.LeftArrow,
+                CheckThat(() => AssertCursorLeftIs(0)),
+                _.Alt_g, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "eca",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Parameter, "-zoo")),
+                CheckThat(() => AssertCursorLeftIs(8)),
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "ec",
+                        TokenClassification.Prediction, "a -zoo")),
+                CheckThat(() => AssertCursorLeftIs(2)),
+                // Move cursor to column 0 again.
+                _.LeftArrow, _.LeftArrow,
+                CheckThat(() => AssertCursorLeftIs(0)),
+                _.Alt_f, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "eca",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Prediction, "-zoo")),
+                CheckThat(() => AssertCursorLeftIs(4))
+            ));
+        }
+
+        [SkippableFact]
+        public void AcceptSuggestionWithSelection()
+        {
+            TestSetup(KeyMode.Cmd,
+                      new KeyHandler("Ctrl+f", PSConsoleReadLine.ForwardWord));
+
+            SetHistory("git diff --cached", "git diff");
+            Test("git diff", Keys(
+                "git", CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "git",
+                        TokenClassification.Prediction, " diff")),
+                _.RightArrow, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "git",
+                        TokenClassification.None, " diff")),
+                _.Ctrl_z, CheckThat(() => AssertCursorLeftIs(3)),
+                _.Ctrl_f, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "git",
+                        TokenClassification.None, " diff",
+                        TokenClassification.Prediction, " --cached")),
+
+                // Perform visual selection and then accept suggestion.
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "git",
+                        TokenClassification.Prediction, " diff")),
+                _.LeftArrow, _.Shift_RightArrow,
+                CheckThat(() =>
+                {
+                    PSConsoleReadLine.GetSelectionState(out var start, out var length);
+                    Assert.Equal(2, start);
+                    Assert.Equal(1, length);
+                }),
+                _.RightArrow, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "git",
+                        TokenClassification.None, " diff")),
+
+                // Perform visual selection and then accept next suggestion word.
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "git",
+                        TokenClassification.Prediction, " diff")),
+                _.LeftArrow, _.Shift_RightArrow,
+                CheckThat(() =>
+                {
+                    PSConsoleReadLine.GetSelectionState(out var start, out var length);
+                    Assert.Equal(2, start);
+                    Assert.Equal(1, length);
+                }),
+                _.Ctrl_f, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "git",
+                        TokenClassification.None, " diff",
+                        TokenClassification.Prediction, " --cached"))
             ));
         }
 
@@ -72,7 +188,7 @@ namespace Test
         {
             TestSetup(KeyMode.Cmd);
             SetHistory("echo -bar", "eca -zoo");
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {PredictionStyle = PredictionStyle.None});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {PredictionSource = PredictionSource.None});
 
             Test("ech", Keys(
                 'e', CheckThat(() => AssertScreenIs(1, TokenClassification.Command, 'e')),

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -478,7 +478,7 @@ namespace Test
                 ShowToolTips                      = PSConsoleReadLineOptions.DefaultShowToolTips,
                 WordDelimiters                    = PSConsoleReadLineOptions.DefaultWordDelimiters,
                 PromptText                        = new [] {""},
-                PredictionStyle                   = PredictionStyle.Concise,
+                PredictionSource                  = PredictionSource.History,
                 Colors = new Hashtable {
                     { "ContinuationPrompt",       MakeCombinedColor(_console.ForegroundColor, _console.BackgroundColor) },
                     { "Emphasis",                 MakeCombinedColor(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor) },

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -50,6 +50,7 @@ namespace Test
         Number,
         Member,
         Selection,
+        Prediction,
     }
 
     public abstract partial class ReadLine
@@ -101,6 +102,7 @@ namespace Test
         /*Number*/    ConsoleColor.DarkBlue,
         /*Member*/    ConsoleColor.DarkMagenta,
         /*Selection*/ ConsoleColor.Black,
+        /*Prediction*/ConsoleColor.DarkGreen,
         };
 
         internal static readonly ConsoleColor[] BackgroundColors = new[]
@@ -116,7 +118,8 @@ namespace Test
         /*Type*/      ConsoleColor.Black,
         /*Number*/    ConsoleColor.Gray,
         /*Member*/    ConsoleColor.Yellow,
-        /*Selection*/ ConsoleColor.Gray
+        /*Selection*/ ConsoleColor.Gray,
+        /*Prediction*/ConsoleColor.Cyan,
         };
 
         class KeyHandler
@@ -475,6 +478,7 @@ namespace Test
                 ShowToolTips                      = PSConsoleReadLineOptions.DefaultShowToolTips,
                 WordDelimiters                    = PSConsoleReadLineOptions.DefaultWordDelimiters,
                 PromptText                        = new [] {""},
+                PredictionStyle                   = PredictionStyle.Concise,
                 Colors = new Hashtable {
                     { "ContinuationPrompt",       MakeCombinedColor(_console.ForegroundColor, _console.BackgroundColor) },
                     { "Emphasis",                 MakeCombinedColor(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor) },
@@ -505,7 +509,7 @@ namespace Test
             var tokenTypes = new[]
             {
                 "Default", "Comment", "Keyword", "String", "Operator", "Variable",
-                "Command", "Parameter", "Type", "Number", "Member", "Selection"
+                "Command", "Parameter", "Type", "Number", "Member", "Selection", "Prediction"
             };
             var colors = new Hashtable();
             for (var i = 0; i < tokenTypes.Length; i++)


### PR DESCRIPTION
This PR is to merge the existing predictive suggestion changes to the master branch.
Changes were refactored and cleaned up. Also tests are added.

- Currently, the only suggestion source is the PSReadLine history file.
- By default, the suggestion text is rendered with the `dark black` color `\x1b[38;5;238m`, which works OK with a black background.
  You can change it by running `Set-PSReadLineOption -Colors @{ Prediction = '<your-choice-of-color>' }`
- Parameter `-PredictionSource` is added to `Set-PSReadLineOption`, currently with the options `None` and `History`.
  The value is `None` by default, meaning that the predictive suggestion feature is disabled by default.
  A user can enable the prediction feature by set it to `History`. The feature cannot be enabled when the console output doesn't support VT.
- Make `AcceptSuggestion` and `AcceptNextSuggestionWord` bindable.
- Also fix #1495

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1496)