### PR TITLE
[vi-mode] Undo now leaves the cursor under the position at the start of the deletion

### DIFF
--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -25,8 +25,6 @@ namespace Microsoft.PowerShell
             private HashSet<string> _cacheHistorySet;
             private List<SuggestionEntry> _cacheHistoryList;
 
-            internal string InputText => _inputText;
-
             protected PredictionViewBase(PSConsoleReadLine singleton)
             {
                 _singleton = singleton;
@@ -583,6 +581,7 @@ namespace Microsoft.PowerShell
             private bool _alreadyAccepted;
 
             internal string SuggestionText => _suggestionText;
+
             internal PredictionInlineView(PSConsoleReadLine singleton)
                 : base(singleton)
             {

--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -25,6 +25,8 @@ namespace Microsoft.PowerShell
             private HashSet<string> _cacheHistorySet;
             private List<SuggestionEntry> _cacheHistoryList;
 
+            internal string InputText => _inputText;
+
             protected PredictionViewBase(PSConsoleReadLine singleton)
             {
                 _singleton = singleton;
@@ -581,7 +583,6 @@ namespace Microsoft.PowerShell
             private bool _alreadyAccepted;
 
             internal string SuggestionText => _suggestionText;
-
             internal PredictionInlineView(PSConsoleReadLine singleton)
                 : base(singleton)
             {

--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -69,13 +69,17 @@ namespace Microsoft.PowerShell
             Prediction prediction = _singleton._prediction;
             if (prediction.ActiveView is PredictionInlineView inlineView && inlineView.HasActiveSuggestion)
             {
+                var start = inlineView.InputText.Length;
+
                 // Ignore the visual selection.
                 _singleton._visualSelectionCommandCount = 0;
 
                 inlineView.OnSuggestionAccepted();
 
                 using var _ = prediction.DisableScoped();
-                Replace(0, _singleton._buffer.Length, inlineView.SuggestionText);
+
+                _singleton._current = start;
+                Insert(inlineView.SuggestionText.Substring(_singleton._current));
             }
         }
 
@@ -102,17 +106,21 @@ namespace Microsoft.PowerShell
         {
             if (_singleton._prediction.ActiveView is PredictionInlineView inlineView && inlineView.HasActiveSuggestion)
             {
+                var start = Math.Max(0, inlineView.InputText.Length);
+                var index = _singleton._buffer.Length;
+
                 // Ignore the visual selection.
                 _singleton._visualSelectionCommandCount = 0;
 
-                int index = _singleton._buffer.Length;
                 while (numericArg-- > 0 && index < inlineView.SuggestionText.Length)
                 {
                     index = inlineView.FindForwardSuggestionWordPoint(index, _singleton.Options.WordDelimiters);
                 }
 
                 inlineView.OnSuggestionAccepted();
-                Replace(0, _singleton._buffer.Length, inlineView.SuggestionText.Substring(0, index));
+
+                _singleton._current = start;
+                Insert(inlineView.SuggestionText.Substring(start, index - start));
             }
         }
 

--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -69,8 +69,6 @@ namespace Microsoft.PowerShell
             Prediction prediction = _singleton._prediction;
             if (prediction.ActiveView is PredictionInlineView inlineView && inlineView.HasActiveSuggestion)
             {
-                var start = inlineView.InputText.Length;
-
                 // Ignore the visual selection.
                 _singleton._visualSelectionCommandCount = 0;
 
@@ -78,7 +76,7 @@ namespace Microsoft.PowerShell
 
                 using var _ = prediction.DisableScoped();
 
-                _singleton._current = start;
+                _singleton._current = _singleton._buffer.Length;
                 Insert(inlineView.SuggestionText.Substring(_singleton._current));
             }
         }
@@ -106,12 +104,11 @@ namespace Microsoft.PowerShell
         {
             if (_singleton._prediction.ActiveView is PredictionInlineView inlineView && inlineView.HasActiveSuggestion)
             {
-                var start = Math.Max(0, inlineView.InputText.Length);
-                var index = _singleton._buffer.Length;
-
                 // Ignore the visual selection.
                 _singleton._visualSelectionCommandCount = 0;
 
+                int start = _singleton._buffer.Length;
+                int index = start;
                 while (numericArg-- > 0 && index < inlineView.SuggestionText.Length)
                 {
                     index = inlineView.FindForwardSuggestionWordPoint(index, _singleton.Options.WordDelimiters);

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -631,7 +631,7 @@ namespace Microsoft.PowerShell
                         _singleton._current,
                         InvertCase,
                         arg,
-                        adjustCursor: false);
+                        moveCursorToEndWhenUndo: false);
 
                     EditItem insEditItem = EditItemInsertChar.Create(newChar, _singleton._current);
                     _singleton.SaveEditItem(GroupedEdit.Create(new List<EditItem>
@@ -1351,7 +1351,7 @@ namespace Microsoft.PowerShell
                     _singleton._current,
                     ViJoinLines,
                     arg,
-                    adjustCursor: false));
+                    moveCursorToEndWhenUndo: false));
 
                 _singleton.SaveEditItem(EditItemInsertChar.Create(' ', _singleton._current));
                 _singleton._groupUndoHelper.EndGroup();

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -459,6 +459,11 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
+        /// Returns true if in Vi edit mode, otherwise false.
+        /// </summary>
+        internal static bool InViEditMode() => _singleton.Options.EditMode == EditMode.Vi;
+
+        /// <summary>
         /// Returns true if in Vi Command mode, otherwise false.
         /// </summary>
         public static bool InViCommandMode() => _singleton._dispatchTable == _viCmdKeyMap;
@@ -621,7 +626,13 @@ namespace Microsoft.PowerShell
                 if (Char.IsLetter(c))
                 {
                     char newChar = Char.IsUpper(c) ? Char.ToLower(c, CultureInfo.CurrentCulture) : char.ToUpper(c, CultureInfo.CurrentCulture);
-                    EditItem delEditItem = EditItemDelete.Create(c.ToString(), _singleton._current);
+                    EditItem delEditItem = EditItemDelete.Create(
+                        c.ToString(),
+                        _singleton._current,
+                        InvertCase,
+                        arg,
+                        adjustCursor: false);
+
                     EditItem insEditItem = EditItemInsertChar.Create(newChar, _singleton._current);
                     _singleton.SaveEditItem(GroupedEdit.Create(new List<EditItem>
                         {
@@ -1335,7 +1346,13 @@ namespace Microsoft.PowerShell
             {
                 _singleton._buffer[_singleton._current] = ' ';
                 _singleton._groupUndoHelper.StartGroup(ViJoinLines, arg);
-                _singleton.SaveEditItem(EditItemDelete.Create("\n", _singleton._current));
+                _singleton.SaveEditItem(EditItemDelete.Create(
+                    "\n",
+                    _singleton._current,
+                    ViJoinLines,
+                    arg,
+                    adjustCursor: false));
+
                 _singleton.SaveEditItem(EditItemInsertChar.Create(' ', _singleton._current));
                 _singleton._groupUndoHelper.EndGroup();
                 _singleton.Render();

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -657,19 +657,20 @@ namespace Microsoft.PowerShell
             if (cursor == bufferLength)
                 --cursor; // if at end of line, swap previous two chars
 
-            char current = _singleton._buffer[cursor];
-            char previous = _singleton._buffer[cursor - 1];
+            _singleton.SaveEditItem(EditItemSwapCharacters.Create(cursor));
+            _singleton.SwapCharactersImpl(cursor);
 
-            _singleton.StartEditGroup();
-            _singleton.SaveEditItem(EditItemDelete.Create(_singleton._buffer.ToString(cursor - 1, 2), cursor - 1));
-            _singleton.SaveEditItem(EditItemInsertChar.Create(current, cursor - 1));
-            _singleton.SaveEditItem(EditItemInsertChar.Create(previous, cursor));
-            _singleton.EndEditGroup();
-
-            _singleton._buffer[cursor] = previous;
-            _singleton._buffer[cursor - 1] = current;
             _singleton.MoveCursor(Math.Min(cursor + 1, cursorRightLimit));
             _singleton.Render();
+        }
+
+        private void SwapCharactersImpl(int cursor)
+        {
+            char current = _buffer[cursor];
+            char previous = _buffer[cursor - 1];
+
+            _buffer[cursor] = previous;
+            _buffer[cursor - 1] = current;
         }
 
         /// <summary>

--- a/PSReadLine/Replace.vi.cs
+++ b/PSReadLine/Replace.vi.cs
@@ -65,7 +65,13 @@ namespace Microsoft.PowerShell
             {
                 _singleton.StartEditGroup();
                 string insStr = _singleton._buffer.ToString(startingCursor, _singleton._current - startingCursor);
-                _singleton.SaveEditItem(EditItemDelete.Create(deletedStr.ToString(), startingCursor));
+                _singleton.SaveEditItem(EditItemDelete.Create(
+                    deletedStr.ToString(),
+                    startingCursor,
+                    ViReplaceUntilEsc,
+                    arg,
+                    adjustCursor: false));
+
                 _singleton.SaveEditItem(EditItemInsertString.Create(insStr, startingCursor));
                 _singleton.EndEditGroup();
             }
@@ -226,7 +232,13 @@ namespace Microsoft.PowerShell
             if (_singleton._buffer.Length > 0 && nextKey.KeyStr.Length == 1)
             {
                 _singleton.StartEditGroup();
-                _singleton.SaveEditItem(EditItemDelete.Create(_singleton._buffer[_singleton._current].ToString(), _singleton._current));
+                _singleton.SaveEditItem(EditItemDelete.Create(
+                    _singleton._buffer[_singleton._current].ToString(),
+                    _singleton._current,
+                    ReplaceCharInPlace,
+                    arg,
+                    adjustCursor: false));
+
                 _singleton.SaveEditItem(EditItemInsertString.Create(nextKey.KeyStr, _singleton._current));
                 _singleton.EndEditGroup();
 

--- a/PSReadLine/Replace.vi.cs
+++ b/PSReadLine/Replace.vi.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell
                     startingCursor,
                     ViReplaceUntilEsc,
                     arg,
-                    adjustCursor: false));
+                    moveCursorToEndWhenUndo: false));
 
                 _singleton.SaveEditItem(EditItemInsertString.Create(insStr, startingCursor));
                 _singleton.EndEditGroup();
@@ -237,7 +237,7 @@ namespace Microsoft.PowerShell
                     _singleton._current,
                     ReplaceCharInPlace,
                     arg,
-                    adjustCursor: false));
+                    moveCursorToEndWhenUndo: false));
 
                 _singleton.SaveEditItem(EditItemInsertString.Create(nextKey.KeyStr, _singleton._current));
                 _singleton.EndEditGroup();

