### PR TITLE
Remove LineIsMultiline in favor of multiline agnostic algorithms (#1125)

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -432,21 +432,35 @@ namespace Microsoft.PowerShell
             {
                 switch (commandName[0])
                 {
-                // The following are debugger commands that should be accepted if we're debugging
-                // because the console host will interpret these commands directly.
-                case 's': case 'v': case 'o': case 'c': case 'q': case 'k': case 'l':
-                case 'S': case 'V': case 'O': case 'C': case 'Q': case 'K': case 'L':
-                case '?': case 'h': case 'H':
-                    // Ideally we would check $PSDebugContext, but it is set at function
-                    // scope, and because we're in a module, we can't find that variable
-                    // (arguably a PowerShell issue.)
-                    // NestedPromptLevel is good enough though - it's rare to be in a nested.
-                    var nestedPromptLevel = _engineIntrinsics.SessionState.PSVariable.GetValue("NestedPromptLevel");
-                    if (nestedPromptLevel is int)
-                    {
-                        return ((int)nestedPromptLevel) > 0;
-                    }
-                    break;
+                    // The following are debugger commands that should be accepted if we're debugging
+                    // because the console host will interpret these commands directly.
+                    case 's':
+                    case 'v':
+                    case 'o':
+                    case 'c':
+                    case 'q':
+                    case 'k':
+                    case 'l':
+                    case 'S':
+                    case 'V':
+                    case 'O':
+                    case 'C':
+                    case 'Q':
+                    case 'K':
+                    case 'L':
+                    case '?':
+                    case 'h':
+                    case 'H':
+                        // Ideally we would check $PSDebugContext, but it is set at function
+                        // scope, and because we're in a module, we can't find that variable
+                        // (arguably a PowerShell issue.)
+                        // NestedPromptLevel is good enough though - it's rare to be in a nested.
+                        var nestedPromptLevel = _engineIntrinsics.SessionState.PSVariable.GetValue("NestedPromptLevel");
+                        if (nestedPromptLevel is int)
+                        {
+                            return ((int)nestedPromptLevel) > 0;
+                        }
+                        break;
                 }
             }
 
@@ -522,24 +536,16 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void InsertLineBelow(ConsoleKeyInfo? key = null, object arg = null)
         {
-            // Move the current position to the end of the current line and only the current line.
-            if (_singleton.LineIsMultiLine())
+            int i = _singleton._current;
+            for (; i < _singleton._buffer.Length; i++)
             {
-                int i = _singleton._current;
-                for (; i < _singleton._buffer.Length; i++)
+                if (_singleton._buffer[i] == '\n')
                 {
-                    if (_singleton._buffer[i] == '\n')
-                    {
-                        break;
-                    }
+                    break;
                 }
+            }
 
-                _singleton._current = i;
-            }
-            else
-            {
-                _singleton._current = _singleton._buffer.Length;
-            }
+            _singleton._current = i;
 
             Insert('\n');
         }

--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -432,35 +432,21 @@ namespace Microsoft.PowerShell
             {
                 switch (commandName[0])
                 {
-                    // The following are debugger commands that should be accepted if we're debugging
-                    // because the console host will interpret these commands directly.
-                    case 's':
-                    case 'v':
-                    case 'o':
-                    case 'c':
-                    case 'q':
-                    case 'k':
-                    case 'l':
-                    case 'S':
-                    case 'V':
-                    case 'O':
-                    case 'C':
-                    case 'Q':
-                    case 'K':
-                    case 'L':
-                    case '?':
-                    case 'h':
-                    case 'H':
-                        // Ideally we would check $PSDebugContext, but it is set at function
-                        // scope, and because we're in a module, we can't find that variable
-                        // (arguably a PowerShell issue.)
-                        // NestedPromptLevel is good enough though - it's rare to be in a nested.
-                        var nestedPromptLevel = _engineIntrinsics.SessionState.PSVariable.GetValue("NestedPromptLevel");
-                        if (nestedPromptLevel is int)
-                        {
-                            return ((int)nestedPromptLevel) > 0;
-                        }
-                        break;
+                // The following are debugger commands that should be accepted if we're debugging
+                // because the console host will interpret these commands directly.
+                case 's': case 'v': case 'o': case 'c': case 'q': case 'k': case 'l':
+                case 'S': case 'V': case 'O': case 'C': case 'Q': case 'K': case 'L':
+                case '?': case 'h': case 'H':
+                    // Ideally we would check $PSDebugContext, but it is set at function
+                    // scope, and because we're in a module, we can't find that variable
+                    // (arguably a PowerShell issue.)
+                    // NestedPromptLevel is good enough though - it's rare to be in a nested.
+                    var nestedPromptLevel = _engineIntrinsics.SessionState.PSVariable.GetValue("NestedPromptLevel");
+                    if (nestedPromptLevel is int)
+                    {
+                        return ((int)nestedPromptLevel) > 0;
+                    }
+                    break;
                 }
             }
 

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -21,23 +21,16 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void EndOfLine(ConsoleKeyInfo? key = null, object arg = null)
         {
-            if (_singleton.LineIsMultiLine())
+            int i = _singleton._current;
+            for (; i < _singleton._buffer.Length; i++)
             {
-                int i = _singleton._current;
-                for (; i < _singleton._buffer.Length; i++)
+                if (_singleton._buffer[i] == '\n')
                 {
-                    if (_singleton._buffer[i] == '\n')
-                    {
-                        break;
-                    }
+                    break;
                 }
+            }
 
-                _singleton.MoveCursor((i == _singleton._current) ? _singleton._buffer.Length : i);
-            }
-            else
-            {
-                _singleton.MoveCursor(_singleton._buffer.Length);
-            }
+            _singleton.MoveCursor((i == _singleton._current) ? _singleton._buffer.Length : i);
         }
 
         /// <summary>
