### PR TITLE
Improve the bug reporting message

### DIFF
--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -830,8 +830,10 @@ namespace Microsoft.PowerShell.PSReadLine {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///Oops, something went wrong.  Please report this bug with the details below.
-        ///Report on GitHub: https://github.com/PowerShell/PSReadLine/issues/new.
+        ///Oops, something went wrong.
+        ///Please report this bug with ALL the details below, including both the 'Environment' and 'Exception' sections.
+        ///Please report on GitHub: https://github.com/PowerShell/PSReadLine/issues/new?template=Bug_Report.md
+        ///Thank you!
         /// </summary>
         internal static string OopsAnErrorMessage1 {
             get {
@@ -840,20 +842,23 @@ namespace Microsoft.PowerShell.PSReadLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ### Environment
+        ///   Looks up a localized string similar to
+        ///### Environment
         ///PSReadLine: {0}
         ///PowerShell: {1}
         ///OS: {2}
-        ///Last {3} Keys
+        ///BufferWidth: {3}
+        ///BufferHeight: {4}
+
+        ///Last {5} Keys
         ///```
-        ///{4}
+        ///{6}
         ///```
-        ///
+
         ///### Exception
         ///```
-        ///{5}
+        ///{7}
         ///```
-        ///.
         /// </summary>
         internal static string OopsAnErrorMessage2 {
             get {

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -389,8 +389,11 @@
   </data>
   <data name="OopsAnErrorMessage1" xml:space="preserve">
     <value>
-Oops, something went wrong.  Please report this bug with the details below.
-Report on GitHub: https://github.com/PowerShell/PSReadLine/issues/new?template=Bug_Report.md</value>
+Oops, something went wrong.
+Please report this bug with ALL the details below, including both the 'Environment' and 'Exception' sections.
+Please report on GitHub: https://github.com/PowerShell/PSReadLine/issues/new?template=Bug_Report.md
+Thank you!
+</value>
   </data>
   <data name="OopsAnErrorMessage2" xml:space="preserve">
     <value>### Environment
@@ -399,6 +402,7 @@ PowerShell: {1}
 OS: {2}
 BufferWidth: {3}
 BufferHeight: {4}
+
 Last {5} Keys
 ```
 {6}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Improve the bug reporting message to explicitly ask the user to include both `Environment` and `Exception` sections when opening the issue. 

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1698)