### PR TITLE
Update the release build

### DIFF
--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -17,7 +17,7 @@ resources:
 
 jobs:
 - job: build_windows
-  pool: Package ES Standard Build
+  pool: Package ES CodeHub Lab E
 
   # APIScan can take a long time
   timeoutInMinutes: 240

--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -17,7 +17,7 @@ resources:
 
 jobs:
 - job: build_windows
-  pool: Package ES Lab A
+  pool: Package ES Standard Build
 
   # APIScan can take a long time
   timeoutInMinutes: 240

--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -86,39 +86,14 @@ jobs:
   - pwsh: |
       # Show the signed files
       Get-ChildItem -Path $(Signed)
-      Copy-Item -Path $(Signed)\* -Destination $(PSReadLine) -Force
+      Copy-Item -Path $(Signed)\* -Destination $(PSReadLine) -Recurse -Force
     displayName: 'Replace unsigned files with signed ones'
-
-  # Create catalog file from the signed modules files
-  - pwsh: |
-      New-FileCatalog -CatalogFilePath $(PSReadLine)\PSReadLine.cat -Path $(PSReadLine) -CatalogVersion 2.0 | `
-          ForEach-Object -MemberName FullName
-    displayName: 'Create catalog file'
-
-  # Sign the catalog file
-  - task: PkgESCodeSign@10
-    displayName: 'CodeSign - catalog file'
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    inputs:
-      signConfigXml: '$(Build.SourcesDirectory)\.vsts-ci\sign-catalog.xml'
-      inPathRoot: '$(PSReadLine)'
-      outPathRoot: '$(Signed)'
-      binVersion: Production
-      binVersionOverride: ''
-
-  # Copy the signed catalog file over
-  - pwsh: |
-      # Show the signed files
-      Get-ChildItem -Path $(Signed)
-      Copy-Item -Path $(Signed)\PSReadLine.cat -Destination $(PSReadLine) -Force
-    displayName: 'Replace catalog file with the signed one'
 
   # Verify the signatures
   - pwsh: |
       $HasInvalidFiles = $false
       $WrongCert = @{}
-      Get-ChildItem -Path $(PSReadLine) -Recurse -Include "*.dll","*.ps*1*","*.cat" | `
+      Get-ChildItem -Path $(PSReadLine) -Recurse -Include "*.dll","*.ps*1*" | `
           Get-AuthenticodeSignature | ForEach-Object {
               $_ | Select-Object Path, Status
               if ($_.Status -ne 'Valid') { $HasInvalidFiles = $true }
@@ -133,12 +108,6 @@ jobs:
           throw "Certificate should have the subject starts with 'Microsoft Corporation'"
       }
     displayName: 'Verify the signed files'
-
-  - pwsh: |
-      $CatInfo = Test-FileCatalog -Path $(PSReadLine) -CatalogFilePath $(PSReadLine)\PSReadLine.cat -Detailed
-      $CatInfo | Format-List
-      if ($CatInfo.Status -ne "Valid") { throw "Catalog file is invalid." }
-    displayName: 'Verify the catalog file'
 
   - pwsh: |
       try {

--- a/.vsts-ci/sign-catalog.xml
+++ b/.vsts-ci/sign-catalog.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-
-<!-- Config files for Azure DevOps code-signing pipeline. -->
-<SignConfigXML>
-  <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PSReadLine" approvers="dongbow;slee">
-    <file src="__INPATHROOT__\PSReadLine.cat" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\PSReadLine.cat" />
-  </job>
-</SignConfigXML>

--- a/.vsts-ci/sign-module-files.xml
+++ b/.vsts-ci/sign-module-files.xml
@@ -9,7 +9,6 @@
     <file src="__INPATHROOT__\PSReadLine.format.ps1xml" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\PSReadLine.format.ps1xml" />
 
     <file src="__INPATHROOT__\Microsoft.PowerShell.PSReadLine2.dll" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\Microsoft.PowerShell.PSReadLine2.dll" />
-    <file src="__INPATHROOT__\System.Runtime.InteropServices.RuntimeInformation.dll" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\System.Runtime.InteropServices.RuntimeInformation.dll" />
     <file src="__INPATHROOT__\net461\Microsoft.PowerShell.PSReadLine.Polyfiller.dll" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\net461\Microsoft.PowerShell.PSReadLine.Polyfiller.dll" />
     <file src="__INPATHROOT__\net5.0\Microsoft.PowerShell.PSReadLine.Polyfiller.dll" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\net5.0\Microsoft.PowerShell.PSReadLine.Polyfiller.dll" />
   </job>

--- a/.vsts-ci/sign-module-files.xml
+++ b/.vsts-ci/sign-module-files.xml
@@ -10,5 +10,7 @@
 
     <file src="__INPATHROOT__\Microsoft.PowerShell.PSReadLine2.dll" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\Microsoft.PowerShell.PSReadLine2.dll" />
     <file src="__INPATHROOT__\System.Runtime.InteropServices.RuntimeInformation.dll" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\System.Runtime.InteropServices.RuntimeInformation.dll" />
+    <file src="__INPATHROOT__\net461\Microsoft.PowerShell.PSReadLine.Polyfiller.dll" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\net461\Microsoft.PowerShell.PSReadLine.Polyfiller.dll" />
+    <file src="__INPATHROOT__\net5.0\Microsoft.PowerShell.PSReadLine.Polyfiller.dll" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\net5.0\Microsoft.PowerShell.PSReadLine.Polyfiller.dll" />
   </job>
 </SignConfigXML>

--- a/PSReadLine.build.ps1
+++ b/PSReadLine.build.ps1
@@ -92,18 +92,6 @@ task BuildMockPSConsole @mockPSConsoleParams {
 }
 
 <#
-Synopsis: Generate the file catalog
-#>
-task GenerateCatalog {
-    exec {
-        Remove-Item -ea Ignore $PSScriptRoot/bin/$Configuration/PSReadLine/PSReadLine.cat
-        $null = New-FileCatalog -CatalogFilePath $PSScriptRoot/bin/$Configuration/PSReadLine/PSReadLine.cat `
-                                -Path $PSScriptRoot/bin/$Configuration/PSReadLine `
-                                -CatalogVersion 2.0
-    }
-}
-
-<#
 Synopsis: Run the unit tests
 #>
 task RunTests BuildMainModule, BuildXUnitTests, { Start-TestRun -Configuration $Configuration -Framework $Framework }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update the release build:

- Use a new builder pool, which has the latest PowerShell 7.0.3 available.
- Remove catalog related steps, as the catalog file is unnecessary to PowerShell Gallery now.
- Update the signing xml file to sign the new "Polyfiller" assemblies.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1930)