### PR TITLE
Update PSReadLine corresponding to the prediction interface update

### DIFF
--- a/MockPSConsole/MockPSConsole.csproj
+++ b/MockPSConsole/MockPSConsole.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MockPSConsole</RootNamespace>
     <AssemblyName>MockPSConsole</AssemblyName>
-    <TargetFrameworks>net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <ApplicationManifest>Program.manifest</ApplicationManifest>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
@@ -17,8 +17,8 @@
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.1.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.0-preview.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine.build.ps1
+++ b/PSReadLine.build.ps1
@@ -19,7 +19,7 @@ param(
     [ValidateSet("Debug", "Release")]
     [string]$Configuration = (property Configuration Release),
 
-    [ValidateSet("net461", "net5.0")]
+    [ValidateSet("net461", "net6.0")]
     [string]$Framework,
 
     [switch]$CheckHelpContent
@@ -32,7 +32,7 @@ $targetDir = "bin/$Configuration/PSReadLine"
 
 if (-not $Framework)
 {
-    $Framework = if ($PSVersionTable.PSEdition -eq "Core") { "net5.0" } else { "net461" }
+    $Framework = if ($PSVersionTable.PSEdition -eq "Core") { "net6.0" } else { "net461" }
 }
 
 Write-Verbose "Building for '$Framework'" -Verbose
@@ -65,9 +65,9 @@ $mockPSConsoleParams = @{
 Synopsis: Build the Polyfiller assembly
 #>
 task BuildPolyfiller @polyFillerParams -If ($Framework -eq "net461") {
-    ## Build both "net461" and "net5.0"
+    ## Build both "net461" and "net6.0"
     exec { dotnet publish -f "net461" -c $Configuration Polyfill }
-    exec { dotnet publish -f "net5.0" -c $Configuration Polyfill }
+    exec { dotnet publish -f "net6.0" -c $Configuration Polyfill }
 }
 
 <#
@@ -132,12 +132,12 @@ task LayoutModule BuildPolyfiller, BuildMainModule, {
         if (-not (Test-Path "$targetDir/net461")) {
             New-Item "$targetDir/net461" -ItemType Directory -Force > $null
         }
-        if (-not (Test-Path "$targetDir/net5.0")) {
-            New-Item "$targetDir/net5.0" -ItemType Directory -Force > $null
+        if (-not (Test-Path "$targetDir/net6plus")) {
+            New-Item "$targetDir/net6plus" -ItemType Directory -Force > $null
         }
 
         Copy-Item "Polyfill/bin/$Configuration/net461/Microsoft.PowerShell.PSReadLine.Polyfiller.dll" "$targetDir/net461" -Force
-        Copy-Item "Polyfill/bin/$Configuration/net5.0/Microsoft.PowerShell.PSReadLine.Polyfiller.dll" "$targetDir/net5.0" -Force
+        Copy-Item "Polyfill/bin/$Configuration/net6.0/Microsoft.PowerShell.PSReadLine.Polyfiller.dll" "$targetDir/net6plus" -Force
     }
 
     $binPath = "PSReadLine/bin/$Configuration/$Framework/publish"

--- a/PSReadLine/OnImportAndRemove.cs
+++ b/PSReadLine/OnImportAndRemove.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.PSReadLine
             }
 
             string root = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location);
-            string subd = (Environment.Version.Major >= 5) ? "net5.0" : "net461";
+            string subd = (Environment.Version.Major >= 6) ? "net6plus" : "net461";
             string path = Path.Combine(root, subd, "Microsoft.PowerShell.PSReadLine.Polyfiller.dll");
 
             return Assembly.LoadFrom(path);

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell
                 }
 
                 bool notTest = ReferenceEquals(_mockableMethods, this);
-                if ((options.PredictionSource & PredictionSource.Plugin) != 0 && Environment.Version.Major < 5 && notTest)
+                if ((options.PredictionSource & PredictionSource.Plugin) != 0 && Environment.Version.Major < 6 && notTest)
                 {
                     throw new ArgumentException(PSReadLineResources.PredictionPluginNotSupported);
                 }

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.1.0" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -9,7 +9,7 @@
     <FileVersion>2.2.0</FileVersion>
     <InformationalVersion>2.2.0-beta1</InformationalVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <TargetFrameworks>net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
@@ -20,8 +20,8 @@
     <ProjectReference Include="..\Polyfill\Polyfill.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.5" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.sln
