### PR TITLE
Relax the sensitive words we filter

### DIFF
--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell
 
         // Pattern used to check for sensitive inputs.
         private static readonly Regex s_sensitivePattern = new Regex(
-            "password|asplaintext|token|key|secret",
+            "password|asplaintext|token|apikey|secret",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private void ClearSavedCurrentLine()

--- a/docs/Set-PSReadLineOption.md
+++ b/docs/Set-PSReadLineOption.md
@@ -215,7 +215,7 @@ This usually indicates the command line has sensitive content that should not be
 PSReadLine provides a default handler to this option:
     `[Microsoft.PowerShell.PSConsoleReadLine]::GetDefaultAddToHistoryOption(string line)`
 The default handler attempts to detect sensitive information in a command line by matching with a simple regex pattern:
-    `"password|asplaintext|token|key|secret"`
+    `"password|asplaintext|token|apikey|secret"`
 When successfully matched, the command line is considered to contain sensitive content, and `MemoryOnly` is returned.
 Otherwise, `MemoryAndFile` is returned.
 

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -62,7 +62,7 @@ namespace Test
                 "echo foo",
                 "cmd1 /token abc",
                 "echo bar",
-                "cmd2 --key abc",
+                "cmd2 --apikey abc",
                 "echo zoo",
                 "pki secret",
                 "gcm p*"


### PR DESCRIPTION
Fix #1459

Change `key` to `apikey` to reduce false positives.
`key` as a sensitive word is too aggressive. Some false positives that one can easily run into:
- `Set/Get/Remove-PSReadLineKeyHandler`
- `-KeyFilePath` parameter on all PowerShell remoting cmdlets, such as `Enter/New-PSSession`, `Invoke-Command`
- `-Key` parameter on CIM cmdlets such as `New/Get-CimInstance`, which specifies the properties that are used as keys.
- `Update-TypeData -DefaultKeyPropertySet`
-  `-Key` and `-SecureKey` parameter on `ConvertTo/ConvertFrom-SecureString` accept a byte array and a `SecureString` respectively, so they don't need to be removed from the history.

`-NuGetApiKey` is used by `Publish-Module/Script` to accept a sensitive string, and `apikey` can continue to filter those cmdlets out from the history.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1517)