### PR TITLE
[vi-mode]: Using 'dgg' to delete from the beginning of the buffer to the current logical line

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -400,6 +400,7 @@ namespace Microsoft.PowerShell
             case nameof(DeleteCharOrExit):
             case nameof(DeleteEndOfBuffer):
             case nameof(DeleteEndOfWord):
+            case nameof(DeleteRelativeLines):
             case nameof(DeleteLine):
             case nameof(DeleteLineToFirstChar):
             case nameof(DeleteNextLines):

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerShell
         private static Dictionary<PSKeyInfo, KeyHandler> _viChordGTable;
         private static Dictionary<PSKeyInfo, KeyHandler> _viChordCTable;
         private static Dictionary<PSKeyInfo, KeyHandler> _viChordYTable;
+        private static Dictionary<PSKeyInfo, KeyHandler> _viChordDGTable;
 
         private static Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>> _viCmdChordTable;
         private static Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>> _viInsChordTable;
@@ -226,6 +227,7 @@ namespace Microsoft.PowerShell
                 { Keys.W,               MakeKeyHandler( DeleteWord,                   "DeleteWord") },
                 { Keys.ucW,             MakeKeyHandler( ViDeleteGlob,                 "ViDeleteGlob") },
                 { Keys.E,               MakeKeyHandler( DeleteEndOfWord,              "DeleteEndOfWord") },
+                { Keys.G,               MakeKeyHandler( ViDGChord,                    "ViDGChord") },
                 { Keys.ucG,             MakeKeyHandler( DeleteEndOfBuffer,            "DeleteEndOfBuffer") },
                 { Keys.ucE,             MakeKeyHandler( ViDeleteEndOfGlob,            "ViDeleteEndOfGlob") },
                 { Keys.H,               MakeKeyHandler( BackwardDeleteChar,           "BackwardDeleteChar") },
@@ -285,6 +287,11 @@ namespace Microsoft.PowerShell
                 { Keys._0,              MakeKeyHandler( ViYankBeginningOfLine, "ViYankBeginningOfLine") },
                 { Keys.Uphat,           MakeKeyHandler( ViYankToFirstChar,     "ViYankToFirstChar") },
                 { Keys.Percent,         MakeKeyHandler( ViYankPercent,         "ViYankPercent") },
+            };
+
+            _viChordDGTable = new Dictionary<PSKeyInfo, KeyHandler>
+            {
+                { Keys.G,               MakeKeyHandler( DeleteRelativeLines,   "DeleteRelativeLines") },
             };
 
             _viCmdChordTable = new Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>>();

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -811,4 +811,7 @@ Or not saving history with:
   <data name="DeleteNextLinesDescription" xml:space="preserve">
     <value>Deletes the current and next n logical lines in a multiline buffer</value>
   </data>
+  <data name="DeleteRelativeLinesDescription" xml:space="preserve">
+    <value>Delete from the current logical line to the n-th requested logical line in a multiline buffer</value>
+  </data>
 </root>

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -368,7 +368,7 @@ namespace Microsoft.PowerShell
             _singleton._buffer.Remove(_singleton._current, 1 + endPoint - _singleton._current);
             if (_singleton._current >= _singleton._buffer.Length)
             {
-                _singleton._current = Math.Max(0,_singleton._buffer.Length - 1);
+                _singleton._current = Math.Max(0, _singleton._buffer.Length - 1);
             }
             _singleton.Render();
         }
@@ -522,11 +522,11 @@ namespace Microsoft.PowerShell
             _singleton._dispatchTable = _viCmdKeyMap;
             _singleton._chordDispatchTable = _viCmdChordTable;
 
-            return new Disposable( () =>
-            {
-                _singleton._dispatchTable = oldDispatchTable;
-                _singleton._chordDispatchTable = oldChordDispatchTable;
-            } );
+            return new Disposable(() =>
+           {
+               _singleton._dispatchTable = oldDispatchTable;
+               _singleton._chordDispatchTable = oldChordDispatchTable;
+           });
         }
 
         /// <summary>
@@ -540,11 +540,11 @@ namespace Microsoft.PowerShell
             _singleton._dispatchTable = _viInsKeyMap;
             _singleton._chordDispatchTable = _viInsChordTable;
 
-            return new Disposable( () =>
-            {
-                _singleton._dispatchTable = oldDispatchTable;
-                _singleton._chordDispatchTable = oldChordDispatchTable;
-            } );
+            return new Disposable(() =>
+           {
+               _singleton._dispatchTable = oldDispatchTable;
+               _singleton._chordDispatchTable = oldChordDispatchTable;
+           });
         }
 
         private void ViIndicateCommandMode()
