### PR TITLE
Reset all VT attributes for PromptText if it contains VT sequences

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -342,7 +342,29 @@ namespace Microsoft.PowerShell
         /// If the prompt function is pure, this value can be inferred, e.g.
         /// the default prompt will use "> " for this value.
         /// </summary>
-        public string[] PromptText { get; set; }
+        public string[] PromptText
+        {
+            get => _promptText;
+            set
+            {
+                _promptText = value;
+                if (_promptText == null || _promptText.Length == 0)
+                    return;
+
+                // For texts with VT sequences, reset all attributes if not already.
+                // We only handle the first 2 elements because that's all will potentially be used.
+                int minLength = _promptText.Length == 1 ? 1 : 2;
+                for (int i = 0; i < minLength; i ++)
+                {
+                    var text = _promptText[i];
+                    if (text.Contains('\x1b') && !text.EndsWith("\x1b[0m", StringComparison.Ordinal))
+                    {
+                        _promptText[i] = string.Concat(text, "\x1b[0m");
+                    }
+                }
+            }
+        }
+        private string[] _promptText;
 
         public object DefaultTokenColor
         {

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -444,9 +444,13 @@ namespace Microsoft.PowerShell
                 {
                     string color = renderData.errorPrompt ? _options._errorColor : defaultColor;
                     _console.Write(color);
+                    _console.Write(promptText);
+                    _console.Write("\x1b[0m");
                 }
-                _console.Write(promptText);
-                _console.Write("\x1b[0m");
+                else
+                {
+                    _console.Write(promptText);
+                }
             }
 
             return true;

--- a/test/OptionsTest.cs
+++ b/test/OptionsTest.cs
@@ -132,6 +132,45 @@ namespace Test
         }
 
         [SkippableFact]
+        public void SetPromptTextOption()
+        {
+            // For prompt texts with VT sequences, reset all attributes if not already.
+            string[] promptTexts_1 = new[] { "\x1b[91m> " };
+            string[] promptTexts_2 = new[] { "\x1b[91m> ", "\x1b[92m> ", "\x1b[93m> " };
+            string[] promptTexts_3 = new[] { "> " };
+            string[] promptTexts_4 = new[] { "> ", "] " };
+            string[] promptTexts_5 = new[] { "\x1b[93m> \x1b[0m" };
+
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {
+                PromptText = promptTexts_1,
+            });
+            Assert.Equal("\x1b[91m> \x1b[0m", promptTexts_1[0]);
+
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {
+                PromptText = promptTexts_2,
+            });
+            Assert.Equal("\x1b[91m> \x1b[0m", promptTexts_2[0]);
+            Assert.Equal("\x1b[92m> \x1b[0m", promptTexts_2[1]);
+            Assert.Equal("\x1b[93m> ", promptTexts_2[2]);
+
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {
+                PromptText = promptTexts_3,
+            });
+            Assert.Equal("> ", promptTexts_3[0]);
+
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {
+                PromptText = promptTexts_4,
+            });
+            Assert.Equal("> ", promptTexts_4[0]);
+            Assert.Equal("] ", promptTexts_4[1]);
+
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {
+                PromptText = promptTexts_5,
+            });
+            Assert.Equal("\x1b[93m> \x1b[0m", promptTexts_5[0]);
+        }
+
+        [SkippableFact]
         [ExcludeFromCodeCoverage]
         public void UselessStuffForBetterCoverage()
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #1542
Reset all VT attributes for PromptText if it contains VT sequences.
If the text doesn't contain VT sequences, we leave it unchanged, so that when rendering we can apply the default error color as expected. 

After the fix, the color doesn't leak in the formatted output:
![image](https://user-images.githubusercontent.com/127450/82618658-8b1ccf00-9b88-11ea-9a5e-970b1445c8e9.png)

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1544)