### PR TITLE
Make 'ViForwardChar' able to accept suggestions

### DIFF
--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -91,7 +91,14 @@ namespace Microsoft.PowerShell
         {
             if (TryGetArgAsInt(arg, out var numericArg, 1))
             {
-                ViOffsetCursorPosition(+ numericArg);
+                if (InViInsertMode() && _singleton._current == _singleton._buffer.Length && numericArg > 0)
+                {
+                    AcceptSuggestion(key, arg);
+                }
+                else
+                {
+                    ViOffsetCursorPosition(+ numericArg);
+                }
             }
         }
 

--- a/PSReadLine/UndoRedo.cs
+++ b/PSReadLine/UndoRedo.cs
@@ -75,9 +75,10 @@ namespace Microsoft.PowerShell
                 }
                 _singleton._edits[_singleton._undoEditIndex - 1].Undo();
                 _singleton._undoEditIndex--;
+
                 if (_singleton._options.EditMode == EditMode.Vi && _singleton._current >= _singleton._buffer.Length)
                 {
-                    _singleton._current = Math.Max(0, _singleton._buffer.Length - 1);
+                    _singleton._current = Math.Max(0, _singleton._buffer.Length + ViEndOfLineFactor);
                 }
                 _singleton.Render();
             }

--- a/test/SuggestionTest.cs
+++ b/test/SuggestionTest.cs
@@ -289,5 +289,40 @@ namespace Test
                     TokenClassification.None, " checkout ")),
                 _.Escape));
         }
+
+        [SkippableFact]
+        public void AcceptSuggestionInVIMode()
+        {
+            TestSetup(KeyMode.Vi);
+
+            SetHistory("echo -bar", "eca -zoo");
+            Test("ech", Keys(
+                'e', CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, 'e',
+                        TokenClassification.Prediction, "ca -zoo")),
+                'c', CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "ec",
+                        TokenClassification.Prediction, "a -zoo")),
+                'h', CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "ech",
+                        TokenClassification.Prediction, "o -bar")),
+                CheckThat(() => AssertCursorLeftIs(3)),
+                _.RightArrow, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "echo",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Parameter, "-bar")),
+                CheckThat(() => AssertCursorLeftIs(9)),
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "ech",
+                        TokenClassification.Prediction, "o -bar")),
+                CheckThat(() => AssertCursorLeftIs(3)),
+
+                _.RightArrow, _.Escape,
+                CheckThat(() => AssertCursorLeftIs(8)),
+                _.Ctrl_z, CheckThat(() => AssertScreenIs(1,
+                        TokenClassification.Command, "ech")),
+                CheckThat(() => AssertCursorLeftIs(2))
+            ));
+        }
     }
 }


### PR DESCRIPTION
- Make `ViForwardChar` able to accept suggestions
- Fix the cursor position in `Undo` in VI mode, so the cursor is correctly placed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1528)