### PR TITLE
#1751 - Using 'd^' to delete to first non blank character of line

### DIFF
--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -476,7 +476,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Switches to insert mode after positioning the cursor past the end of the line.</value>
   </data>
   <data name="DeleteLineToFirstCharDescription" xml:space="preserve">
-    <value>Deletes all of the line except for leading whitespace.</value>
+    <value>Deletes from the first non blank character of the current logical line in a multiline buffer.</value>
   </data>
   <data name="BackwardReplaceCharDescription" xml:space="preserve">
     <value>Replaces the character in front of the cursor.</value>

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -722,14 +722,7 @@ namespace Microsoft.PowerShell
         {
             if (_singleton._current > 0)
             {
-                int i = 0;
-                for (; i < _singleton._current; i++)
-                {
-                    if (!Char.IsWhiteSpace(_singleton._buffer[i]))
-                    {
-                        break;
-                    }
-                }
+                var i = GetFirstNonBlankOfLogicalLinePos(_singleton._current);
 
                 _singleton.SaveToClipboard(i, _singleton._current - i);
                 _singleton.SaveEditItem(EditItemDelete.Create(_clipboard, i, DeleteLineToFirstChar));

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -550,6 +550,25 @@ namespace Test
         }
 
         [SkippableFact]
+        public void ViDeleteLineToFirstChar()
+        {
+            TestSetup(KeyMode.Vi);
+
+            int continuationPrefixLength = PSConsoleReadLineOptions.DefaultContinuationPrompt.Length;
+
+            Test("\"\n   some spaces\n\"", Keys(
+                _.DQuote, _.Enter,
+                "   this is a line with some spaces", _.Enter,
+                _.DQuote, _.Escape,
+                "k6W",
+                CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 23)),
+                // delete from first non blank of line
+                "d^",
+                CheckThat(() => AssertCursorLeftIs(continuationPrefixLength + 3))
+            ));
+        }
+
+        [SkippableFact]
         public void ViDeleteNextLines()
         {
             TestSetup(KeyMode.Vi);


### PR DESCRIPTION
# PR Summary

This pull requests fixes #1751.

It replaces the implementation for the `DeleteLineToFirstChar` to delete characters from the first non blank character of the logical line in a multiline buffer. It behaves like the original implementation for a single line buffer.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [x] Doc Issue filed: [PowerShell-Docs#6958](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/6958)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2001)