### PR TITLE
Correct the descriptions of 'SelectBackwardsLine' and 'SelectLine'

### DIFF
--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -373,10 +373,10 @@
     <value>Move the cursor to the end of the current token</value>
   </data>
   <data name="SelectBackwardsLineDescription" xml:space="preserve">
-    <value>Adjust the current selection to include from the cursor to the end of the line</value>
+    <value>Adjust the current selection to include from the cursor to the start of the line</value>
   </data>
   <data name="SelectLineDescription" xml:space="preserve">
-    <value>Adjust the current selection to include from the cursor to the start of the line</value>
+    <value>Adjust the current selection to include from the cursor to the end of the line</value>
   </data>
   <data name="SelectAllDescription" xml:space="preserve">
     <value>Select the entire line. Moves the cursor to the end of the line</value>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #1855
The descriptions for `SelectBackwardsLine` and `SelectLine` were reversed. They are corrected by this PR.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests [**Not Applicable**]
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1857)