### PR TITLE
Update build to use .NET 3.1 for compliance

### DIFF
--- a/MockPSConsole/MockPSConsole.csproj
+++ b/MockPSConsole/MockPSConsole.csproj
@@ -4,13 +4,13 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MockPSConsole</RootNamespace>
     <AssemblyName>MockPSConsole</AssemblyName>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <ApplicationManifest>Program.manifest</ApplicationManifest>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <RuntimeFrameworkVersion>2.1.13</RuntimeFrameworkVersion>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <RuntimeFrameworkVersion>3.1.6</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +18,7 @@
     <PackageReference Include="System.Data.DataSetExtensions" version="4.5.0" />
     <PackageReference Include="Microsoft.CSharp" version="4.5.0" />
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0-*" Condition="'$(TargetFramework)' == 'net461'" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" version="6.2.4" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.0.3" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine.build.ps1
+++ b/PSReadLine.build.ps1
@@ -19,7 +19,7 @@ param(
     [ValidateSet("Debug", "Release")]
     [string]$Configuration = (property Configuration Release),
 
-    [ValidateSet("net461", "netcoreapp2.1")]
+    [ValidateSet("net461", "netcoreapp3.1")]
     [string]$Framework,
 
     [switch]$CheckHelpContent
@@ -32,7 +32,7 @@ $targetDir = "bin/$Configuration/PSReadLine"
 
 if (-not $Framework)
 {
-    $Framework = if ($PSVersionTable.PSEdition -eq "Core") { "netcoreapp2.1" } else { "net461" }
+    $Framework = if ($PSVersionTable.PSEdition -eq "Core") { "netcoreapp3.1" } else { "net461" }
 }
 
 Write-Verbose "Building for '$Framework'" -Verbose

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.PowerShell.PSReadLine;
+using AllowNull = System.Management.Automation.AllowNullAttribute;
 
 namespace Microsoft.PowerShell
 {
@@ -577,7 +578,7 @@ namespace Microsoft.PowerShell
         internal SwitchParameter? _historyNoDuplicates;
 
         [Parameter]
-        [AllowNull]
+        [@AllowNull]
         public Func<string, object> AddToHistoryHandler
         {
             get => _addToHistoryHandler;
@@ -591,7 +592,7 @@ namespace Microsoft.PowerShell
         internal bool _addToHistoryHandlerSpecified;
 
         [Parameter]
-        [AllowNull]
+        [@AllowNull]
         public Action<CommandAst> CommandValidationHandler
         {
             get => _commandValidationHandler;

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -8,12 +8,12 @@
     <FileVersion>2.1.0</FileVersion>
     <InformationalVersion>2.1.0-beta2</InformationalVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <RuntimeFrameworkVersion>2.1.13</RuntimeFrameworkVersion>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <RuntimeFrameworkVersion>3.1.6</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build.ps1
+++ b/build.ps1
@@ -26,7 +26,7 @@
 .PARAMETER Framework
     The target framework for the build.
     When not specified, the target framework is determined by the current PowerShell session:
-    - If the current session is PowerShell Core, then use 'netcoreapp2.1' as the default target framework.
+    - If the current session is PowerShell Core, then use 'netcoreapp3.1' as the default target framework.
     - If the current session is Windows PowerShell, then use 'net461' as the default target framework.
 #>
 [CmdletBinding()]
@@ -39,7 +39,7 @@ param(
     [ValidateSet("Debug", "Release")]
     [string] $Configuration = "Debug",
 
-    [ValidateSet("net461", "netcoreapp2.1")]
+    [ValidateSet("net461", "netcoreapp3.1")]
     [string] $Framework
 )
 

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -5,15 +5,15 @@
     <OutputType>library</OutputType>
     <RootNamespace>UnitTestPSReadLine</RootNamespace>
     <AssemblyName>PSReadLine.Tests</AssemblyName>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <RuntimeFrameworkVersion>2.1.13</RuntimeFrameworkVersion>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <RuntimeFrameworkVersion>3.1.6</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.4" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.3" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0-*" Condition="'$(TargetFramework)' == 'net461'" />
   </ItemGroup>
 

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -1,5 +1,5 @@
 
-$MinimalSDKVersion = '2.1.802'
+$MinimalSDKVersion = '3.1.302'
 $IsWindowsEnv = [System.Environment]::OSVersion.Platform -eq "Win32NT"
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $LocalDotnetDirPath = if ($IsWindowsEnv) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }
@@ -39,7 +39,7 @@ function Find-Dotnet
             $env:PATH = $LocalDotnetDirPath + [IO.Path]::PathSeparator + $env:PATH
         }
         else {
-            throw "Cannot find the dotnet SDK for .NET Core 2.1. Please specify '-Bootstrap' to install build dependencies."
+            throw "Cannot find the dotnet SDK for .NET Core 3.1. Please specify '-Bootstrap' to install build dependencies."
         }
     }
 }
@@ -68,7 +68,7 @@ function Install-Dotnet
     [CmdletBinding()]
     param(
         [string]$Channel = 'release',
-        [string]$Version = '2.1.802'
+        [string]$Version = $MinimalSDKVersion
     )
 
     try {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update the build to use .NET 3.1 to resolve a compliance issue in Azure DevOps release build, so that we can renew the code sign authorization.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1702)