### PR TITLE
Rename `PredictionColor` to `InlinePredictionColor`

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PowerShell
 
         // Use dark black by default for the suggestion text.
         // Find the most suitable color using https://stackoverflow.com/a/33206814
-        public const string DefaultPredictionColor = "\x1b[38;5;238m";
+        public const string DefaultInlinePredictionColor = "\x1b[38;5;238m";
 
         public static EditMode DefaultEditMode = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? EditMode.Windows
@@ -451,10 +451,10 @@ namespace Microsoft.PowerShell
             set => _selectionColor = VTColorUtils.AsEscapeSequence(value);
         }
 
-        public object PredictionColor
+        public object InlinePredictionColor
         {
-            get => _predictionColor;
-            set => _predictionColor = VTColorUtils.AsEscapeSequence(value);
+            get => _inlinePredictionColor;
+            set => _inlinePredictionColor = VTColorUtils.AsEscapeSequence(value);
         }
 
         internal string _defaultTokenColor;
@@ -471,7 +471,7 @@ namespace Microsoft.PowerShell
         internal string _emphasisColor;
         internal string _errorColor;
         internal string _selectionColor;
-        internal string _predictionColor;
+        internal string _inlinePredictionColor;
 
         internal void ResetColors()
         {
@@ -489,7 +489,7 @@ namespace Microsoft.PowerShell
             MemberColor       = DefaultNumberColor;
             EmphasisColor     = DefaultEmphasisColor;
             ErrorColor        = DefaultErrorColor;
-            PredictionColor   = DefaultPredictionColor;
+            InlinePredictionColor = DefaultInlinePredictionColor;
 
             var bg = Console.BackgroundColor;
             if (fg == VTColorUtils.UnknownColor || bg == VTColorUtils.UnknownColor)
@@ -526,7 +526,7 @@ namespace Microsoft.PowerShell
                         {"Number", (o, v) => o.NumberColor = v},
                         {"Member", (o, v) => o.MemberColor = v},
                         {"Selection", (o, v) => o.SelectionColor = v},
-                        {"Prediction", (o, v) => o.PredictionColor = v},
+                        {"InlinePrediction", (o, v) => o.InlinePredictionColor = v},
                     };
 
                 Interlocked.CompareExchange(ref ColorSetters, setters, null);

--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -206,8 +206,8 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                 <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.ParameterColor)</ScriptBlock>
               </ListItem>
               <ListItem>
-                <Label>PredictionColor</Label>
-                <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.PredictionColor)</ScriptBlock>
+                <Label>InlinePredictionColor</Label>
+                <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.InlinePredictionColor)</ScriptBlock>
               </ListItem>
               <ListItem>
                 <Label>SelectionColor</Label>

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -340,7 +340,7 @@ namespace Microsoft.PowerShell
 
             if (suggestion != null)
             {
-                color = _options._predictionColor;
+                color = _options._inlinePredictionColor;
                 foreach (char charToRender in suggestion)
                 {
                     RenderOneChar(charToRender, toEmphasize: false);

--- a/test/SuggestionTest.cs
+++ b/test/SuggestionTest.cs
@@ -240,7 +240,7 @@ namespace Test
             TestSetup(KeyMode.Cmd);
             var predictionColor = MakeCombinedColor(ConsoleColor.DarkYellow, ConsoleColor.Yellow);
             var predictionColorToCheck = Tuple.Create(ConsoleColor.DarkYellow, ConsoleColor.Yellow);
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {Colors = new Hashtable(){{"Prediction", predictionColor}}});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {Colors = new Hashtable(){{"InlinePrediction", predictionColor}}});
 
             SetHistory("echo -bar", "eca -zoo");
             Test("ech", Keys(

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -509,7 +509,7 @@ namespace Test
             var tokenTypes = new[]
             {
                 "Default", "Comment", "Keyword", "String", "Operator", "Variable",
-                "Command", "Parameter", "Type", "Number", "Member", "Selection", "Prediction"
+                "Command", "Parameter", "Type", "Number", "Member", "Selection", "InlinePrediction"
             };
             var colors = new Hashtable();
             for (var i = 0; i < tokenTypes.Length; i++)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Rename `PredictionColor` to `InlinePredictionColor` to make the color setting unambiguous.
We will have a couple more color settings for the list view, so rename `PredictionColor` to make it more specific.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [x] Doc Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/pull/6722


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1860)