### PR TITLE
[vi-mode] Use 'dk' to delete the previous _n_ requested logical lines and the current logical line in the multiline buffer

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -403,6 +403,7 @@ namespace Microsoft.PowerShell
             case nameof(DeleteLine):
             case nameof(DeleteLineToFirstChar):
             case nameof(DeleteNextLines):
+            case nameof(DeletePreviousLines):
             case nameof(DeleteToEnd):
             case nameof(DeleteWord):
             case nameof(ForwardDeleteLine):

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -230,6 +230,7 @@ namespace Microsoft.PowerShell
                 { Keys.ucE,             MakeKeyHandler( ViDeleteEndOfGlob,            "ViDeleteEndOfGlob") },
                 { Keys.H,               MakeKeyHandler( BackwardDeleteChar,           "BackwardDeleteChar") },
                 { Keys.J,               MakeKeyHandler( DeleteNextLines,              "DeleteNextLines") },
+                { Keys.K,               MakeKeyHandler( DeletePreviousLines,          "DeletePreviousLines") },
                 { Keys.L,               MakeKeyHandler( DeleteChar,                   "DeleteChar") },
                 { Keys.Space,           MakeKeyHandler( DeleteChar,                   "DeleteChar") },
                 { Keys._0,              MakeKeyHandler( BackwardDeleteLine,           "BackwardDeleteLine") },

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -805,6 +805,9 @@ Or not saving history with:
   <data name="DeleteEndOfBufferDescription" xml:space="preserve">
     <value>Delete the current logical line and up to the end of the multiline buffer</value>
   </data>
+  <data name="DeletePreviousLinesDescription" xml:space="preserve">
+    <value>Deletes from the previous n logical lines in a multiline buffer to the current logical line included.</value>
+  </data>
   <data name="DeleteNextLinesDescription" xml:space="preserve">
     <value>Deletes the current and next n logical lines in a multiline buffer</value>
   </data>

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -828,6 +828,28 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
+        /// Deletes from the previous n logical lines to the current logical line included.
+        /// </summary>
+        private static void DeletePreviousLines(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            if (TryGetArgAsInt(arg, out int requestedLineCount, 1))
+            {
+                var currentLineIndex = _singleton.GetLogicalLineNumber() - 1;
+                var startLineIndex = Math.Max(0, currentLineIndex - requestedLineCount);
+
+                DeleteLineImpl(startLineIndex, currentLineIndex - startLineIndex + 1);
+
+                // go the beginning of the line at index 'startLineIndex'
+                // or at the beginning of the last line
+                startLineIndex = Math.Min(startLineIndex, _singleton.GetLogicalLineCount() - 1);
+                var newCurrent = GetBeginningOfNthLinePos(startLineIndex);
+
+                _singleton._current = newCurrent;
+                _singleton.Render();
+            }
+        }
+
+        /// <summary>
         /// Deletes the previous word.
         /// </summary>
         public static void BackwardDeleteWord(ConsoleKeyInfo? key = null, object arg = null)

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -830,7 +830,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Deletes from the previous n logical lines to the current logical line included.
         /// </summary>
-        private static void DeletePreviousLines(ConsoleKeyInfo? key = null, object arg = null)
+        public static void DeletePreviousLines(ConsoleKeyInfo? key = null, object arg = null)
         {
             if (TryGetArgAsInt(arg, out int requestedLineCount, 1))
             {

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -490,6 +490,46 @@ namespace Test
         }
 
         [SkippableFact]
+        public void ViDeletePreviousLines()
+        {
+            TestSetup(KeyMode.Vi);
+
+            int continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
+
+            Test("\"\n\"", Keys(
+                 _.DQuote, _.Enter,
+                 "one", _.Enter,
+                 "two", _.Enter,
+                 "three", _.Enter,
+                 _.DQuote, _.Escape,
+                 "kl", // go to the 'hree' portion of "three"
+                 "2dk", CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0))
+                ));
+        }
+
+        [SkippableFact]
+        public void ViDeletePreviousLines_LastLine()
+        {
+            TestSetup(KeyMode.Vi);
+
+            int continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
+
+            Test("\"\none\ntwo\n\"", Keys(
+                 _.DQuote, _.Enter,
+                 "one", _.Enter,
+                 "two", _.Enter,
+                 "three", _.Enter,
+                 _.DQuote, _.Escape,
+                 "dk",
+                 CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0)),
+                 CheckThat(() => AssertCursorTopIs(2)),
+                 CheckThat(() => AssertLineIs("\"\none\ntwo")),
+                 // finish the buffer to close the multiline string
+                 _.A, _.Enter, _.DQuote, _.Escape
+                ));
+        }
+
+        [SkippableFact]
         public void ViDeleteToEnd()
         {
             TestSetup(KeyMode.Vi);


### PR DESCRIPTION
# PR Summary

Fix #1691
This PR introduces a new command `DeletePreviousLines` to support the VI <kbd>d</kbd><kbd>k</kbd> command that deletes the previous _n_ logical lines and the current logical line a multiline buffer.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [x] Doc Issue filed: [PowerShell-Docs#6451](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6451)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1737)