@@ -857,7 +857,15 @@ namespace Microsoft.PowerShell
             if (TryGetArgAsInt(arg, out var requestedLineNumber, 1))
             {
                 var currentLineIndex = _singleton.GetLogicalLineNumber() - 1;
-                var requestedLineIndex = Math.Max(requestedLineNumber, _singleton.GetStatusLineCount()) - 1;
+                var requestedLineIndex = requestedLineNumber - 1;
+                if (requestedLineIndex < 0)
+                {
+                    requestedLineIndex = 0;
+                }
+                if (requestedLineIndex >= _singleton.GetLogicalLineCount())
+                {
+                    requestedLineIndex = _singleton.GetLogicalLineCount() - 1;
+                }
 
                 var requestedLineCount = requestedLineIndex - currentLineIndex;
                 if (requestedLineCount < 0)
@@ -1284,7 +1292,7 @@ namespace Microsoft.PowerShell
             _singleton.MoveToBeginningOfPhrase();
             _singleton._buffer.Insert(_singleton._current, '\n');
             //_singleton._current = Math.Max(0, _singleton._current - 1);
-            _singleton.SaveEditItem(EditItemInsertChar.Create( '\n', _singleton._current));
+            _singleton.SaveEditItem(EditItemInsertChar.Create('\n', _singleton._current));
             _singleton.Render();
             ViInsertMode();
         }

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -862,9 +862,11 @@ namespace Microsoft.PowerShell
                 {
                     requestedLineIndex = 0;
                 }
-                if (requestedLineIndex >= _singleton.GetLogicalLineCount())
+
+                var logicalLineCount = _singleton.GetLogicalLineCount();
+                if (requestedLineIndex >= logicalLineCount)
                 {
-                    requestedLineIndex = _singleton.GetLogicalLineCount() - 1;
+                    requestedLineIndex = logicalLineCount - 1;
                 }
 
                 var requestedLineCount = requestedLineIndex - currentLineIndex;

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -568,6 +568,50 @@ namespace Test
         }
 
         [SkippableFact]
+        public void ViDeleteRelativeLines()
+        {
+            TestSetup(KeyMode.Vi);
+
+            var continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
+
+            Test("\"\nthree\n\"", Keys(
+                _.DQuote, _.Enter,
+                "one", _.Enter,
+                "two", _.Enter,
+                "three", _.Enter,
+                _.DQuote, _.Escape,
+                "kkl", // go to the 'wo' portion of "two"
+                // delete from line 2 to the current line (3)
+                "2dgg",
+                CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0))
+                ));
+
+            Test("\"\none\nthree\n\"", Keys(
+                _.DQuote, _.Enter,
+                "one", _.Enter,
+                "two", _.Enter,
+                "three", _.Enter,
+                _.DQuote, _.Escape,
+                "kkl", // go to the 'wo' portion of "two"
+                // delete the current line (3)
+                "3dgg",
+                CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0))
+                ));
+
+            Test("\"\none\n\"", Keys(
+                _.DQuote, _.Enter,
+                "one", _.Enter,
+                "two", _.Enter,
+                "three", _.Enter,
+                _.DQuote, _.Escape,
+                "kkl", // go to the 'wo' portion of "two"
+                // delete from the current line (3) to line 4
+                "4dgg",
+                CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 0))
+                ));
+        }
+
+        [SkippableFact]
         public void ViGlobDelete()
         {
             TestSetup(KeyMode.Vi);


### PR DESCRIPTION
# PR Summary

Fix #1749. 

This PR introduces a new function `DeleteRelativeLines` which deletes any number of lines before or after the current logical line in a multiline buffer.

It is used to support a new bound command <kbd>d</kbd><kbd>g</kbd><kbd>g</kbd> to delete from the beginning of the multiline buffer up to the current line.

The method is called `DeleteRelativeLines` because a numeric argument can be specified using the <kbd>d</kbd><kbd>g</kbd><kbd>g</kbd> command. This numeric argument specifies an absolute line number which, together with the current line number, make up a range of lines to be deleted. The actual number of lines to be deleted from the current logical line is computed by the difference between those two numbers, which can thus be negative. Hence the *relative* part of the name.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
      - [x] Doc Issue number: [#6497](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6497)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1752)