### PR TITLE
Expose 'ViBackwardChar' and 'ViForwardChar' as bindable functions

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -502,7 +502,9 @@ namespace Microsoft.PowerShell
             case nameof(ShellBackwardWord):
             case nameof(ShellForwardWord):
             case nameof(ShellNextWord):
+            case nameof(ViBackwardChar):
             case nameof(ViBackwardWord):
+            case nameof(ViForwardChar):
             case nameof(ViEndOfGlob):
             case nameof(ViEndOfPreviousGlob):
             case nameof(ViGotoBrace):

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Moves the cursor one character to the right on a single logical line.
         /// </summary>
-        private static void ViForwardChar(ConsoleKeyInfo? key = null, object arg = null)
+        public static void ViForwardChar(ConsoleKeyInfo? key = null, object arg = null)
         {
             if (TryGetArgAsInt(arg, out var numericArg, 1))
             {
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Move the cursor one character to the left on a single logical line.
         /// </summary>
-        private static void ViBackwardChar(ConsoleKeyInfo? key = null, object arg = null)
+        public static void ViBackwardChar(ConsoleKeyInfo? key = null, object arg = null)
         {
             if (TryGetArgAsInt(arg, out var numericArg, 1))
             {

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -591,6 +591,12 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
   <data name="ViBackwardWordDescription" xml:space="preserve">
     <value>Delete backward to the beginning of the previous word, as delimited by white space and common delimiters, and enter insert mode.</value>
   </data>
+  <data name="ViBackwardCharDescription" xml:space="preserve">
+    <value>Move the cursor back one character in the Vi edit mode.</value>
+  </data>
+  <data name="ViForwardCharDescription" xml:space="preserve">
+    <value>Move the cursor forward one character in the Vi edit mode.</value>
+  </data>
   <data name="PasteAfterDescription" xml:space="preserve">
     <value>Write the contents of the local clipboard after the cursor.</value>
   </data>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR is a follow-up of #1537, to expose `ViBackwardChar` and `ViForwardChar` as bindable functions.
Also submitted https://github.com/MicrosoftDocs/PowerShell-Docs/pull/6007 to update the about topic doc.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1547)