--- a/PSReadLine/UndoRedo.cs
+++ b/PSReadLine/UndoRedo.cs
@@ -278,7 +278,7 @@ namespace Microsoft.PowerShell
             public override void Undo()
             {
                 _singleton._buffer.Insert(_deleteStartPosition, _deletedString);
-                _singleton._current = _deleteStartPosition + _deletedString.Length;
+                _singleton._current = _deleteStartPosition;
             }
 
             public override void Redo()

--- a/PSReadLine/UndoRedo.cs
+++ b/PSReadLine/UndoRedo.cs
@@ -314,6 +314,32 @@ namespace Microsoft.PowerShell
             }
         }
 
+        [DebuggerDisplay("SwapCharacters")]
+        class EditItemSwapCharacters : EditItem
+        {
+            private readonly int _swapPosition;
+
+            private EditItemSwapCharacters(int swapPosition)
+            {
+                _swapPosition = swapPosition;
+            }
+
+            public static EditItem Create(int swapPosition)
+            { 
+                return new EditItemSwapCharacters(swapPosition);
+            }
+
+            public override void Redo()
+            {
+                Undo();
+            }
+
+            public override void Undo()
+            {
+                _singleton.SwapCharactersImpl(_swapPosition);
+            }
+        }
+
         class GroupedEdit : EditItem
         {
             internal List<EditItem> _groupedEditItems;

--- a/PSReadLine/YankPaste.vi.cs
+++ b/PSReadLine/YankPaste.vi.cs
@@ -78,14 +78,21 @@ namespace Microsoft.PowerShell
         /// <param name="count"></param>
         /// <param name="instigator"></param>
         /// <param name="arg"></param>
-        private void RemoveTextToViRegister(int start, int count, Action<ConsoleKeyInfo?, object> instigator = null, object arg = null)
+        /// <param name="moveCursorToEndWhenUndo"></param>
+        private void RemoveTextToViRegister(
+            int start,
+            int count,
+            Action<ConsoleKeyInfo?, object> instigator = null,
+            object arg = null,
+            bool moveCursorToEndWhenUndo = false)
         {
             _singleton.SaveToClipboard(start, count);
             _singleton.SaveEditItem(EditItemDelete.Create(
                 _viRegister.RawText,
                 start,
                 instigator,
-                arg));
+                arg,
+                moveCursorToEndWhenUndo));
             _singleton._buffer.Remove(start, count);
         }
 

