### PR TITLE
[vi-mode] 'D' and 'd$' delete to the end of the current logical line

### DIFF
--- a/PSReadLine/Position.cs
+++ b/PSReadLine/Position.cs
@@ -94,6 +94,16 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
+        /// Returns the position of the end of the logical line
+        /// for the 0-based specified line number.
+        /// </summary>
+        private static int GetEndOfNthLogicalLinePos(int lineIndex)
+        {
+            return GetEndOfLogicalLinePos(
+                GetBeginningOfNthLinePos(lineIndex));
+        }
+
+        /// <summary>
         /// Returns the position of the first non whitespace character in
         /// the current logical line as specified by the "current" position.
         /// </summary>

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -490,6 +490,26 @@ namespace Test
         }
 
         [SkippableFact]
+        public void ViDeleteToEnd()
+        {
+            TestSetup(KeyMode.Vi);
+
+            int continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
+
+            Test("\"\no\nthree\n\"", Keys(
+                _.DQuote, _.Enter,
+                "one", _.Enter,
+                "two", _.Enter,
+                "three", _.Enter,
+                _.DQuote, _.Escape,
+                "kkkl", // go to the 'ne' portion of "one"
+                // delete to the end of the next line
+                "2d$",
+                CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0))
+                ));
+        }
+
+        [SkippableFact]
         public void ViGlobDelete()
         {
             TestSetup(KeyMode.Vi);


### PR DESCRIPTION
# PR Summary

This PR fixes #1688.

Previously, using <kbd>d</kbd><kbd>$</kbd> deleted the text up to the end of the buffer. This PR now more closely aligns with vim by deleting only up to the end of the current logical line in a multiline buffer.

The previous behaviour will be re-introduced in a further PR.

I believe the documentation for the `DeleteToEnd` function to be correct. The concept of line is what has changed with this PR, as well as previous and upcoming work on improving multiline buffer handling in vi-mode.

## PR Checklist

- [x ] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Not Applicable


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1695)