+++ b/PSReadLine/PSReadLine.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PSReadLine", "PSReadLine.csproj", "{615788CB-1B9A-4B34-97B3-4608686E59CA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Polyfill", "..\Polyfill\Polyfill.csproj", "{DE521A7D-A3BE-4A07-BE75-5AB7D87E799D}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MockPSConsole", "..\MockPSConsole\MockPSConsole.csproj", "{08218B1A-8B85-4722-9E3F-4D6C0BF58AD8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PSReadLine.Tests", "..\test\PSReadLine.Tests.csproj", "{8ED51D01-158C-4B29-824A-35B9B861E45A}"

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -705,7 +705,7 @@ namespace Microsoft.PowerShell.PSReadLine {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The prediction plugin source is not supported in this version of PowerShell. The 7.1 or a higher version of PowerShell is required to use this source.
+        ///   Looks up a localized string similar to The prediction plugin source is not supported in this version of PowerShell. The 7.2 or a higher version of PowerShell is required to use this source.
         /// </summary>
         internal static string PredictionPluginNotSupported
         {

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -815,7 +815,7 @@ Or not saving history with:
     <value>The predictive suggestion feature cannot be enabled because the console output doesn't support virtual terminal processing or it's redirected.</value>
   </data>
   <data name="PredictionPluginNotSupported" xml:space="preserve">
-    <value>The prediction plugin source is not supported in this version of PowerShell. The 7.1 or a higher version of PowerShell is required to use this source.</value>
+    <value>The prediction plugin source is not supported in this version of PowerShell. The 7.2 or a higher version of PowerShell is required to use this source.</value>
   </data>
   <data name="DeleteEndOfBufferDescription" xml:space="preserve">
     <value>Delete the current logical line and up to the end of the multiline buffer</value>

--- a/PSReadLine/Prediction.Entry.cs
+++ b/PSReadLine/Prediction.Entry.cs
@@ -15,14 +15,21 @@ namespace Microsoft.PowerShell
         private struct SuggestionEntry
         {
             internal readonly Guid PredictorId;
+            internal readonly uint? PredictorSession;
             internal readonly string Source;
             internal readonly string SuggestionText;
             internal readonly int InputMatchIndex;
 
-            internal SuggestionEntry(string soruce, Guid id, string suggestion, int matchIndex)
+            internal SuggestionEntry(string suggestion, int matchIndex)
+                : this(soruce: "History", predictorId: Guid.Empty, predictorSession: null, suggestion, matchIndex)
+            {
+            }
+
+            internal SuggestionEntry(string soruce, Guid predictorId, uint? predictorSession, string suggestion, int matchIndex)
             {
                 Source = soruce;
-                PredictorId = id;
+                PredictorId = predictorId;
+                PredictorSession = predictorSession;
                 SuggestionText = suggestion;
                 InputMatchIndex = matchIndex;
             }

--- a/PSReadLine/Prediction.Entry.cs
+++ b/PSReadLine/Prediction.Entry.cs
@@ -21,13 +21,13 @@ namespace Microsoft.PowerShell
             internal readonly int InputMatchIndex;
 
             internal SuggestionEntry(string suggestion, int matchIndex)
-                : this(soruce: "History", predictorId: Guid.Empty, predictorSession: null, suggestion, matchIndex)
+                : this(source: "History", predictorId: Guid.Empty, predictorSession: null, suggestion, matchIndex)
             {
             }
 
-            internal SuggestionEntry(string soruce, Guid predictorId, uint? predictorSession, string suggestion, int matchIndex)
+            internal SuggestionEntry(string source, Guid predictorId, uint? predictorSession, string suggestion, int matchIndex)
             {
-                Source = soruce;
+                Source = source;
                 PredictorId = predictorId;
                 PredictorSession = predictorSession;
                 SuggestionText = suggestion;

--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -16,23 +16,31 @@ namespace Microsoft.PowerShell
 {
     public partial class PSConsoleReadLine
     {
+        private const string PSReadLine = "PSReadLine";
+
         // Stub helper methods so prediction can be mocked
         [ExcludeFromCodeCoverage]
         Task<List<PredictionResult>> IPSConsoleReadLineMockableMethods.PredictInput(Ast ast, Token[] tokens)
         {
-            return CommandPrediction.PredictInput(ast, tokens);
+            return CommandPrediction.PredictInput(PSReadLine, ast, tokens);
+        }
+
+        [ExcludeFromCodeCoverage]
+        void IPSConsoleReadLineMockableMethods.OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex)
+        {
+            CommandPrediction.OnSuggestionDisplayed(PSReadLine, predictorId, session, countOrIndex);
+        }
+
+        [ExcludeFromCodeCoverage]
+        void IPSConsoleReadLineMockableMethods.OnSuggestionAccepted(Guid predictorId, uint session, string suggestionText)
+        {
+            CommandPrediction.OnSuggestionAccepted(PSReadLine, predictorId, session, suggestionText);
         }
 
         [ExcludeFromCodeCoverage]
         void IPSConsoleReadLineMockableMethods.OnCommandLineAccepted(IReadOnlyList<string> history)
         {
-            CommandPrediction.OnCommandLineAccepted(history);
-        }
-
-        [ExcludeFromCodeCoverage]
-        void IPSConsoleReadLineMockableMethods.OnSuggestionAccepted(Guid predictorId, string suggestionText)
-        {
-            CommandPrediction.OnSuggestionAccepted(predictorId, suggestionText);
+            CommandPrediction.OnCommandLineAccepted(PSReadLine, history);
         }
 
         private readonly Prediction _prediction;

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -28,7 +28,8 @@ namespace Microsoft.PowerShell
             bool RunspaceIsRemote(Runspace runspace);
             Task<List<PredictionResult>> PredictInput(Ast ast, Token[] tokens);
             void OnCommandLineAccepted(IReadOnlyList<string> history);
-            void OnSuggestionAccepted(Guid predictorId, string suggestionText);
+            void OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex);
+            void OnSuggestionAccepted(Guid predictorId, uint session, string suggestionText);
             void RenderFullHelp(string content, string regexPatternToScrollTo);
             object GetDynamicHelpContent(string commandName, string parameterName, bool isFullHelp);
         }

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -668,7 +668,7 @@ namespace Microsoft.PowerShell
             }
             if (hostName == null)
             {
-                hostName = "PSReadLine";
+                hostName = PSReadLine;
             }
             _options = new PSConsoleReadLineOptions(hostName);
             _prediction = new Prediction(this);

--- a/Polyfill/CommandPrediction.cs
+++ b/Polyfill/CommandPrediction.cs
@@ -24,15 +24,23 @@ namespace System.Management.Automation.Subsystem
         public string Name { get; }
 
         /// <summary>
+        /// Gets the mini-session id that represents a specific invocation that returns this result.
+        /// When it's not specified, it's considered by a client that the predictor doesn't expect feedback.
+        /// </summary>
+        [HiddenAttribute]
+        public uint? Session { get; }
+
+        /// <summary>
         /// Gets the suggestions.
         /// </summary>
         [HiddenAttribute]
         public IReadOnlyList<PredictiveSuggestion> Suggestions { get; }
 
-        internal PredictionResult(Guid id, string name, List<PredictiveSuggestion> suggestions)
+        internal PredictionResult(Guid id, string name, uint? session, List<PredictiveSuggestion> suggestions)
         {
             Id = id;
             Name = name;
+            Session = session;
             Suggestions = suggestions;
         }
     }
@@ -90,11 +98,12 @@ namespace System.Management.Automation.Subsystem
         /// <summary>
         /// Collect the predictive suggestions from registered predictors using the default timeout.
         /// </summary>
+        /// <param name="client">Represents the client that initiates the call.</param>
         /// <param name="ast">The <see cref="Ast"/> object from parsing the current command line input.</param>
         /// <param name="astTokens">The <see cref="Token"/> objects from parsing the current command line input.</param>
         /// <returns>A list of <see cref="PredictionResult"/> objects.</returns>
         [HiddenAttribute]
-        public static Task<List<PredictionResult>> PredictInput(Ast ast, Token[] astTokens)
+        public static Task<List<PredictionResult>> PredictInput(string client, Ast ast, Token[] astTokens)
         {
             return null;
         }
@@ -102,12 +111,13 @@ namespace System.Management.Automation.Subsystem
         /// <summary>
         /// Collect the predictive suggestions from registered predictors using the specified timeout.
         /// </summary>
+        /// <param name="client">Represents the client that initiates the call.</param>
         /// <param name="ast">The <see cref="Ast"/> object from parsing the current command line input.</param>
         /// <param name="astTokens">The <see cref="Token"/> objects from parsing the current command line input.</param>
         /// <param name="millisecondsTimeout">The milliseconds to timeout.</param>
         /// <returns>A list of <see cref="PredictionResult"/> objects.</returns>
         [HiddenAttribute]
-        public static Task<List<PredictionResult>> PredictInput(Ast ast, Token[] astTokens, int millisecondsTimeout)
+        public static Task<List<PredictionResult>> PredictInput(string client, Ast ast, Token[] astTokens, int millisecondsTimeout)
         {
             return null;
         }
@@ -115,19 +125,37 @@ namespace System.Management.Automation.Subsystem
         /// <summary>
         /// Allow registered predictors to do early processing when a command line is accepted.
         /// </summary>
+        /// <param name="client">Represents the client that initiates the call.</param>
         /// <param name="history">History command lines provided as references for prediction.</param>
         [HiddenAttribute]
-        public static void OnCommandLineAccepted(IReadOnlyList<string> history)
+        public static void OnCommandLineAccepted(string client, IReadOnlyList<string> history)
+        {
+        }
+
+        /// <summary>
+        /// Send feedback to a predictor when one or more suggestions from it were displayed to the user.
+        /// </summary>
+        /// <param name="client">Represents the client that initiates the call.</param>
+        /// <param name="predictorId">The identifier of the predictor whose prediction result was accepted.</param>
+        /// <param name="session">The mini-session where the displayed suggestions came from.</param>
+        /// <param name="countOrIndex">
+        /// When the value is <code>> 0</code>, it's the number of displayed suggestions from the list returned in <see cref="session"/>, starting from the index 0.
+        /// When the value is <code><= 0</code>, it means a single suggestion from the list got displayed, and the index is the absolute value.
+        /// </param>
+        [HiddenAttribute]
+        public static void OnSuggestionDisplayed(string client, Guid predictorId, uint session, int countOrIndex)
         {
         }
 
         /// <summary>
         /// Send feedback to predictors about their last suggestions.
         /// </summary>
+        /// <param name="client">Represents the client that initiates the call.</param>
         /// <param name="predictorId">The identifier of the predictor whose prediction result was accepted.</param>
+        /// <param name="session">The mini-session where the accepted suggestion came from.</param>
         /// <param name="suggestionText">The accepted suggestion text.</param>
         [HiddenAttribute]
-        public static void OnSuggestionAccepted(Guid predictorId, string suggestionText)
+        public static void OnSuggestionAccepted(string client, Guid predictorId, uint session, string suggestionText)
         {
         }
     }

--- a/Polyfill/Polyfill.csproj
+++ b/Polyfill/Polyfill.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.PowerShell.PSReadLine.Polyfiller</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <TargetFrameworks>net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
@@ -11,8 +11,8 @@
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.1.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.3" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/build.ps1
+++ b/build.ps1
@@ -39,7 +39,7 @@ param(
     [ValidateSet("Debug", "Release")]
     [string] $Configuration = "Debug",
 
-    [ValidateSet("net461", "net5.0")]
+    [ValidateSet("net461", "net6.0")]
     [string] $Framework
 )
 

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="local" value="C:\arena\tmp\NugetPackages" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="local" value="C:\arena\tmp\NugetPackages" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>

--- a/test/InlinePredictionTest.cs
+++ b/test/InlinePredictionTest.cs
@@ -364,6 +364,7 @@ namespace Test
             ));
         }
 