--- a/PSReadLine/YankPaste.vi.cs
+++ b/PSReadLine/YankPaste.vi.cs
@@ -78,13 +78,17 @@ namespace Microsoft.PowerShell
         /// <param name="count"></param>
         /// <param name="instigator"></param>
         /// <param name="arg"></param>
-        /// <param name="moveCursorToEndWhenUndo"></param>
+        /// <param name="moveCursorToEndWhenUndoDelete">
+        /// Use 'false' as the default value because this method is used a lot by VI operations,
+        /// and for VI opeartions, we do NOT want to move the cursor to the end when undoing a
+        /// deletion.
+        /// </param>
         private void RemoveTextToViRegister(
             int start,
             int count,
             Action<ConsoleKeyInfo?, object> instigator = null,
             object arg = null,
-            bool moveCursorToEndWhenUndo = false)
+            bool moveCursorToEndWhenUndoDelete = false)
         {
             _singleton.SaveToClipboard(start, count);
             _singleton.SaveEditItem(EditItemDelete.Create(
@@ -92,7 +96,7 @@ namespace Microsoft.PowerShell
                 start,
                 instigator,
                 arg,
-                moveCursorToEndWhenUndo));
+                moveCursorToEndWhenUndoDelete));
             _singleton._buffer.Remove(start, count);
         }
 

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -137,7 +137,7 @@ namespace Test
             Test("", Keys(
                 "0123(567)9ab", _.Escape, "hhh", CheckThat(() => AssertCursorLeftIs(8)),
                 'c', _.Percent, "45678", _.Escape, CheckThat(() => AssertLineIs("0123456789ab")), CheckThat(() => AssertCursorLeftIs(8)),
-                'u', CheckThat(() => AssertLineIs("0123(567)9ab")), CheckThat(() => AssertCursorLeftIs(9)),
+                'u', CheckThat(() => AssertLineIs("0123(567)9ab")), CheckThat(() => AssertCursorLeftIs(4)),
                 'U'
                 ));
             Test("", Keys(
@@ -381,8 +381,8 @@ namespace Test
             Test("0123", Keys(
                 "0123", _.Escape,
                 "d1h", CheckThat(() => AssertLineIs("013")),
-                "ud3h", CheckThat(() => AssertLineIs("3")),
-                "ud4h", CheckThat(() => AssertLineIs("3")),
+                "u$d3h", CheckThat(() => AssertLineIs("3")),
+                "u$d4h", CheckThat(() => AssertLineIs("3")),
                 "u0dl", CheckThat(() => AssertLineIs("123")),
                 "u0d4l", CheckThat(() => AssertLineIs("")),
                 "u0d5l", CheckThat(() => AssertLineIs("")),
@@ -432,20 +432,20 @@ namespace Test
             Test("nslookup www.google.com", Keys(
                 "nslookup www", _.Period, "google", _.Period, "com", _.Escape,
                 "d1b", CheckThat(() => AssertLineIs("nslookup www.google.m")),
-                "ud2b", CheckThat(() => AssertLineIs("nslookup www.googlem")),
-                "ud3b", CheckThat(() => AssertLineIs("nslookup www.m")),
-                "ud4b", CheckThat(() => AssertLineIs("nslookup wwwm")),
-                "ud5b", CheckThat(() => AssertLineIs("nslookup m")),
-                "ud6b", CheckThat(() => AssertLineIs("m")),
-                "ud7b", CheckThat(() => AssertLineIs("m")),
+                "u$d2b", CheckThat(() => AssertLineIs("nslookup www.googlem")),
+                "u$d3b", CheckThat(() => AssertLineIs("nslookup www.m")),
+                "u$d4b", CheckThat(() => AssertLineIs("nslookup wwwm")),
+                "u$d5b", CheckThat(() => AssertLineIs("nslookup m")),
+                "u$d6b", CheckThat(() => AssertLineIs("m")),
+                "u$d7b", CheckThat(() => AssertLineIs("m")),
                 'u'
                 ));
 
             Test("nslookup www.google.com", Keys(
                 "nslookup www", _.Period, "google", _.Period, "com", _.Escape,
                 "d1B", CheckThat(() => AssertLineIs("nslookup m")),
-                "ud2B", CheckThat(() => AssertLineIs("m")),
-                "ud3B", CheckThat(() => AssertLineIs("m")),
+                "u$d2B", CheckThat(() => AssertLineIs("m")),
+                "u$d3B", CheckThat(() => AssertLineIs("m")),
                 'u'
                 ));
 
@@ -526,6 +526,22 @@ namespace Test
                  CheckThat(() => AssertLineIs("\"\none\ntwo")),
                  // finish the buffer to close the multiline string
                  _.A, _.Enter, _.DQuote, _.Escape
+                ));
+        }
+
+        // Defect #1673
+        [SkippableFact]
+        public void ViDelete_UndoCursorPosition()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("one", Keys(
+                "one", _.Escape,
+                "h", // move back to the 'n' character
+                "x", CheckThat(() => AssertLineIs("oe")),
+
+                // undo
+                "u", CheckThat(() => AssertCursorLeftIs(1))
                 ));
         }
 
