### PR TITLE
Make edit group more stable in VI mode

### DIFF
--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -85,6 +85,7 @@ namespace Microsoft.PowerShell
             internal bool _sensitive;
             internal List<EditItem> _edits;
             internal int _undoEditIndex;
+            internal int _editGroupStart;
         }
 
         // History state
@@ -119,6 +120,7 @@ namespace Microsoft.PowerShell
             _savedCurrentLine.CommandLine = null;
             _savedCurrentLine._edits = null;
             _savedCurrentLine._undoEditIndex = 0;
+            _savedCurrentLine._editGroupStart = -1;
         }
 
         private AddToHistoryOption GetAddToHistoryOption(string line)
@@ -194,6 +196,7 @@ namespace Microsoft.PowerShell
                     CommandLine = result,
                     _edits = edits,
                     _undoEditIndex = undoEditIndex,
+                    _editGroupStart = -1,
                     _saved = fromHistoryFile,
                     FromOtherSession = fromDifferentSession,
                     FromHistoryFile = fromInitialRead,
@@ -477,12 +480,14 @@ namespace Microsoft.PowerShell
                 line = _savedCurrentLine.CommandLine;
                 _edits = new List<EditItem>(_savedCurrentLine._edits);
                 _undoEditIndex = _savedCurrentLine._undoEditIndex;
+                _editGroupStart = _savedCurrentLine._editGroupStart;
             }
             else
             {
                 line = _history[_currentHistoryIndex].CommandLine;
                 _edits = new List<EditItem>(_history[_currentHistoryIndex]._edits);
                 _undoEditIndex = _history[_currentHistoryIndex]._undoEditIndex;
+                _editGroupStart = _history[_currentHistoryIndex]._editGroupStart;
             }
             _buffer.Clear();
             _buffer.Append(line);
@@ -519,6 +524,7 @@ namespace Microsoft.PowerShell
                 _savedCurrentLine.CommandLine = _buffer.ToString();
                 _savedCurrentLine._edits = _edits;
                 _savedCurrentLine._undoEditIndex = _undoEditIndex;
+                _savedCurrentLine._editGroupStart = _editGroupStart;
             }
         }
 

--- a/test/UndoRedoTest.cs
+++ b/test/UndoRedoTest.cs
@@ -1,8 +1,60 @@
-﻿namespace Test
+﻿using Xunit;
+
+namespace Test
 {
-    // Disgusting language hack to make it easier to read a sequence of keys.
-    
     public partial class ReadLine
     {
+        [SkippableFact]
+        public void UndoneEditsShouldBeRemovedBeforeEndingEditGroup()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("yuiogh", Keys(
+                "yuiogh", _.Escape, CheckThat(() => AssertLineIs("yuiogh")),
+                _.C, CheckThat(() => AssertLineIs("yuiog")),
+                "897", CheckThat(() => AssertLineIs("yuiog897")),
+                _.Ctrl_z, CheckThat(() => AssertLineIs("yuiog89")),
+                _.Escape, _.u, CheckThat(() => AssertLineIs("yuiogh"))
+            ));
+        }
+
+        [SkippableFact]
+        public void ProperlyUpdateEditGroupStartMarkWhenRemovingUndoneEdits()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("yuiogh", Keys(
+                "yuiogh", _.Escape, CheckThat(() => AssertLineIs("yuiogh")),
+                _.LeftArrow, _.C, CheckThat(() => AssertLineIs("yuio")),
+                "789", CheckThat(() => AssertLineIs("yuio789")),
+                _.Ctrl_z, CheckThat(() => AssertLineIs("yuio78")),
+                '1', _.Escape, _.u, CheckThat(() => AssertLineIs("yuiogh"))
+            ));
+        }
+
+        [SkippableFact]
+        public void ProperlySetEditGroupStartMarkWhenLoopInHistory()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("ok", Keys("ok"));
+
+            // The _editGroupStart mark for an history entry should always be -1, meaning no start mark.
+            Test("ok", Keys(
+                "yuiogh", _.Escape, CheckThat(() => AssertLineIs("yuiogh")),
+                _.C, CheckThat(() => AssertLineIs("yuiog")),
+                _.UpArrow, CheckThat(() => AssertLineIs("ok")),
+                _.Escape));
+
+            // The _editGroupStart mark should be restored when loop back to the current command line.
+            Test("yuiogh", Keys(
+                "yuiogh", _.Escape, CheckThat(() => AssertLineIs("yuiogh")),
+                _.C, CheckThat(() => AssertLineIs("yuiog")),
+                _.UpArrow, CheckThat(() => AssertLineIs("ok")),
+                _.DownArrow, CheckThat(() => AssertLineIs("yuiog")),
+                "123", CheckThat(() => AssertLineIs("yuiog123")),
+                _.Escape, _.u, CheckThat(() => AssertLineIs("yuiogh"))
+            ));
+        }
     }
 }


### PR DESCRIPTION
Make edit group more stable in VI mode.

Fix #1524
Fix #1523
Fix #1518

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1526)