### PR TITLE
Add the 'SelectCommandArgument' bind-able function

### DIFF
--- a/PSReadLine/DynamicHelp.cs
+++ b/PSReadLine/DynamicHelp.cs
@@ -15,37 +15,11 @@ namespace Microsoft.PowerShell
 {
     public partial class PSConsoleReadLine
     {
-        private Microsoft.PowerShell.Pager _pager;
-
-        /// <summary>
-        /// Attempt to show help content.
-        /// Show the full help for the command on the alternate screen buffer.
-        /// </summary>
-        public static void ShowCommandHelp(ConsoleKeyInfo? key = null, object arg = null)
+        // Stub helper methods so dynamic help can be mocked
+        [ExcludeFromCodeCoverage]
+        void IPSConsoleReadLineMockableMethods.RenderFullHelp(string content, string regexPatternToScrollTo)
         {
-            if (_singleton._console is PlatformWindows.LegacyWin32Console)
-            {
-                Collection<string> helpBlock = new Collection<string>()
-                {
-                    string.Empty,
-                    PSReadLineResources.FullHelpNotSupportedInLegacyConsole
-                };
-
-                _singleton.WriteDynamicHelpBlock(helpBlock);
-
-                return;
-            }
-
-            _singleton.DynamicHelpImpl(isFullHelp: true);
-        }
-
-        /// <summary>
-        /// Attempt to show help content.
-        /// Show the short help of the parameter next to the cursor.
-        /// </summary>
-        public static void ShowParameterHelp(ConsoleKeyInfo? key = null, object arg = null)
-        {
-            _singleton.DynamicHelpImpl(isFullHelp: false);
+            _pager.Write(content, regexPatternToScrollTo);
         }
 
         [ExcludeFromCodeCoverage]
@@ -112,9 +86,37 @@ namespace Microsoft.PowerShell
             }
         }
 
-        void IPSConsoleReadLineMockableMethods.RenderFullHelp(string content, string regexPatternToScrollTo)
+        private Pager _pager;
+
+        /// <summary>
+        /// Attempt to show help content.
+        /// Show the full help for the command on the alternate screen buffer.
+        /// </summary>
+        public static void ShowCommandHelp(ConsoleKeyInfo? key = null, object arg = null)
         {
-            _pager.Write(content, regexPatternToScrollTo);
+            if (_singleton._console is PlatformWindows.LegacyWin32Console)
+            {
+                Collection<string> helpBlock = new Collection<string>()
+                {
+                    string.Empty,
+                    PSReadLineResources.FullHelpNotSupportedInLegacyConsole
+                };
+
+                _singleton.WriteDynamicHelpBlock(helpBlock);
+
+                return;
+            }
+
+            _singleton.DynamicHelpImpl(isFullHelp: true);
+        }
+
+        /// <summary>
+        /// Attempt to show help content.
+        /// Show the short help of the parameter next to the cursor.
+        /// </summary>
+        public static void ShowParameterHelp(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            _singleton.DynamicHelpImpl(isFullHelp: false);
         }
 
         private void WriteDynamicHelpContent(string commandName, string parameterName, bool isFullHelp)

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -229,6 +229,7 @@ namespace Microsoft.PowerShell
                 { Keys.Alt9,                   MakeKeyHandler(DigitArgument,             "DigitArgument") },
                 { Keys.AltMinus,               MakeKeyHandler(DigitArgument,             "DigitArgument") },
                 { Keys.AltQuestion,            MakeKeyHandler(WhatIsKey,                 "WhatIsKey") },
+                { Keys.AltA,                   MakeKeyHandler(SelectCommandArgument,     "SelectCommandArgument") },
                 { Keys.F2,                     MakeKeyHandler(SwitchPredictionView,      "SwitchPredictionView") },
                 { Keys.F3,                     MakeKeyHandler(CharacterSearch,           "CharacterSearch") },
                 { Keys.ShiftF3,                MakeKeyHandler(CharacterSearchBackward,   "CharacterSearchBackward") },
