### PR TITLE
Add argument selection handler to sample profile

### DIFF
--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -606,7 +606,7 @@ Set-PSReadLineKeyHandler -Key RightArrow `
 # on the command line. 
 Set-PSReadLineKeyHandler -Key Alt+a `
                          -BriefDescription SelectCommandArguments `
-                         -LongDescription "Set current selection to next command argument in the command line. Use of digit argument selects argument by position"                        
+                         -LongDescription "Set current selection to next command argument in the command line. Use of digit argument selects argument by position" `
                          -ScriptBlock {
     param($key, $arg)
   

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -617,7 +617,7 @@ Set-PSReadLineKeyHandler -Key Alt+a `
     [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$ast, [ref]$tokens, [ref]$parseErrors, [ref]$cursor)
   
     $asts = $ast.FindAll( {
-        $args[0] -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+        $args[0] -is [System.Management.Automation.Language.ExpressionAst] -and
         $args[0].Parent -is [System.Management.Automation.Language.CommandAst] -and
         $args[0].Extent.StartOffset -ne $args[0].Parent.Extent.StartOffset
       }, $true)
@@ -639,14 +639,14 @@ Set-PSReadLineKeyHandler -Key Alt+a `
             $nextAst = $asts[0]
         }
     }
-    
-    if ($nextAst.StringConstantType -ne [System.Management.Automation.Language.StringConstantType]::BareWord) {
-        $startOffsetAdjustment = 1
-        $endOffsetAdjustment = 2
-    }
-    else {
-        $startOffsetAdjustment = 0
-        $endOffsetAdjustment = 0
+
+    $startOffsetAdjustment = 0
+    $endOffsetAdjustment = 0
+
+    if ($nextAst -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+        $nextAst.StringConstantType -ne [System.Management.Automation.Language.StringConstantType]::BareWord) {
+            $startOffsetAdjustment = 1
+            $endOffsetAdjustment = 2
     }
   
     [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($nextAst.Extent.StartOffset + $startOffsetAdjustment)

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -610,14 +610,11 @@ Set-PSReadLineKeyHandler -Key Alt+a `
                          -ScriptBlock {
     param($key, $arg)
   
-    $line = $null
-    $cursor = $null
-    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
-  
     $tokens = $null
     $ast = $null
     $parseErrors = $null
-    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$ast, [ref]$tokens, [ref]$parseErrors, [ref]$null)
+    $cursor = $null
+    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$ast, [ref]$tokens, [ref]$parseErrors, [ref]$cursor)
   
     $asts = $ast.FindAll( {
         $args[0] -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
@@ -625,6 +622,8 @@ Set-PSReadLineKeyHandler -Key Alt+a `
         $args[0].Extent.StartOffset -ne $args[0].Parent.Extent.StartOffset
       }, $true)
   
+    $nextAst = $null
+
     if ($null -ne $arg) {
       $nextAst = $asts[$arg - 1]
     }

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -601,6 +601,9 @@ Set-PSReadLineKeyHandler -Key RightArrow `
     }
 }
 
+# Cycle through arguments on current line and select the text. This makes it easier to quickly change the argument if re-running a previously run command from the history
+# or if using a psreadline predictor. You can also use a digit argument to specify which argument you want to select, i.e. Alt+1, Alt+a selects the first argument
+# on the command line. 
 Set-PSReadLineKeyHandler -Key Alt+a `
                          -BriefDescription SelectCommandArguments `
                          -LongDescription "Set current selection to next command argument in the command line. Use of digit argument selects argument by position"                        

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -625,28 +625,28 @@ Set-PSReadLineKeyHandler -Key Alt+a `
     $nextAst = $null
 
     if ($null -ne $arg) {
-      $nextAst = $asts[$arg - 1]
+        $nextAst = $asts[$arg - 1]
     }
     else {
-      foreach ($ast in $asts) {
-        if ($ast.Extent.StartOffset -ge $cursor) {
-          $nextAst = $ast
-          break
+        foreach ($ast in $asts) {
+            if ($ast.Extent.StartOffset -ge $cursor) {
+                $nextAst = $ast
+                break
+            }
+        } 
+        
+        if ($null -eq $nextAst) {
+            $nextAst = $asts[0]
         }
-      } 
-    
-      if ($null -eq $nextAst) {
-        $nextAst = $asts[0]
-      }
     }
     
     if ($nextAst.StringConstantType -ne [System.Management.Automation.Language.StringConstantType]::BareWord) {
-      $startOffsetAdjustment = 1
-      $endOffsetAdjustment = 2
+        $startOffsetAdjustment = 1
+        $endOffsetAdjustment = 2
     }
     else {
-      $startOffsetAdjustment = 0
-      $endOffsetAdjustment = 0
+        $startOffsetAdjustment = 0
+        $endOffsetAdjustment = 0
     }
   
     [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($nextAst.Extent.StartOffset + $startOffsetAdjustment)

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -610,11 +610,9 @@ Set-PSReadLineKeyHandler -Key Alt+a `
                          -ScriptBlock {
     param($key, $arg)
   
-    $tokens = $null
     $ast = $null
-    $parseErrors = $null
     $cursor = $null
-    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$ast, [ref]$tokens, [ref]$parseErrors, [ref]$cursor)
+    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$ast, [ref]$null, [ref]$null, [ref]$cursor)
   
     $asts = $ast.FindAll( {
         $args[0] -is [System.Management.Automation.Language.ExpressionAst] -and

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -620,6 +620,11 @@ Set-PSReadLineKeyHandler -Key Alt+a `
         $args[0].Extent.StartOffset -ne $args[0].Parent.Extent.StartOffset
       }, $true)
   
+    if ($asts.Count -eq 0) {
+        [Microsoft.PowerShell.PSConsoleReadLine]::Ding()
+        return
+    }
+    
     $nextAst = $null
 
     if ($null -ne $arg) {

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -652,4 +652,4 @@ Set-PSReadLineKeyHandler -Key Alt+a `
     [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($nextAst.Extent.StartOffset + $startOffsetAdjustment)
     [Microsoft.PowerShell.PSConsoleReadLine]::SetMark($null, $null)
     [Microsoft.PowerShell.PSConsoleReadLine]::SelectForwardChar($null, ($nextAst.Extent.EndOffset - $nextAst.Extent.StartOffset) - $endOffsetAdjustment)
-  }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This adds a handler to the sample PSReadLine profile which cycles through the arguments on the current command line, and selects the entire argument. This makes it simpler to quickly change an argument when recalling a command from the history, or changing the values of an argument when using a suggested command from a PSReadLine predictor plugin. 
<!-- Summarize your PR between here and the checklist. -->

## PR Checklist

- [X] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [X] Summarized changes
- [ ] Make sure you've added one or more new tests
- [X] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1947)