### PR TITLE
Limit the folder for APIScan

### DIFF
--- a/.vsts-ci/templates/compliance.yml
+++ b/.vsts-ci/templates/compliance.yml
@@ -40,7 +40,7 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-apiscan.APIScan@2
   displayName: 'Run APIScan'
   inputs:
-    softwareFolder: '$(Build.SourcesDirectory)'
+    softwareFolder: '$(Build.SourcesDirectory)\bin\${{ parameters.configuration }}\PSReadLine'
     softwareName: PSReadLine
     softwareVersionNum: '$(ModuleVersion)'
     isLargeApp: false


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The API Scan step took a very long time, usually nearly 3 hours. It's very easy to get timeout in release build with the current setting. This PR limits the source folder for API Scan to the bin folder that contains the artifacts that are part of the final module, so we can bring the API Scan time down to around 30 minutes.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests **NA**
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1731)