### PR TITLE
Fix the inline prediction to not leak color beyond the suggestion text

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -345,6 +345,9 @@ namespace Microsoft.PowerShell
                 {
                     RenderOneChar(charToRender, toEmphasize: false);
                 }
+
+                // Reset the inline prediction color, so that the color setting doesn't leak.
+                UpdateColorsIfNecessary(VTColorUtils.AnsiReset);
             }
 
             if (_statusLinePrompt != null)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix the inline prediction to not leak color beyond the suggestion text.

When setting the prediction color to be 'foreground/background inverted', you will see the color setting gets leaked:

![image](https://user-images.githubusercontent.com/127450/95399185-78e3c900-08bc-11eb-892d-cfa912805c99.png)



## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1861)