### PR TITLE
Add readonly modifier to some private fields

### DIFF
--- a/PSReadLine/CharMap.cs
+++ b/PSReadLine/CharMap.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell
     // Hard-coded translator for the only VT mode Windows supports.
     internal class WindowsAnsiCharMap : ICharMap
     {
-        private List<ConsoleKeyInfo> _pendingKeys;
+        private readonly List<ConsoleKeyInfo> _pendingKeys;
         // The next index in `_pendingKeys` to write to.
         private int _addKeyIndex;
         // The next index in `_pendingKeys` to read from. This index becomes
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell
         // The upper bound of `_pendingKeys` to read from, exclusive.
         private int _readKeyIndexTo;
 
-        private Stopwatch _escTimeoutStopwatch = new Stopwatch();
+        private readonly Stopwatch _escTimeoutStopwatch = new Stopwatch();
 
         public WindowsAnsiCharMap(long escapeTimeout = 50)
         {

--- a/PSReadLine/CharMap.cs
+++ b/PSReadLine/CharMap.cs
@@ -64,6 +64,8 @@ namespace Microsoft.PowerShell
     internal class WindowsAnsiCharMap : ICharMap
     {
         private readonly List<ConsoleKeyInfo> _pendingKeys;
+        private readonly Stopwatch _escTimeoutStopwatch = new Stopwatch();
+
         // The next index in `_pendingKeys` to write to.
         private int _addKeyIndex;
         // The next index in `_pendingKeys` to read from. This index becomes
@@ -74,8 +76,6 @@ namespace Microsoft.PowerShell
         private int _readKeyIndexFrom;
         // The upper bound of `_pendingKeys` to read from, exclusive.
         private int _readKeyIndexTo;
-
-        private readonly Stopwatch _escTimeoutStopwatch = new Stopwatch();
 
         public WindowsAnsiCharMap(long escapeTimeout = 50)
         {

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell
         private static readonly char[] EolChars = {'\r', '\n'};
 
         // String helper for directory paths
-        private static string DirectorySeparatorString = System.IO.Path.DirectorySeparatorChar.ToString();
+        private static readonly string DirectorySeparatorString = System.IO.Path.DirectorySeparatorChar.ToString();
 
         // Stub helper method so completion can be mocked
         [ExcludeFromCodeCoverage]

--- a/PSReadLine/PlatformWindows.cs
+++ b/PSReadLine/PlatformWindows.cs
@@ -403,8 +403,8 @@ static class PlatformWindows
 
     internal class LegacyWin32Console : VirtualTerminal
     {
-        private static ConsoleColor InitialFG = Console.ForegroundColor;
-        private static ConsoleColor InitialBG = Console.BackgroundColor;
+        private static readonly ConsoleColor InitialFG = Console.ForegroundColor;
+        private static readonly ConsoleColor InitialBG = Console.BackgroundColor;
         private static int maxTop = 0;
 
         private static readonly Dictionary<int, Action> VTColorAction = new Dictionary<int, Action> {

--- a/test/MockConsole.cs
+++ b/test/MockConsole.cs
@@ -68,8 +68,8 @@ namespace Test
         private readonly int _bufferHeight;
         private readonly int _windowWidth;
         private readonly int _windowHeight;
+        private readonly dynamic _keyboardLayout;
         private bool _ignoreNextNewline;
-        private dynamic _keyboardLayout;
 
         internal TestConsole(dynamic keyboardLayout)
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add readonly modifier to some private fields.
The included changes are based on @xtqqczze's PR #1923 (thanks @xtqqczze!). Some private fields changed in #1923 need to be reverted because they are set via reflection either by PSReadLine xUnit tests or PowerShellEditorService (PSES).

Set readonly field via reflection doesn't work in .NET Core 3.0 and later versions, see https://stackoverflow.com/a/934942:
> In dotnet core 3.0 this is no longer possible. A System.FieldAccessException is thrown saying: "Cannot set initonly static field 'bar' after type 'Foo' is initialized."

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1984)