### PR TITLE
[vi-mode] 'dj' deletes the current and next n logical lines

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -402,6 +402,7 @@ namespace Microsoft.PowerShell
             case nameof(DeleteEndOfWord):
             case nameof(DeleteLine):
             case nameof(DeleteLineToFirstChar):
+            case nameof(DeleteNextLines):
             case nameof(DeleteToEnd):
             case nameof(DeleteWord):
             case nameof(ForwardDeleteLine):

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -229,6 +229,7 @@ namespace Microsoft.PowerShell
                 { Keys.ucG,             MakeKeyHandler( DeleteEndOfBuffer,            "DeleteEndOfBuffer") },
                 { Keys.ucE,             MakeKeyHandler( ViDeleteEndOfGlob,            "ViDeleteEndOfGlob") },
                 { Keys.H,               MakeKeyHandler( BackwardDeleteChar,           "BackwardDeleteChar") },
+                { Keys.J,               MakeKeyHandler( DeleteNextLines,              "DeleteNextLines") },
                 { Keys.L,               MakeKeyHandler( DeleteChar,                   "DeleteChar") },
                 { Keys.Space,           MakeKeyHandler( DeleteChar,                   "DeleteChar") },
                 { Keys._0,              MakeKeyHandler( BackwardDeleteLine,           "BackwardDeleteLine") },

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -805,4 +805,7 @@ Or not saving history with:
   <data name="DeleteEndOfBufferDescription" xml:space="preserve">
     <value>Delete the current logical line and up to the end of the multiline buffer</value>
   </data>
+  <data name="DeleteNextLinesDescription" xml:space="preserve">
+    <value>Deletes the current and next n logical lines in a multiline buffer</value>
+  </data>
 </root>

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -817,6 +817,17 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
+        /// Deletes the current and next n logical lines.
+        /// </summary>
+        private static void DeleteNextLines(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            if (TryGetArgAsInt(arg, out int requestedLineCount, 1))
+            {
+                DeleteLine(key, requestedLineCount + 1);
+            }
+        }
+
+        /// <summary>
         /// Deletes the previous word.
         /// </summary>
         public static void BackwardDeleteWord(ConsoleKeyInfo? key = null, object arg = null)

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -510,6 +510,24 @@ namespace Test
         }
 
         [SkippableFact]
+        public void ViDeleteNextLines()
+        {
+            TestSetup(KeyMode.Vi);
+
+            int continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
+
+            Test("\"\n\"", Keys(
+                 _.DQuote, _.Enter,
+                 "one", _.Enter,
+                 "two", _.Enter,
+                 "three", _.Enter,
+                 _.DQuote, _.Escape,
+                 "kkkl", // go to the 'ne' portion of "one"
+                 "2dj", CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0))
+                ));
+        }
+
+        [SkippableFact]
         public void ViGlobDelete()
         {
             TestSetup(KeyMode.Vi);


### PR DESCRIPTION
# PR Summary

Fix #1690
This PR introduces a new command `DeleteNextLines` to support the VI <kbd>d</kbd><kbd>j</kbd> command that deletes the current logical line and the next _n_ logical lines in a multiline buffer.

**Note** this PR is a **WIP** because, although all the unit tests pass, I stumbled upon a regression in the way the command-line is rendered and I have no idea how to solve it or even where to look. I would like a bit of help on this front. The faulty behaviour is described in [the following issue](https://github.com/PowerShell/PSReadLine/issues/1696).

Onced solve, the function `DeleteNextLines` will be made public and documentation updated at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs).

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: **wip**

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1697)