### PR TITLE
useLocalScope to true so that it works in CLM

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -653,7 +653,7 @@ namespace Microsoft.PowerShell
             {
                 try
                 {
-                    var results = ps.AddScript("$Host").Invoke<PSHost>();
+                    var results = ps.AddScript("$Host", useLocalScope: true).Invoke<PSHost>();
                     PSHost host = results.Count == 1 ? results[0] : null;
                     hostName = host?.Name;
                 }

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -230,7 +230,7 @@ namespace Microsoft.PowerShell
                             if (ps == null)
                             {
                                 ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
-                                ps.AddScript("0");
+                                ps.AddScript("0", useLocalScope: true);
                             }
 
                             // To detect output during possible event processing, see if the cursor moved


### PR DESCRIPTION
`.AddScript("0")` dot sources the script. Since it's created in C#, the script is considered trusted... You can't dot source trusted scripts into a runspace that is running in ConstrainedLanguage mode otherwise it throws an exception.

This allows PSReadLine to be loaded in the PowerShell extension for VS Code when running in ConstrainedLanguage mode.