@@ -685,9 +701,9 @@ namespace Test
             Test("0 2+4 6", Keys(
                 "0 2+4 6", _.Escape, CheckThat(() => AssertLineIs("0 2+4 6")), CheckThat(() => AssertCursorLeftIs(6)),
                 "dB", CheckThat(() => AssertLineIs("0 6")), CheckThat(() => AssertCursorLeftIs(2)),
-                "u", CheckThat(() => AssertLineIs("0 2+4 6")), CheckThat(() => AssertCursorLeftIs(6)),
-                "2dB", CheckThat(() => AssertLineIs("6")), CheckThat(() => AssertCursorLeftIs(0)),
-                "u", CheckThat(() => AssertLineIs("0 2+4 6")), CheckThat(() => AssertCursorLeftIs(6))
+                "u", CheckThat(() => AssertLineIs("0 2+4 6")), CheckThat(() => AssertCursorLeftIs(2)),
+                "$2dB", CheckThat(() => AssertLineIs("6")), CheckThat(() => AssertCursorLeftIs(0)),
+                "u", CheckThat(() => AssertLineIs("0 2+4 6")), CheckThat(() => AssertCursorLeftIs(0))
                 ));
 
             Test("0 2+4 6", Keys(
@@ -697,7 +713,7 @@ namespace Test
                 "u0ldE", CheckThat(() => AssertLineIs("0 6")), CheckThat(() => AssertCursorLeftIs(1)),
                 "u0l2dE", CheckThat(() => AssertLineIs("0")), CheckThat(() => AssertCursorLeftIs(0)),
                 "u03dE", CheckThat(() => AssertLineIs("")), CheckThat(() => AssertCursorLeftIs(0)),
-                "u", CheckThat(() => AssertLineIs("0 2+4 6")), CheckThat(() => AssertCursorLeftIs(6))
+                "u", CheckThat(() => AssertLineIs("0 2+4 6")), CheckThat(() => AssertCursorLeftIs(0))
                 ));
 
             Test("0 2+4 6", Keys(
@@ -708,7 +724,7 @@ namespace Test
                 "u0l2dW", CheckThat(() => AssertLineIs("06")), CheckThat(() => AssertCursorLeftIs(1)),
                 "u0l3dW", CheckThat(() => AssertLineIs("0")), CheckThat(() => AssertCursorLeftIs(0)),
                 "u03dW", CheckThat(() => AssertLineIs("")), CheckThat(() => AssertCursorLeftIs(0)),
-                "u", CheckThat(() => AssertLineIs("0 2+4 6")), CheckThat(() => AssertCursorLeftIs(6))
+                "u", CheckThat(() => AssertLineIs("0 2+4 6")), CheckThat(() => AssertCursorLeftIs(0))
                 ));
         }
 