+        private const uint MiniSessionId = 56;
         private static readonly Guid predictorId_1 = Guid.Parse("b45b5fbe-90fa-486c-9c87-e7940fdd6273");
         private static readonly Guid predictorId_2 = Guid.Parse("74a86463-033b-44a3-b386-41ee191c94be");
 
@@ -395,9 +396,9 @@ namespace Test
             return new List<PredictionResult>
             {
                 (PredictionResult)ctor.Invoke(
-                    new object[] { predictorId_1, "TestPredictor", (uint)56, suggestions_1 }),
+                    new object[] { predictorId_1, "TestPredictor", MiniSessionId, suggestions_1 }),
                 (PredictionResult)ctor.Invoke(
-                    new object[] { predictorId_2, "LongNamePredictor", (uint)56, suggestions_2 }),
+                    new object[] { predictorId_2, "LongNamePredictor", MiniSessionId, suggestions_2 }),
             };
         }
 
@@ -417,7 +418,7 @@ namespace Test
                     TokenClassification.Command, "git",
                     TokenClassification.InlinePrediction, " SOME TEXT AFTER")),
                 // `OnSuggestionDisplayed` should be fired for only one predictor because we are in 'inline' view.
-                CheckThat(() => AssertDisplayedSuggestions(count: 1, predictorId_1, 56, -1)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 1, predictorId_1, MiniSessionId, -1)),
                 CheckThat(() => _mockedMethods.ClearPredictionFields()),
                 // 'ctrl+f' will trigger 'OnSuggestionAccepted'.
                 _.Ctrl_f, CheckThat(() => AssertScreenIs(1,
@@ -466,7 +467,7 @@ namespace Test
 
             // 'Enter' will trigger 'OnCommandLineAccepted', because plugin is in use.
             // Also, we still have `OnSuggestionDisplayed` fired, from the typing of each character of `nets`.
-            AssertDisplayedSuggestions(count: 1, predictorId_1, 56, -1);
+            AssertDisplayedSuggestions(count: 1, predictorId_1, MiniSessionId, -1);
             Assert.Equal(Guid.Empty, _mockedMethods.acceptedPredictorId);
             Assert.Null(_mockedMethods.acceptedSuggestion);
             Assert.NotNull(_mockedMethods.commandHistory);
@@ -492,7 +493,7 @@ namespace Test
                     TokenClassification.Command, "git",
                     TokenClassification.InlinePrediction, " SOME TEXT AFTER")),
                 // `OnSuggestionDisplayed` should be fired for only one predictor because we are in 'inline' view.
