### PR TITLE
Allow 'MaximumHistoryCount' to be set from user's profile

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -159,7 +159,6 @@ namespace Microsoft.PowerShell
             ExtraPromptLineCount = DefaultExtraPromptLineCount;
             AddToHistoryHandler = DefaultAddToHistoryHandler;
             HistoryNoDuplicates = DefaultHistoryNoDuplicates;
-            MaximumHistoryCount = DefaultMaximumHistoryCount;
             MaximumKillRingCount = DefaultMaximumKillRingCount;
             HistorySearchCursorMovesToEnd = DefaultHistorySearchCursorMovesToEnd;
             ShowToolTips = DefaultShowToolTips;
@@ -172,6 +171,7 @@ namespace Microsoft.PowerShell
             HistorySaveStyle = DefaultHistorySaveStyle;
             AnsiEscapeTimeout = DefaultAnsiEscapeTimeout;
             PredictionSource = DefaultPredictionSource;
+            MaximumHistoryCount = 0;
 
             var historyFileName = hostName + "_history.txt";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -757,10 +757,13 @@ namespace Microsoft.PowerShell
             // specifies a custom history save file, we don't want to try reading
             // from the default one.
 
-            var historyCountVar = _engineIntrinsics?.SessionState.PSVariable.Get("MaximumHistoryCount");
-            if (historyCountVar?.Value is int historyCountValue)
+            if (_options.MaximumHistoryCount == 0)
             {
-                _options.MaximumHistoryCount = historyCountValue;
+                // Initialize 'MaximumHistoryCount' if it's not defined in user's profile.
+                var historyCountVar = _engineIntrinsics?.SessionState.PSVariable.Get("MaximumHistoryCount");
+                _options.MaximumHistoryCount = (historyCountVar?.Value is int historyCountValue)
+                    ? historyCountValue
+                    : PSConsoleReadLineOptions.DefaultMaximumHistoryCount;
             }
 
             if (_options.PromptText == null &&


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #1781

Allow 'MaximumHistoryCount' to be set from user's profile.
Fix `DelayedOneTimeInitialize()` to initialize the `MaximumHistoryCount` only if it's not already defined (by user's profile, before `ReadLine` is called).

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests **Not Applicable**
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1869)