### PR TITLE
Use const strings for some common ANSI control sequences

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -358,9 +358,9 @@ namespace Microsoft.PowerShell
                 for (int i = 0; i < minLength; i ++)
                 {
                     var text = _promptText[i];
-                    if (text.Contains('\x1b') && !text.EndsWith("\x1b[0m", StringComparison.Ordinal))
+                    if (text.Contains('\x1b') && !text.EndsWith(VTColorUtils.AnsiReset, StringComparison.Ordinal))
                     {
-                        _promptText[i] = string.Concat(text, "\x1b[0m");
+                        _promptText[i] = string.Concat(text, VTColorUtils.AnsiReset);
                     }
                 }
             }
@@ -946,6 +946,11 @@ namespace Microsoft.PowerShell
 
     public static class VTColorUtils
     {
+        internal const string AnsiReset = "\x1b[0m";
+        internal const string DefaultForeground = "\x1b[39m";
+        internal const string DefaultBackground = "\x1b[49m";
+        internal const string DefaultColor = "\x1b[39;49m";
+
         public const ConsoleColor UnknownColor = (ConsoleColor) (-1);
         private static readonly Dictionary<string, ConsoleColor> ConsoleColors =
             new Dictionary<string, ConsoleColor>(StringComparer.OrdinalIgnoreCase)
@@ -1138,7 +1143,7 @@ namespace Microsoft.PowerShell
             var result = seq.ToString();
             if (seq is ConsoleColor) return result;
 
-            result = result + "\"" + FormatEscape(result) + "\"" + "\x1b[0m";
+            result = result + "\"" + FormatEscape(result) + "\"" + AnsiReset;
             return result;
         }
     }

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -603,7 +603,7 @@ namespace Microsoft.PowerShell
 
                 if (select) console.Write(Singleton.Options._selectionColor);
                 console.Write(GetMenuItem(listItem, ColumnWidth));
-                if (select) console.Write("\x1b[0m");
+                if (select) console.Write(VTColorUtils.AnsiReset);
 
                 ToolTipLines = 0;
                 if (showTooltips)
@@ -617,7 +617,7 @@ namespace Microsoft.PowerShell
                     console.Write(toolTip);
                     ToolTipLines = toolTipLines;
 
-                    console.Write("\x1b[0m");
+                    console.Write(VTColorUtils.AnsiReset);
                 }
 
                 RestoreCursor();

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -122,7 +122,7 @@ namespace Microsoft.PowerShell
 
         private void ForceRender()
         {
-            var defaultColor = "\x1b[39;49m";
+            var defaultColor = VTColorUtils.DefaultColor;
 
             // Geneate a sequence of logical lines with escape sequences for coloring.
             int logicalLineCount = GenerateRender(defaultColor);
@@ -179,7 +179,7 @@ namespace Microsoft.PowerShell
                     if (inSelectedRegion)
                     {
                         // Turn off inverse before end of line, turn on after continuation prompt
-                        _consoleBufferLines[currentLogicalLine].Append("\x1b[0m");
+                        _consoleBufferLines[currentLogicalLine].Append(VTColorUtils.AnsiReset);
                     }
 
                     currentLogicalLine += 1;
@@ -254,7 +254,7 @@ namespace Microsoft.PowerShell
                 }
                 else if (i == selectionEnd)
                 {
-                    _consoleBufferLines[currentLogicalLine].Append("\x1b[0m");
+                    _consoleBufferLines[currentLogicalLine].Append(VTColorUtils.AnsiReset);
                     _consoleBufferLines[currentLogicalLine].Append(activeColor);
                     inSelectedRegion = false;
                 }
@@ -334,7 +334,7 @@ namespace Microsoft.PowerShell
 
             if (inSelectedRegion)
             {
-                _consoleBufferLines[currentLogicalLine].Append("\x1b[0m");
+                _consoleBufferLines[currentLogicalLine].Append(VTColorUtils.AnsiReset);
                 inSelectedRegion = false;
             }
 
@@ -444,7 +444,7 @@ namespace Microsoft.PowerShell
                     string color = renderData.errorPrompt ? _options._errorColor : defaultColor;
                     _console.Write(color);
                     _console.Write(promptText);
-                    _console.Write("\x1b[0m");
+                    _console.Write(VTColorUtils.AnsiReset);
                 }
                 else
                 {
@@ -772,7 +772,7 @@ namespace Microsoft.PowerShell
             physicalLine -= pseudoPhysicalLineOffset;
 
             // Reset the colors after we've finished all our rendering.
-            _console.Write("\x1b[0m");
+            _console.Write(VTColorUtils.AnsiReset);
 
             if (_initialY + physicalLine > bufferHeight)
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use const strings for the following often used ANSI control sequences:
- Reset sequence: `"\x1b[0m"`
- Default foreground: `"\x1b[39m"`
- Default background: `"\x1b[49m"`
- Default color: `"\x1b[39;49m"`

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests - Not Applicable
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1809)