-                CheckThat(() => AssertDisplayedSuggestions(count: 1, predictorId_1, 56, -1)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 1, predictorId_1, MiniSessionId, -1)),
                 CheckThat(() => _mockedMethods.ClearPredictionFields()),
                 _.Ctrl_f, CheckThat(() => AssertScreenIs(1,
                     TokenClassification.Command, "git",
@@ -537,7 +538,7 @@ namespace Test
                     TokenClassification.Command, "netsh",
                     TokenClassification.InlinePrediction, " show me")),
                 // Yeah, we still have `OnSuggestionDisplayed` fired, from the typing of each character of `nets`.
-                CheckThat(() => AssertDisplayedSuggestions(count: 1, predictorId_1, 56, -1)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 1, predictorId_1, MiniSessionId, -1)),
                 CheckThat(() => _mockedMethods.ClearPredictionFields()),
                 // 'ctrl+f' won't trigger 'OnSuggestionAccepted' as the suggestion is from history.
                 _.Ctrl_f, CheckThat(() => AssertScreenIs(1,

--- a/test/ListPredictionTest.cs
+++ b/test/ListPredictionTest.cs
@@ -37,6 +37,15 @@ namespace Test
                 new SetPSReadLineOption { PredictionSource = oldSource, PredictionViewStyle = oldView }));
         }
 
