### PR TITLE
Simplify the detection of Windows Terminal

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -33,16 +33,8 @@ Please run the script in the PowerShell session where you ran into the issue and
 
 & {
     $hostName = $Host.Name
-    if ($hostName -eq "ConsoleHost" -and (Get-Command Get-CimInstance -ErrorAction SilentlyContinue)) {
-        $id = $PID
-        $inWindowsTerminal = $false
-        while ($true) {
-            $p = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId Like $id"
-            if (!$p -or !$p.Name) { break }
-            if ($p.Name -eq "WindowsTerminal.exe") { $inWindowsTerminal = $true; break }
-            $id = $p.ParentProcessId
-        }
-        if ($inWindowsTerminal) { $hostName += " (Windows Terminal)" }
+    if (Test-Path env:\WT_SESSION) {
+        $hostName += " (Windows Terminal)"
     }
 
     "`nPS version: $($PSVersionTable.PSVersion)"


### PR DESCRIPTION
Use the environment variable `WT_SESSION` instead of walk up the process chain.

```
WT_SESSION=e1d171d9-4739-4cd0-b086-50d729f39631
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1511)