@@ -738,7 +754,7 @@ namespace Test
             Test("(1{3{5)789)b}c", Keys(
                 "(1{3{5)789)b}c", _.Escape, CheckThat(() => AssertLineIs("(1{3{5)789)b}c")), CheckThat(() => AssertCursorLeftIs(13)),
                 "hd", _.Percent, CheckThat(() => AssertLineIs("(1{3c")), CheckThat(() => AssertCursorLeftIs(4)),
-                "u", CheckThat(() => AssertLineIs("(1{3{5)789)b}c")), CheckThat(() => AssertCursorLeftIs(13))
+                "u", CheckThat(() => AssertLineIs("(1{3{5)789)b}c")), CheckThat(() => AssertCursorLeftIs(4))
                 ));
 
             Test("(1{3[5)7}9)b]", Keys(
@@ -750,13 +766,13 @@ namespace Test
             Test("(1{3[5)7}9)b]c", Keys(
                 "(1{3[5)7}9)b]c", _.Escape, CheckThat(() => AssertLineIs("(1{3[5)7}9)b]c")), CheckThat(() => AssertCursorLeftIs(13)),
                 "hhhhhd", _.Percent, CheckThat(() => AssertLineIs("(19)b]c")), CheckThat(() => AssertCursorLeftIs(2)),
-                "u", CheckThat(() => AssertLineIs("(1{3[5)7}9)b]c")), CheckThat(() => AssertCursorLeftIs(9))
+                "u", CheckThat(() => AssertLineIs("(1{3[5)7}9)b]c")), CheckThat(() => AssertCursorLeftIs(2))
                 ));
 
             Test("(1{3[5)7}9)b]d", Keys(
                 "(1{3[5)7}9)b]d", _.Escape, CheckThat(() => AssertLineIs("(1{3[5)7}9)b]d")), CheckThat(() => AssertCursorLeftIs(13)),
                 "h", _.Percent, "d", _.Percent, CheckThat(() => AssertLineIs("(1{3d")), CheckThat(() => AssertCursorLeftIs(4)),
-                "u", CheckThat(() => AssertLineIs("(1{3[5)7}9)b]d")), CheckThat(() => AssertCursorLeftIs(13))
+                "u", CheckThat(() => AssertLineIs("(1{3[5)7}9)b]d")), CheckThat(() => AssertCursorLeftIs(4))
                 ));
 
             Test("(1{3[5)7}9)b]", Keys(
@@ -770,7 +786,7 @@ namespace Test
             Test("(1{3[5)7}9)b]c", Keys(
                 "(1{3[5)7}9)b]c", _.Escape, CheckThat(() => AssertLineIs("(1{3[5)7}9)b]c")), CheckThat(() => AssertCursorLeftIs(13)),
                 "hhhhh", _.Percent, "d", _.Percent, CheckThat(() => AssertLineIs("(19)b]c")), CheckThat(() => AssertCursorLeftIs(2)),
-                "u", CheckThat(() => AssertLineIs("(1{3[5)7}9)b]c")), CheckThat(() => AssertCursorLeftIs(9))
+                "u", CheckThat(() => AssertLineIs("(1{3[5)7}9)b]c")), CheckThat(() => AssertCursorLeftIs(2))
                 ));
 
             Test("012 [ 67 ] bc", Keys(
@@ -779,7 +795,7 @@ namespace Test
                 _.Percent, CheckThat(() => AssertCursorLeftIs(4)),
                 _.Percent, CheckThat(() => AssertCursorLeftIs(9)),
                 'd', _.Percent, CheckThat(() => AssertLineIs("012  bc")),
-                "uh", CheckThat(() => AssertLineIs("012 [ 67 ] bc")), CheckThat(() => AssertCursorLeftIs(9)),
+                "u", CheckThat(() => AssertLineIs("012 [ 67 ] bc")), CheckThat(() => AssertCursorLeftIs(4)),
                 'c', _.Percent, "99", _.Escape, CheckThat(() => AssertLineIs("012 99 bc")),
                 'u'
                 ));
@@ -790,10 +806,9 @@ namespace Test
                 _.Percent, CheckThat(() => AssertCursorLeftIs(4)),
                 _.Percent, CheckThat(() => AssertCursorLeftIs(9)),
                 'd', _.Percent, CheckThat(() => AssertLineIs("012  bc")), CheckThat(() => AssertCursorLeftIs(4)),
-                'u', CheckThat(() => AssertLineIs("012 { 67 } bc")), CheckThat(() => AssertCursorLeftIs(10)),
-                'h', _.Percent, CheckThat(() => AssertCursorLeftIs(4)),
+                'u', CheckThat(() => AssertLineIs("012 { 67 } bc")), CheckThat(() => AssertCursorLeftIs(4)),
                 'd', _.Percent, CheckThat(() => AssertLineIs("012  bc")), CheckThat(() => AssertCursorLeftIs(4)),
-                'u', CheckThat(() => AssertCursorLeftIs(10))
+                'u', CheckThat(() => AssertCursorLeftIs(4))
                 ));
 
             Test("012 ( 67 ) bc", Keys(
@@ -802,10 +817,9 @@ namespace Test
                 _.Percent, CheckThat(() => AssertCursorLeftIs(4)),
                 _.Percent, CheckThat(() => AssertCursorLeftIs(9)),
                 'd', _.Percent, CheckThat(() => AssertLineIs("012  bc")), CheckThat(() => AssertCursorLeftIs(4)),
-                'u', CheckThat(() => AssertLineIs("012 ( 67 ) bc")), CheckThat(() => AssertCursorLeftIs(10)),
-                'h', _.Percent, CheckThat(() => AssertCursorLeftIs(4)),
+                'u', CheckThat(() => AssertLineIs("012 ( 67 ) bc")), CheckThat(() => AssertCursorLeftIs(4)),
                 'd', _.Percent, CheckThat(() => AssertLineIs("012  bc")), CheckThat(() => AssertCursorLeftIs(4)),
-                'u', CheckThat(() => AssertCursorLeftIs(10))
+                'u', CheckThat(() => AssertCursorLeftIs(4))
                 ));
         }
 
@@ -865,9 +879,9 @@ namespace Test
             Test("012 45", Keys(
                 "012 45", _.Escape,
                 "0cwabc", _.Escape, CheckThat(() => AssertLineIs("abc 45")),
-                "u", CheckThat(() => AssertLineIs("012 45")), CheckThat(() => AssertCursorLeftIs(4)),
+                "u", CheckThat(() => AssertLineIs("012 45")), CheckThat(() => AssertCursorLeftIs(0)),
                 "0cwabc", _.Escape, CheckThat(() => AssertLineIs("abc 45")),
-                "u", CheckThat(() => AssertCursorLeftIs(4)),
+                "u", CheckThat(() => AssertCursorLeftIs(0)),
                 "0cwabc", _.Escape, "wcwef", _.Escape, CheckThat(() => AssertLineIs("abc ef")),
                 "uu", CheckThat(() => AssertLineIs("012 45")),
                 "02cwabcdef", _.Escape, CheckThat(() => AssertLineIs("abcdef")),
@@ -1037,25 +1051,25 @@ namespace Test
             Test("0123456", Keys(
                 "0123456", _.Escape, CheckThat(() => AssertLineIs("0123456")),
                 "0cf6abc", _.Escape, CheckThat(() => AssertLineIs("abc")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(0)),
                 "0cf5abc", _.Escape, CheckThat(() => AssertLineIs("abc6")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(0)),
                 "0lcf6abc", _.Escape, CheckThat(() => AssertLineIs("0abc")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "cf6abc", _.Escape, CheckThat(() => AssertLineIs("0123456bc")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(1)),
+                "$cf6abc", _.Escape, CheckThat(() => AssertLineIs("0123456bc")),
                 'u'
                 ));
 
             Test("0123456", Keys(
                 "0123456", _.Escape, CheckThat(() => AssertLineIs("0123456")),
                 "cF0abc", _.Escape, CheckThat(() => AssertLineIs("abc6")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "cF1abc", _.Escape, CheckThat(() => AssertLineIs("0abc6")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "hcF0abc", _.Escape, CheckThat(() => AssertLineIs("abc56")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(5)),
-                "hcF1abc", _.Escape, CheckThat(() => AssertLineIs("0abc456")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(4)),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(0)),
+                "$cF1abc", _.Escape, CheckThat(() => AssertLineIs("0abc6")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(1)),
+                "$hcF0abc", _.Escape, CheckThat(() => AssertLineIs("abc56")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(0)),
+                "$hhcF1abc", _.Escape, CheckThat(() => AssertLineIs("0abc456")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(1)),
                 "0cF0abc", _.Escape, CheckThat(() => AssertLineIs("0bc123456")),
                 'u'
                 ));
@@ -1063,19 +1077,19 @@ namespace Test
             Test("0123456", Keys(
                 "0123456", _.Escape, CheckThat(() => AssertLineIs("0123456")),
                 "0ct6abc", _.Escape, CheckThat(() => AssertLineIs("abc6")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(0)),
                 "0lct6abc", _.Escape, CheckThat(() => AssertLineIs("0abc6")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "ct6abc", _.Escape, CheckThat(() => AssertLineIs("0123456bc")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(1)),
+                "$ct6abc", _.Escape, CheckThat(() => AssertLineIs("0123456bc")),
                 'u'
                 ));
 
             Test("0123456", Keys(
                 "0123456", _.Escape, CheckThat(() => AssertLineIs("0123456")),
                 "cT1abc", _.Escape, CheckThat(() => AssertLineIs("01abc6")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "hcT1abc", _.Escape, CheckThat(() => AssertLineIs("01abc56")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(5)),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(2)),
+                "$hcT1abc", _.Escape, CheckThat(() => AssertLineIs("01abc56")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(2)),
                 "0cT0abc", _.Escape, CheckThat(() => AssertLineIs("0bc123456")),
                 'u'
                 ));

--- a/test/BasicEditingTest.cs
+++ b/test/BasicEditingTest.cs
@@ -201,6 +201,36 @@ namespace Test
         }
 
         [SkippableFact]
+        public void SelectAndDelete()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            Test("abcde", Keys(
+                "abcde",
+                CheckThat(() => AssertCursorLeftIs(5)),
+                _.Shift_LeftArrow, _.Shift_LeftArrow, _.Shift_LeftArrow,
+                _.Backspace,
+                CheckThat(() => AssertLineIs("ab")),
+                CheckThat(() => AssertCursorLeftIs(2)),
+                _.Ctrl_z,
+                CheckThat(() => AssertLineIs("abcde")),
+                CheckThat(() => AssertCursorLeftIs(5))));
+
+            Test("abcde", Keys(
+                "abcde", _.Home,
+                CheckThat(() => AssertCursorLeftIs(0)),
+                _.RightArrow, _.RightArrow,
+                CheckThat(() => AssertCursorLeftIs(2)),
+                _.Shift_RightArrow, _.Shift_RightArrow,
+                _.Delete,
+                CheckThat(() => AssertLineIs("abe")),
+                CheckThat(() => AssertCursorLeftIs(2)),
+                _.Ctrl_z,
+                CheckThat(() => AssertLineIs("abcde")),
+                CheckThat(() => AssertCursorLeftIs(4))));
+        }
+
+        [SkippableFact]
         public void SwapCharacters()
         {
             TestSetup(KeyMode.Emacs);

--- a/test/BasicEditingTest.cs
+++ b/test/BasicEditingTest.cs
@@ -212,7 +212,7 @@ namespace Test
             Test("abc", Keys(
                 "abc", CheckThat(() => AssertLineIs("abc")),
                 _.Ctrl_t, CheckThat(() => AssertLineIs("acb")),
-                _.Ctrl_Underbar
+                _.Ctrl_Underbar, CheckThat(() => AssertCursorLeftIs(3))
                 ));
 
             Test("abcd", Keys(

--- a/test/InlinePredictionTest.cs
+++ b/test/InlinePredictionTest.cs
@@ -364,6 +364,36 @@ namespace Test
             ));
         }
 
+        [SkippableFact]
+        public void ViDefect2408()
+        {
+            TestSetup(KeyMode.Vi);
+            using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.InlineView);
+
+            SetHistory("echo -bar");
+            Test("ech", Keys(
+                "abcd",
+                CheckThat(() => AssertScreenIs(1,
+                    TokenClassification.Command, "abcd")),
+                _.Escape, 'S',
+                CheckThat(() => AssertLineIs(string.Empty)),
+                CheckThat(() => AssertCursorLeftIs(0)),
+                "ech",
+                CheckThat(() => AssertScreenIs(1,
+                    TokenClassification.Command, "ech",
+                    TokenClassification.InlinePrediction, "o -bar")),
+                _.RightArrow,
+                CheckThat(() => AssertScreenIs(1,
+                    TokenClassification.Command, "echo",
+                    TokenClassification.None, ' ',
+                    TokenClassification.Parameter, "-bar")),
+                CheckThat(() => AssertCursorLeftIs(9)),
+                _.Ctrl_z,
+                CheckThat(() => AssertScreenIs(1,
+                    TokenClassification.Command, "ech",
+                    TokenClassification.InlinePrediction, "o -bar"))));
+        }
+
         private const uint MiniSessionId = 56;
         private static readonly Guid predictorId_1 = Guid.Parse("b45b5fbe-90fa-486c-9c87-e7940fdd6273");
         private static readonly Guid predictorId_2 = Guid.Parse("74a86463-033b-44a3-b386-41ee191c94be");

--- a/test/MovementTest.VI.cs
+++ b/test/MovementTest.VI.cs
@@ -666,5 +666,17 @@ namespace Test
                 _.Escape, "kjw"
                 ));
         }
