### PR TITLE
[vi-mode] 'dd' now handles single line or multiline buffers consistently

### DIFF
--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -722,36 +722,25 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void DeleteLine(ConsoleKeyInfo? key = null, object arg = null)
         {
-            if (_singleton.LineIsMultiLine())
+            var lineCount = _singleton.GetLogicalLineCount();
+            var lineIndex = _singleton.GetLogicalLineNumber() - 1;
+
+            TryGetArgAsInt(arg, out var requestedLineCount, 1);
+
+            var deletePosition = DeleteLineImpl(lineIndex, requestedLineCount);
+
+            // goto the first character of the first remaining logical line
+            var newCurrent = deletePosition + 1;
+
+            if (lineIndex + requestedLineCount >= lineCount)
             {
-                var lineCount = _singleton.GetLogicalLineCount();
-                var lineIndex = _singleton.GetLogicalLineNumber() - 1;
-
-                TryGetArgAsInt(arg, out var requestedLineCount, 1);
-
-                var deletePosition = DeleteLineImpl(lineIndex, requestedLineCount);
-
-                // goto the first character of the first remaining logical line
-                var newCurrent = deletePosition + 1;
-
-                if (lineIndex + requestedLineCount >= lineCount)
-                {
-                    // if the delete operation has removed all the remaining lines
-                    // goto the first character of the previous logical line 
-                    newCurrent = GetBeginningOfLinePos(deletePosition);
-                }
-
-                _singleton._current = newCurrent;
-                _singleton.Render();
+                // if the delete operation has removed all the remaining lines
+                // goto the first character of the previous logical line 
+                newCurrent = GetBeginningOfLinePos(deletePosition);
             }
-            else
-            {
-                _clipboard.Record(_singleton._buffer);
-                _singleton.SaveEditItem(EditItemDelete.Create(_clipboard, 0));
-                _singleton._current = 0;
-                _singleton._buffer.Remove(0, _singleton._buffer.Length);
-                _singleton.Render();
-            }
+
+            _singleton._current = newCurrent;
+            _singleton.Render();
         }
 
         /// <summary>
@@ -764,20 +753,19 @@ namespace Microsoft.PowerShell
         {
             var range = _singleton._buffer.GetRange(lineIndex, lineCount);
 
+            _clipboard.LinewiseRecord(_singleton._buffer.ToString(range.Offset, range.Count));
+
             var deleteText = _singleton._buffer.ToString(range.Offset, range.Count);
-
-            _clipboard.LinewiseRecord(deleteText);
-
             var deletePosition = range.Offset;
             var anchor = _singleton._current;
 
             _singleton._buffer.Remove(range.Offset, range.Count);
 
-            _singleton.SaveEditItem(
-                EditItemDeleteLines.Create(
-                    deleteText,
-                    deletePosition,
-                    anchor));
+            _singleton.SaveEditItem(EditItemDeleteLines.Create(
+                deleteText,
+                deletePosition,
+                anchor
+            ));
 
             return deletePosition;
         }

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -753,19 +753,20 @@ namespace Microsoft.PowerShell
         {
             var range = _singleton._buffer.GetRange(lineIndex, lineCount);
 
-            _clipboard.LinewiseRecord(_singleton._buffer.ToString(range.Offset, range.Count));
-
             var deleteText = _singleton._buffer.ToString(range.Offset, range.Count);
+
+            _clipboard.LinewiseRecord(deleteText);
+
             var deletePosition = range.Offset;
             var anchor = _singleton._current;
 
             _singleton._buffer.Remove(range.Offset, range.Count);
 
-            _singleton.SaveEditItem(EditItemDeleteLines.Create(
-                deleteText,
-                deletePosition,
-                anchor
-            ));
+            _singleton.SaveEditItem(
+                EditItemDeleteLines.Create(
+                    deleteText,
+                    deletePosition,
+                    anchor));
 
             return deletePosition;
         }

--- a/test/YankPasteTest.VI.cs
+++ b/test/YankPasteTest.VI.cs
@@ -48,11 +48,13 @@ namespace Test
         {
             TestSetup(KeyMode.Vi);
 
+            var continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
+
             Test("abcd", Keys(
                 "abcd", _.Escape,
                 "dd", CheckThat(() => AssertLineIs("")), CheckThat(() => AssertCursorLeftIs(0)),
-                'p', CheckThat(() => AssertLineIs("\nabcd")), CheckThat(() => AssertCursorLeftIs(3)),
-                'P', CheckThat(() => AssertLineIs("\nabcd\nabcd")), CheckThat(() => AssertCursorLeftIs(3)),
+                'p', CheckThat(() => AssertLineIs("\nabcd")), CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0)),
+                'P', CheckThat(() => AssertLineIs("\nabcd\nabcd")), CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0)),
                 "uuu"
                 ));
 

--- a/test/YankPasteTest.VI.cs
+++ b/test/YankPasteTest.VI.cs
@@ -51,8 +51,8 @@ namespace Test
             Test("abcd", Keys(
                 "abcd", _.Escape,
                 "dd", CheckThat(() => AssertLineIs("")), CheckThat(() => AssertCursorLeftIs(0)),
-                'p', CheckThat(() => AssertLineIs("abcd")), CheckThat(() => AssertCursorLeftIs(3)),
-                'P', CheckThat(() => AssertLineIs("abcabcdd")), CheckThat(() => AssertCursorLeftIs(6)),
+                'p', CheckThat(() => AssertLineIs("\nabcd")), CheckThat(() => AssertCursorLeftIs(3)),
+                'P', CheckThat(() => AssertLineIs("\nabcd\nabcd")), CheckThat(() => AssertCursorLeftIs(3)),
                 "uuu"
                 ));
 
@@ -204,12 +204,14 @@ namespace Test
         {
             TestSetup(KeyMode.Vi);
 
+            var continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
+
             Test("abc def", Keys(
                 "abc def", _.Escape,
                 "dd", CheckThat(() => AssertLineIs("")), CheckThat(() => AssertCursorLeftIs(0)),
-                'p', CheckThat(() => AssertLineIs("abc def")), CheckThat(() => AssertCursorLeftIs(6)),
+                'p', CheckThat(() => AssertLineIs("\nabc def")), CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0)),
                 "dd", CheckThat(() => AssertLineIs("")), CheckThat(() => AssertCursorLeftIs(0)),
-                'P', CheckThat(() => AssertLineIs("abc def")), CheckThat(() => AssertCursorLeftIs(6)),
+                'P', CheckThat(() => AssertLineIs("abc def\n")), CheckThat(() => AssertCursorLeftIs(0)),
                 "uuuu"
                 ));
         }


### PR DESCRIPTION
# PR Summary

Fix #1693
The code has been simplified so that the 'dd' command now handles single line or multiline buffers consistently.

I believe the documentation for the `DeleteLine` function to be correct. The concept of _line_ is what has changed with this PR, as well as previous and upcoming work on improving multiline buffer handling in vi-mode.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Not Applicable


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1694)