+        private void AssertDisplayedSuggestions(int count, Guid predictorId, uint session, int countOrIndex)
+        {
+            Assert.Equal(count, _mockedMethods.displayedSuggestions.Count);
+            _mockedMethods.displayedSuggestions.TryGetValue(predictorId, out var tuple);
+            Assert.NotNull(tuple);
+            Assert.Equal(session, tuple.Item1);
+            Assert.Equal(countOrIndex, tuple.Item2);
+        }
+
         [SkippableFact]
         public void List_RenderSuggestion_NoMatching()
         {
@@ -958,6 +967,10 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should be fired for both predictors.
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
+                CheckThat(() => _mockedMethods.ClearPredictionFields()),
                 _.DownArrow,
                      CheckThat(() => AssertScreenIs(5,
                         TokenClassification.Command, "SOME",
@@ -990,6 +1003,8 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should not be fired when navigating the list.
+                CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
                 _.Shift_Home,
                     CheckThat(() => AssertScreenIs(5,
                         TokenClassification.Selection, "SOME TEXT BEFORE ec",
@@ -1021,6 +1036,8 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should not be fired when selecting the input.
+                CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
                 "j",
                      CheckThat(() => AssertScreenIs(5,
                         TokenClassification.Command, "j",
@@ -1052,6 +1069,9 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should be fired for both predictors.
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
                 CheckThat(() => Assert.Equal(predictorId_1, _mockedMethods.acceptedPredictorId)),
                 CheckThat(() => Assert.Equal("SOME TEXT BEFORE ec", _mockedMethods.acceptedSuggestion)),
                 CheckThat(() => Assert.Null(_mockedMethods.commandHistory)),
@@ -1090,6 +1110,8 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should not be fired when navigating the input.
+                CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
                 _.Backspace,
                      CheckThat(() => AssertScreenIs(5,
                         TokenClassification.Command, "SOME",
@@ -1124,6 +1146,9 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should be fired for both predictors.
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
                 CheckThat(() => Assert.Equal(predictorId_2, _mockedMethods.acceptedPredictorId)),
                 CheckThat(() => Assert.Equal("SOME NEW TEXT", _mockedMethods.acceptedSuggestion)),
                 CheckThat(() => Assert.Null(_mockedMethods.commandHistory)),
@@ -1163,6 +1188,8 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should not be fired when navigating the input.
+                CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
                 // Once accepted, the list should be cleared.
                 _.Enter, CheckThat(() => AssertScreenIs(2,
                         TokenClassification.Command, "SOME",
@@ -1171,6 +1198,8 @@ namespace Test
                         TokenClassification.None, new string(' ', windowWidth)))
             ));
 
+            // `OnSuggestionDisplayed` should not be fired when 'Enter' accepting the input.
+            Assert.Empty(_mockedMethods.displayedSuggestions);
             Assert.Equal(predictorId_1, _mockedMethods.acceptedPredictorId);
             Assert.Equal("SOME NEW TEX SOME TEXT AFTER", _mockedMethods.acceptedSuggestion);
             Assert.Equal(3, _mockedMethods.commandHistory.Count);
@@ -1240,6 +1269,10 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should be fired for both predictors.
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
+                CheckThat(() => _mockedMethods.ClearPredictionFields()),
                 _.DownArrow, _.Shift_Home,
                      CheckThat(() => AssertScreenIs(7,
                         TokenClassification.Selection, "eca -zoo",
@@ -1289,6 +1322,8 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should not be fired when navigating the list.
+                CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
                 'j', CheckThat(() => AssertScreenIs(6,
                         TokenClassification.Command, "j",
                         NextLine,
@@ -1328,6 +1363,9 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should be fired for both predictors.
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
                 // Update the selected item won't trigger 'acceptance' callbacks if the item is from history.
                 CheckThat(() => Assert.Equal(Guid.Empty, _mockedMethods.acceptedPredictorId)),
                 CheckThat(() => Assert.Null(_mockedMethods.acceptedSuggestion)),
@@ -1374,6 +1412,8 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should not be fired when navigating the list.
+                CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
                 _.Backspace,
                      CheckThat(() => AssertScreenIs(5,
                         TokenClassification.Command, "SOME",
@@ -1408,6 +1448,9 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should be fired for both predictors.
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
                 CheckThat(() => Assert.Equal(predictorId_2, _mockedMethods.acceptedPredictorId)),
                 CheckThat(() => Assert.Equal("SOME NEW TEXT", _mockedMethods.acceptedSuggestion)),
                 CheckThat(() => Assert.Null(_mockedMethods.commandHistory)),
@@ -1447,6 +1490,8 @@ namespace Test
                         NextLine,
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
+                // `OnSuggestionDisplayed` should not be fired when navigating the list.
+                CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
                 // Once accepted, the list should be cleared.
                 _.Enter, CheckThat(() => AssertScreenIs(2,
                         TokenClassification.Command, "SOME",
@@ -1455,6 +1500,7 @@ namespace Test
                         TokenClassification.None, new string(' ', windowWidth)))
             ));
 
+            Assert.Empty(_mockedMethods.displayedSuggestions);
             Assert.Equal(predictorId_1, _mockedMethods.acceptedPredictorId);
             Assert.Equal("SOME NEW TEX SOME TEXT AFTER", _mockedMethods.acceptedSuggestion);
             Assert.Equal(4, _mockedMethods.commandHistory.Count);

--- a/test/ListPredictionTest.cs
+++ b/test/ListPredictionTest.cs
@@ -968,8 +968,8 @@ namespace Test
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, MiniSessionId, 1)),
                 CheckThat(() => _mockedMethods.ClearPredictionFields()),
                 _.DownArrow,
                      CheckThat(() => AssertScreenIs(5,
@@ -1070,8 +1070,8 @@ namespace Test
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, MiniSessionId, 1)),
                 CheckThat(() => Assert.Equal(predictorId_1, _mockedMethods.acceptedPredictorId)),
                 CheckThat(() => Assert.Equal("SOME TEXT BEFORE ec", _mockedMethods.acceptedSuggestion)),
                 CheckThat(() => Assert.Null(_mockedMethods.commandHistory)),
@@ -1147,8 +1147,8 @@ namespace Test
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, MiniSessionId, 1)),
                 CheckThat(() => Assert.Equal(predictorId_2, _mockedMethods.acceptedPredictorId)),
                 CheckThat(() => Assert.Equal("SOME NEW TEXT", _mockedMethods.acceptedSuggestion)),
                 CheckThat(() => Assert.Null(_mockedMethods.commandHistory)),
@@ -1270,8 +1270,8 @@ namespace Test
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, MiniSessionId, 1)),
                 CheckThat(() => _mockedMethods.ClearPredictionFields()),
                 _.DownArrow, _.Shift_Home,
                      CheckThat(() => AssertScreenIs(7,
@@ -1364,8 +1364,8 @@ namespace Test
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, MiniSessionId, 1)),
                 // Update the selected item won't trigger 'acceptance' callbacks if the item is from history.
                 CheckThat(() => Assert.Equal(Guid.Empty, _mockedMethods.acceptedPredictorId)),
                 CheckThat(() => Assert.Null(_mockedMethods.acceptedSuggestion)),
@@ -1449,8 +1449,8 @@ namespace Test
                         TokenClassification.None, new string(' ', windowWidth)
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, 56, 2)),
-                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, 56, 1)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
+                CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_2, MiniSessionId, 1)),
                 CheckThat(() => Assert.Equal(predictorId_2, _mockedMethods.acceptedPredictorId)),
                 CheckThat(() => Assert.Equal("SOME NEW TEXT", _mockedMethods.acceptedSuggestion)),
                 CheckThat(() => Assert.Null(_mockedMethods.commandHistory)),

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -5,7 +5,7 @@
     <OutputType>library</OutputType>
     <RootNamespace>UnitTestPSReadLine</RootNamespace>
     <AssemblyName>PSReadLine.Tests</AssemblyName>