+
+        [SkippableFact]
+        public void ViDefect1673()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("one", Keys(
+                "one", _.Escape, _.D0,
+                _.x, CheckThat(() => AssertLineIs("ne")),
+                _.u, CheckThat(() => AssertCursorLeftIs(0))
+                ));
+        }
     }
 }

--- a/test/MovementTest.VI.cs
+++ b/test/MovementTest.VI.cs
@@ -620,25 +620,25 @@ namespace Test
             Test("", Keys(
                 "abcdefg", _.Escape, CheckThat(() => AssertLineIs("abcdefg")),
                 "0dfg", CheckThat(() => AssertLineIs("")),
-                'u', CheckThat(() => AssertLineIs("abcdefg")), CheckThat(() => AssertCursorLeftIs(6)),
+                'u', CheckThat(() => AssertLineIs("abcdefg")), CheckThat(() => AssertCursorLeftIs(0)),
                 "0dff", CheckThat(() => AssertLineIs("g")),
-                'u', CheckThat(() => AssertLineIs("abcdefg")), CheckThat(() => AssertCursorLeftIs(6)),
+                'u', CheckThat(() => AssertLineIs("abcdefg")), CheckThat(() => AssertCursorLeftIs(0)),
                 "0dfg"
                 ));
 
-            Test("g", Keys(
+            Test("bcdefg", Keys(
                 "abcdefg", _.Escape, CheckThat(() => AssertLineIs("abcdefg")),
                 "dFa", _.Escape, CheckThat(() => AssertLineIs("g")),
-                'u', CheckThat(() => AssertCursorLeftIs(6)),
-                "dFb", CheckThat(() => AssertLineIs("ag")),
-                'u', CheckThat(() => AssertCursorLeftIs(6)),
+                'u', CheckThat(() => AssertCursorLeftIs(0)),
+                "$dFb", CheckThat(() => AssertLineIs("ag")),
+                'u', CheckThat(() => AssertCursorLeftIs(1)),
                 "dFa"
                 ));
 
             Test("0123456", Keys(
                 "0123456", _.Escape, CheckThat(() => AssertLineIs("0123456")),
                 "0dt6", CheckThat(() => AssertLineIs("6")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(0)),
                 "0dt5", CheckThat(() => AssertLineIs("56")),
                 'u', CheckThat(() => AssertLineIs("0123456")),
                 "0ldt6", CheckThat(() => AssertLineIs("06")),
@@ -650,9 +650,9 @@ namespace Test
             Test("0123456", Keys(
                 "0123456", _.Escape, CheckThat(() => AssertLineIs("0123456")),
                 "dT0", CheckThat(() => AssertLineIs("06")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(6)),
-                "hdT0", CheckThat(() => AssertLineIs("056")),
-                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(5)),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(1)),
+                "$hdT0", CheckThat(() => AssertLineIs("056")),
+                'u', CheckThat(() => AssertLineIs("0123456")), CheckThat(() => AssertCursorLeftIs(1)),
                 "0dT0"
                 ));
         }

--- a/test/WordsTests.VI.cs
+++ b/test/WordsTests.VI.cs
@@ -49,7 +49,7 @@ namespace Test
                 _.Escape, CheckThat(() => AssertCursorLeftIs(5)),
                 'b', CheckThat(() => AssertCursorLeftIs(4)),
                 "dw", CheckThat(() => AssertLineIs("test")),
-                "ubcw", CheckThat(() => AssertLineIs("test")),
+                "ulbcw", CheckThat(() => AssertLineIs("test")),
                 "[]", _.Escape, CheckThat(() => AssertLineIs("test[]")),
                 'u'
                 ));
