### PR TITLE
Prevent crash in GotoFirstNonBlankOfLine

### DIFF
--- a/PSReadLine/Position.cs
+++ b/PSReadLine/Position.cs
@@ -11,28 +11,17 @@ namespace Microsoft.PowerShell
         /// <param name="current">The position in the current logical line.</param>
         private static int GetBeginningOfLinePos(int current)
         {
-            var newCurrent = current;
-
-            if (_singleton.LineIsMultiLine())
+            int i = Math.Max(0, current);
+            while (i > 0)
             {
-                int i = Math.Max(0, current);
-                while (i > 0)
+                if (_singleton._buffer[--i] == '\n')
                 {
-                    if (_singleton._buffer[--i] == '\n')
-                    {
-                        i += 1;
-                        break;
-                    }
+                    i += 1;
+                    break;
                 }
-
-                newCurrent = i;
-            }
-            else
-            {
-                newCurrent = 0;
             }
 
-            return newCurrent;
+            return i;
         }
 
         /// <summary>
@@ -114,7 +103,7 @@ namespace Microsoft.PowerShell
 
             var newCurrent = beginningOfLine;
 
-            while (IsVisibleBlank(newCurrent))
+            while (newCurrent < _singleton._buffer.Length && IsVisibleBlank(newCurrent))
             {
                 newCurrent++;
             }

--- a/test/MovementTest.VI.Multiline.cs
+++ b/test/MovementTest.VI.Multiline.cs
@@ -179,6 +179,16 @@ namespace Test
         }
 
         [SkippableFact]
+        public void ViDefect2050()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("", Keys(
+                _.Escape, _.Underbar
+                ));
+        }
+
+        [SkippableFact]
         public void ViMoveToEndOfLine_NoOp_OnEmptyLine()
         {
             TestSetup(KeyMode.Vi);


### PR DESCRIPTION
# PR Summary

Fixes #2050.

The method `GetBeginningOfLinePos` is updated to remove call to `LineIsMultiline` that do not check the buffer input and attempts to access the underlying `_buffer`.  Additionally, the method `GetFirstNonBlankOfLogicalLinePos` protects access to the `_buffer` member.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2051)