@@ -334,6 +335,7 @@ namespace Microsoft.PowerShell
                 { Keys.AltPeriod,       MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.AltUnderbar,     MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.CtrlAltY,        MakeKeyHandler(YankNthArg,           "YankNthArg") },
+                { Keys.AltA,            MakeKeyHandler(SelectCommandArgument,"SelectCommandArgument") },
                 { Keys.AltH,            MakeKeyHandler(ShowParameterHelp,    "ShowParameterHelp") },
                 { Keys.F1,              MakeKeyHandler(ShowCommandHelp,      "ShowCommandHelp") },
             };
@@ -604,6 +606,7 @@ namespace Microsoft.PowerShell
             case nameof(SelectShellBackwardWord):
             case nameof(SelectShellForwardWord):
             case nameof(SelectShellNextWord):
+            case nameof(SelectCommandArgument):
                 return KeyHandlerGroup.Selection;
 
             default:

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -11,7 +11,7 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TargetFrameworks>net461;net5.0</TargetFrameworks>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -2147,5 +2147,49 @@ namespace Microsoft.PowerShell.PSReadLine {
                 return ResourceManager.GetString("ShowParameterHelpDescription", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select the next suggestion item shown in the list view.
+        /// </summary>
+        internal static string NextSuggestionDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("NextSuggestionDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select the previous suggestion item shown in the list view.
+        /// </summary>
+        internal static string PreviousSuggestionDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("PreviousSuggestionDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Switch between the inline and list prediction views.
+        /// </summary>
+        internal static string SwitchPredictionViewDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("SwitchPredictionViewDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Make visual selection of the command arguments.
+        /// </summary>
+        internal static string SelectCommandArgumentDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("SelectCommandArgumentDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -836,7 +836,7 @@ Or not saving history with:
     <value>Select the previous suggestion item shown in the list view.</value>
   </data>
   <data name="SwitchPredictionViewDescription" xml:space="preserve">
-    <value>Switch to the other prediction view.</value>
+    <value>Switch between the inline and list prediction views.</value>
   </data>
   <data name="WindowSizeTooSmallForListView" xml:space="preserve">
     <value>The prediction 'ListView' is temporarily disabled because the current window size of the console is too small. To use the 'ListView', please make sure the 'WindowWidth' is not less than '{0}' and the 'WindowHeight' is not less than '{1}'.</value>
@@ -852,5 +852,8 @@ Or not saving history with:
   </data>
   <data name="ShowParameterHelpDescription" xml:space="preserve">
     <value>Shows help for the parameter at the cursor.</value>
+  </data>
+  <data name="SelectCommandArgumentDescription" xml:space="preserve">
+    <value>Make visual selection of the command arguments.</value>
   </data>
 </root>

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -29,8 +29,8 @@ namespace Microsoft.PowerShell
             Task<List<PredictionResult>> PredictInput(Ast ast, Token[] tokens);
             void OnCommandLineAccepted(IReadOnlyList<string> history);
             void OnSuggestionAccepted(Guid predictorId, string suggestionText);
-            object GetDynamicHelpContent(string commandName, string parameterName, bool isFullHelp);
             void RenderFullHelp(string content, string regexPatternToScrollTo);
+            object GetDynamicHelpContent(string commandName, string parameterName, bool isFullHelp);
         }
 
         [SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add the `SelectCommandArgument` bind-able function.
This functionality was originally proposed by @ThePSAdmin who added a argument selection handler to `SamplePSReadLineProfile.ps1` via #1947. This PR adds a built-in function for this functionality with improvements.

Improvements:
1. Selection of arguments is scoped in script blocks. Based on the cursor position, it searches from the most nested script block to the outmost script block. This offers better user experience when looping through arguments.
2. When the cursor is at an argument, `Ctrl+a` selects that specific argument.
3. Improve the digit arguments handling to treat the positive/negative argument value as a forward/backward offset from the currently selected argument or the current cursor position when no argument is selected.
4. Some minor fixes and add a lot tests.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [x] Doc Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/7259


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2222)