@@ -97,7 +90,7 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    ViOffsetCursorPosition(+ numericArg);
+                    ViOffsetCursorPosition(+numericArg);
                 }
             }
         }
@@ -109,7 +102,7 @@ namespace Microsoft.PowerShell
         {
             if (TryGetArgAsInt(arg, out var numericArg, 1))
             {
-                ViOffsetCursorPosition(- numericArg);
+                ViOffsetCursorPosition(-numericArg);
             }
         }
 
@@ -225,7 +218,8 @@ namespace Microsoft.PowerShell
                 point = point ?? ConvertOffsetToPoint(_current);
                 int newY = point.Value.Y + lineOffset;
 
-                Point newPoint = new Point() {
+                Point newPoint = new Point()
+                {
                     X = _moveToLineDesiredColumn,
                     Y = Math.Max(newY, _initialY)
                 };
@@ -470,18 +464,18 @@ namespace Microsoft.PowerShell
             int direction;
             switch (token.Kind)
             {
-            case TokenKind.LParen:   toMatch = TokenKind.RParen; direction = 1; break;
-            case TokenKind.LCurly:   toMatch = TokenKind.RCurly; direction = 1; break;
-            case TokenKind.LBracket: toMatch = TokenKind.RBracket; direction = 1; break;
+                case TokenKind.LParen: toMatch = TokenKind.RParen; direction = 1; break;
+                case TokenKind.LCurly: toMatch = TokenKind.RCurly; direction = 1; break;
+                case TokenKind.LBracket: toMatch = TokenKind.RBracket; direction = 1; break;
 
-            case TokenKind.RParen:   toMatch = TokenKind.LParen; direction = -1; break;
-            case TokenKind.RCurly:   toMatch = TokenKind.LCurly; direction = -1; break;
-            case TokenKind.RBracket: toMatch = TokenKind.LBracket; direction = -1; break;
+                case TokenKind.RParen: toMatch = TokenKind.LParen; direction = -1; break;
+                case TokenKind.RCurly: toMatch = TokenKind.LCurly; direction = -1; break;
+                case TokenKind.RBracket: toMatch = TokenKind.LBracket; direction = -1; break;
 
-            default:
-                // Nothing to match (don't match inside strings/comments)
-                Ding();
-                return;
+                default:
+                    // Nothing to match (don't match inside strings/comments)
+                    Ding();
+                    return;
             }
 
             var matchCount = 0;

--- a/PSReadLine/Movement.vi.cs
+++ b/PSReadLine/Movement.vi.cs
@@ -160,20 +160,13 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void MoveToEndOfLine(ConsoleKeyInfo? key = null, object arg = null)
         {
-            if (_singleton.LineIsMultiLine())
+            var eol = GetEndOfLogicalLinePos(_singleton._current);
+            if (eol != _singleton._current)
             {
-                var eol = GetEndOfLogicalLinePos(_singleton._current);
-                if (eol != _singleton._current)
-                {
-                    _singleton.MoveCursor(eol);
-                }
-                _singleton._moveToEndOfLineCommandCount++;
-                _singleton._moveToLineDesiredColumn = int.MaxValue;
+                _singleton.MoveCursor(eol);
             }
-            else
-            {
-                _singleton.MoveCursor(Math.Max(0, _singleton._buffer.Length + ViEndOfLineFactor));
-            }
+            _singleton._moveToEndOfLineCommandCount++;
+            _singleton._moveToLineDesiredColumn = int.MaxValue;
         }
 
         /// <summary>

--- a/PSReadLine/Movement.vi.multiline.cs
+++ b/PSReadLine/Movement.vi.multiline.cs
@@ -12,7 +12,8 @@ namespace Microsoft.PowerShell
         /// <param name="arg" />
         public void MoveToFirstLine(ConsoleKeyInfo? key = null, object arg = null)
         {
-            if (!LineIsMultiLine())
+            var count = GetLogicalLineCount();
+            if (count == 1)
             {
                 Ding(key, arg);
                 return;
@@ -38,13 +39,13 @@ namespace Microsoft.PowerShell
         /// <param name="arg" />
         public void MoveToLastLine(ConsoleKeyInfo? key = null, object arg = null)
         {
-            if (!LineIsMultiLine())
+            var count = GetLogicalLineCount();
+            if (count == 1)
             {
                 Ding(key, arg);
                 return;
             }
 
-            var count = GetLogicalLineCount();
             var currentLine = GetLogicalLineNumber();
 
             var pos = ConvertOffsetToPoint(_singleton._current);

--- a/PSReadLine/Movement.vi.multiline.cs
+++ b/PSReadLine/Movement.vi.multiline.cs
@@ -12,8 +12,7 @@ namespace Microsoft.PowerShell
         /// <param name="arg" />
         public void MoveToFirstLine(ConsoleKeyInfo? key = null, object arg = null)
         {
-            var count = GetLogicalLineCount();
-            if (count == 1)
+            if (!LineIsMultiLine())
             {
                 Ding(key, arg);
                 return;

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -555,6 +555,7 @@ namespace Microsoft.PowerShell
                         // nor a "move to line" command. In that case, the desired column
                         // number will be computed from the current position on the logical line.
 
+                        _moveToEndOfLineCommandCount = 0;
                         _moveToLineDesiredColumn = -1;
                     }
                 }


### PR DESCRIPTION
# PR Summary

Fixes #1125.

This PR removes as many calls as possible of the method `LineIsMultiline()` where the underlying algorithm is already behaving consistently irrespective of the number of logical lines in the buffer.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests - _All non-regression changes covered by existing unit-tests_.
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2047)