### PR TITLE
[vi-mode] 'dG' deletes to end of multiline buffer

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -398,6 +398,7 @@ namespace Microsoft.PowerShell
             case nameof(Cut):
             case nameof(DeleteChar):
             case nameof(DeleteCharOrExit):
+            case nameof(DeleteEndOfBuffer):
             case nameof(DeleteEndOfWord):
             case nameof(DeleteLine):
             case nameof(DeleteLineToFirstChar):

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -226,6 +226,7 @@ namespace Microsoft.PowerShell
                 { Keys.W,               MakeKeyHandler( DeleteWord,                   "DeleteWord") },
                 { Keys.ucW,             MakeKeyHandler( ViDeleteGlob,                 "ViDeleteGlob") },
                 { Keys.E,               MakeKeyHandler( DeleteEndOfWord,              "DeleteEndOfWord") },
+                { Keys.ucG,             MakeKeyHandler( DeleteEndOfBuffer,            "DeleteEndOfBuffer") },
                 { Keys.ucE,             MakeKeyHandler( ViDeleteEndOfGlob,            "ViDeleteEndOfGlob") },
                 { Keys.H,               MakeKeyHandler( BackwardDeleteChar,           "BackwardDeleteChar") },
                 { Keys.L,               MakeKeyHandler( DeleteChar,                   "DeleteChar") },

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -798,4 +798,7 @@ Or not saving history with:
   <data name="PredictiveSuggestionNotSupported" xml:space="preserve">
     <value>The predictive suggestion feature cannot be enabled because the console output doesn't support virtual terminal processing or it's redirected.</value>
   </data>
+  <data name="DeleteEndOfBufferDescription" xml:space="preserve">
+    <value>Delete the current logical line and up to the end of the multiline buffer</value>
+  </data>
 </root>

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -785,7 +785,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Deletes from the current logical line to the end of the buffer.
         /// </summary>
-        private static void DeleteEndOfBuffer(ConsoleKeyInfo? key = null, object arg = null)
+        public static void DeleteEndOfBuffer(ConsoleKeyInfo? key = null, object arg = null)
         {
             var lineIndex = _singleton.GetLogicalLineNumber() - 1;
             var lineCount = _singleton.GetLogicalLineCount() - lineIndex;

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -783,6 +783,25 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
+        /// Deletes from the current logical line to the end of the buffer.
+        /// </summary>
+        private static void DeleteEndOfBuffer(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            var lineIndex = _singleton.GetLogicalLineNumber() - 1;
+            var lineCount = _singleton.GetLogicalLineCount() - lineIndex;
+
+            DeleteLineImpl(lineIndex, lineCount);
+
+            // move the cursor to the beginning of the previous line
+
+            var previousLineIndex = Math.Max(0, lineIndex - 1);
+            var newPosition = GetBeginningOfNthLinePos(previousLineIndex);
+
+            _singleton._current = newPosition;
+            _singleton.Render();
+        }
+
+        /// <summary>
         /// Deletes the previous word.
         /// </summary>
         public static void BackwardDeleteWord(ConsoleKeyInfo? key = null, object arg = null)

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -793,7 +793,6 @@ namespace Microsoft.PowerShell
             DeleteLineImpl(lineIndex, lineCount);
 
             // move the cursor to the beginning of the previous line
-
             var previousLineIndex = Math.Max(0, lineIndex - 1);
             var newPosition = GetBeginningOfNthLinePos(previousLineIndex);
 

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -470,6 +470,27 @@ namespace Test
         }
 
         [SkippableFact]
+        public void ViDeleteToEndOfBuffer()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("\"-\"", Keys(
+                _.DQuote, "-", _.Enter,
+                "one", _.Enter,
+                "two", _.Enter,
+                "three", _.Enter,
+                _.DQuote, _.Escape,
+                "kkkl", // go to the 'ne' portion of "one"
+                // delete to the end of the next line
+                "dG",
+                CheckThat(() => AssertCursorLeftIs(0)),
+                // terminate the buffer
+                _.A, _.DQuote
+                ));
+        }
+
+
+        [SkippableFact]
         public void ViGlobDelete()
         {
             TestSetup(KeyMode.Vi);

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -489,7 +489,6 @@ namespace Test
                 ));
         }
 
-
         [SkippableFact]
         public void ViGlobDelete()
         {


### PR DESCRIPTION
# PR Summary

The [recent](#1658) changes to PSReadLine’s handling of multiline buffer has the `DeleteToEnd` function delete characters to the end of the _logical_ line, instead of the end of the entire buffer as was the case previously.

I introduce a new function `DeleteEndOfBuffer` to delete lines to the end of a multiline buffer.

The new function `DeleteEndOfBuffer` is a new function to the PSReadLine’s API surface.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [x] Doc Issue filed: [PowerShell-Docs#6357](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6357)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1692)