### PR TITLE
Fix a rendering issue regarding cleanup of previous logical lines

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -757,11 +757,19 @@ namespace Microsoft.PowerShell
             }
 
             // Fewer logical lines than our previous render? Clear them.
-            for (; previousLogicalLine < previousRenderLines.Length; previousLogicalLine++)
+            for (int line = previousLogicalLine; line < previousRenderLines.Length; line++)
             {
+                if (line > previousLogicalLine || logicalLineStartIndex < renderLines.Length)
+                {
+                    // For the first of the remaining previous logical lines, if we didn't actually
+                    // render anything for the current logical lines, then the cursor is already at
+                    // the beginning of the right physical line that should be cleared, and thus no
+                    // need to write a new line in such case.
+                    _console.Write("\n");
+                }
+
                 // No need to write new line if all we need is to clear the extra previous render.
-                if (logicalLineStartIndex < renderLines.Length) { _console.Write("\n"); }
-                _console.Write(Spaces(previousRenderLines[previousLogicalLine].columns));
+                _console.Write(Spaces(previousRenderLines[line].columns));
             }
 
             // Preserve the current render data.

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -765,6 +765,9 @@ namespace Microsoft.PowerShell
                     // render anything for the current logical lines, then the cursor is already at
                     // the beginning of the right physical line that should be cleared, and thus no
                     // need to write a new line in such case.
+                    // In other cases, we need to write a new line to get the cursor to the correct
+                    // physical line.
+
                     _console.Write("\n");
                 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #1696  /cc @springcomp 

Fix a rendering issue regarding cleanup of previous logical lines.
Before the fix, when there are more than 1 previous logical lines needed to be cleared, we didn't write out new line to get to the correct physical line when we didn't actually render anything for the current logical lines.

After the fix, the <kbd>dj</kbd> is rendered correctly:

![tabcom2](https://user-images.githubusercontent.com/127450/95517586-2535b600-0976-11eb-87df-543014e3b014.gif)

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests **Not Applicable**
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1865)