-    <TargetFrameworks>net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <IsCodedUITest>False</IsCodedUITest>
@@ -23,8 +23,8 @@
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.0-preview.5" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.0-preview.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.0" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.0-preview.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -26,12 +26,14 @@ namespace Test
         internal Guid acceptedPredictorId;
         internal string acceptedSuggestion;
         internal string helpContentRendered;
+        internal Dictionary<Guid, Tuple<uint, int>> displayedSuggestions = new Dictionary<Guid, Tuple<uint, int>>();
 
         internal void ClearPredictionFields()
         {
             commandHistory = null;
             acceptedPredictorId = Guid.Empty;
             acceptedSuggestion = null;
+            displayedSuggestions.Clear();
         }
 
         public void Ding()
@@ -63,7 +65,12 @@ namespace Test
             commandHistory = history;
         }
 
-        public void OnSuggestionAccepted(Guid predictorId, string suggestionText)
+        public void OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex)
+        {
+            displayedSuggestions[predictorId] = Tuple.Create(session, countOrIndex);
+        }
+
+        public void OnSuggestionAccepted(Guid predictorId, uint session, string suggestionText)
         {
             acceptedPredictorId = predictorId;
             acceptedSuggestion = suggestionText;

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -1,5 +1,5 @@
 
-$MinimalSDKVersion = '5.0.100'
+$MinimalSDKVersion = '6.0.100'
 $IsWindowsEnv = [System.Environment]::OSVersion.Platform -eq "Win32NT"
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $LocalDotnetDirPath = if ($IsWindowsEnv) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -1,5 +1,5 @@
 
-$MinimalSDKVersion = '6.0.100'
+$MinimalSDKVersion = '6.0.100-preview.1.21103.13'
 $IsWindowsEnv = [System.Environment]::OSVersion.Platform -eq "Win32NT"
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $LocalDotnetDirPath = if ($IsWindowsEnv) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #2221

Major changes:
1. Update PSReadLine corresponding to the prediction interface update
    - provide the `OnSuggestionDisplayed` feedback
    - pass in the client-id `PSReadLine`, as well as the predictor mini-session id, when providing feedback.
2. Move to net6.0 and consume `PowerShell 7.2.0-preview.3` NuGet packages

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2225)