@@ -59,8 +59,8 @@ namespace Test
                 CheckThat(() => AssertLineIs(@"vim .\PSReadLine\VisualEditing.vi.cs")),
                 _.Escape, "Bll", CheckThat(() => AssertCursorLeftIs(6)),
                 "cw", _.Escape, CheckThat(() => AssertCursorLeftIs(5)), CheckThat(() => AssertLineIs(@"vim .\\VisualEditing.vi.cs")),
-                'u', CheckThat(() => AssertCursorLeftIs(16)), CheckThat(() => AssertLineIs(@"vim .\PSReadLine\VisualEditing.vi.cs")),
-                "bcwxx", _.Escape, CheckThat(() => AssertCursorLeftIs(7))
+                'u', CheckThat(() => AssertCursorLeftIs(6)), CheckThat(() => AssertLineIs(@"vim .\PSReadLine\VisualEditing.vi.cs")),
+                "cwxx", _.Escape, CheckThat(() => AssertCursorLeftIs(7))
                 ));
 
             Test("$response.Headers['location']", Keys(


### PR DESCRIPTION
# PR Summary

Fixes #1673
Fixes #2408

This PR changes undo so that a deleted text is inserted in the buffer and resetting the cursor at the position where it was when deletion of text occurred. I believe this is also making it more consistent with how most text editors behave.

To implement this PR I also slightly changed the `AcceptSuggestion` and `AcceptNextSuggestionWord` methods which were doing a replacement of the buffer. This PR now makes those methods add the appropriate portion of text so that undoing the operation behaves more inline with most users’ expectations. Externally, the behaviour of those methods has not changed.

This PR also changes `SwapCharacters` to make it an _atomic_ operation while still moving the cursor after swapping characters. This preserves the original behaviour. However, it slightly alters the way the cursor is now positioned when undo occurs, but I’m not sure whether this can be seen as a breaking change or not.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2045)