### PR TITLE
[vi-mode] Deleting backward to|until a character preserves the character under the cursor

### DIFF
--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -299,7 +299,7 @@ namespace Microsoft.PowerShell
 
         private static void DeleteBackwardToEndPoint(object arg, int endPoint, Action<ConsoleKeyInfo?, object> instigator)
         {
-            int deleteLength = _singleton._current - endPoint + 1;
+            int deleteLength = _singleton._current - endPoint;
 
             _singleton.SaveToClipboard(endPoint, deleteLength);
             _singleton.SaveEditItem(EditItemDelete.Create(

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -988,14 +988,14 @@ namespace Test
 
             Test("0123456", Keys(
                 "0123456", _.Escape, CheckThat(() => AssertLineIs("0123456")),
-                "cF0abc", _.Escape, CheckThat(() => AssertLineIs("abc")),
+                "cF0abc", _.Escape, CheckThat(() => AssertLineIs("abc6")),
                 'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "cF1abc", _.Escape, CheckThat(() => AssertLineIs("0abc")),
+                "cF1abc", _.Escape, CheckThat(() => AssertLineIs("0abc6")),
                 'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "hcF0abc", _.Escape, CheckThat(() => AssertLineIs("abc6")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "hcF1abc", _.Escape, CheckThat(() => AssertLineIs("0abc6")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
+                "hcF0abc", _.Escape, CheckThat(() => AssertLineIs("abc56")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(5)),
+                "hcF1abc", _.Escape, CheckThat(() => AssertLineIs("0abc456")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(4)),
                 "0cF0abc", _.Escape, CheckThat(() => AssertLineIs("0bc123456")),
                 'u'
                 ));
@@ -1012,10 +1012,10 @@ namespace Test
 
             Test("0123456", Keys(
                 "0123456", _.Escape, CheckThat(() => AssertLineIs("0123456")),
-                "cT1abc", _.Escape, CheckThat(() => AssertLineIs("01abc")),
+                "cT1abc", _.Escape, CheckThat(() => AssertLineIs("01abc6")),
                 'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "hcT1abc", _.Escape, CheckThat(() => AssertLineIs("01abc6")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
+                "hcT1abc", _.Escape, CheckThat(() => AssertLineIs("01abc56")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(5)),
                 "0cT0abc", _.Escape, CheckThat(() => AssertLineIs("0bc123456")),
                 'u'
                 ));

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -529,6 +529,27 @@ namespace Test
                 ));
         }
 
+        // Defect #1674
+        [SkippableFact]
+        public void ViDeleteToCharBack()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("g", Keys(
+                "abcdefg", _.Escape,
+                // delete to the first character 'a'
+                "dFa",
+                CheckThat(() => AssertCursorLeftIs(0))
+                ));
+
+            Test("06", Keys(
+                "0123456", _.Escape,
+                // delete to the first character '0'
+                "dT0", CheckThat(() => AssertLineIs("06")),
+                CheckThat(() => AssertCursorLeftIs(1))
+                ));
+        }
+
         [SkippableFact]
         public void ViDeleteToEnd()
         {

--- a/test/MovementTest.VI.cs
+++ b/test/MovementTest.VI.cs
@@ -621,11 +621,11 @@ namespace Test
                 "0dfg"
                 ));
 
-            Test("", Keys(
+            Test("g", Keys(
                 "abcdefg", _.Escape, CheckThat(() => AssertLineIs("abcdefg")),
-                "dFa", _.Escape, CheckThat(() => AssertLineIs("")),
+                "dFa", _.Escape, CheckThat(() => AssertLineIs("g")),
                 'u', CheckThat(() => AssertCursorLeftIs(6)),
-                "dFb", CheckThat(() => AssertLineIs("a")),
+                "dFb", CheckThat(() => AssertLineIs("ag")),
                 'u', CheckThat(() => AssertCursorLeftIs(6)),
                 "dFa"
                 ));
@@ -644,10 +644,10 @@ namespace Test
 
             Test("0123456", Keys(
                 "0123456", _.Escape, CheckThat(() => AssertLineIs("0123456")),
-                "dT0", CheckThat(() => AssertLineIs("0")),
+                "dT0", CheckThat(() => AssertLineIs("06")),
                 'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "hdT0", CheckThat(() => AssertLineIs("06")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
+                "hdT0", CheckThat(() => AssertLineIs("056")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(5)),
                 "0dT0"
                 ));
         }


### PR DESCRIPTION

# PR Summary

Fixes #1674.

In `Vi` mode, deleting to backward text should not remove the character under (at the right) of the cursor. This PR adjusts the boundary used by the `DeleteBackwardToEndPoint` to preserve the last (starting) character.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not expecting documentation change.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2007)