### PR TITLE
Prepare for the 2.2.0-beta2 release

### DIFF
--- a/MockPSConsole/MockPSConsole.csproj
+++ b/MockPSConsole/MockPSConsole.csproj
@@ -13,7 +13,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="System.Xml.XDocument" version="4.3.0" />
     <PackageReference Include="System.Data.DataSetExtensions" version="4.5.0" />
-    <PackageReference Include="Microsoft.CSharp" version="4.5.0" />
+    <PackageReference Include="Microsoft.CSharp" version="4.7.0" />
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0" />
   </ItemGroup>
 

--- a/PSReadLine/Changes.txt
+++ b/PSReadLine/Changes.txt
@@ -1,3 +1,26 @@
+### [2.2.0-beta2] - 2021-02-23
+
+- Update PSReadLine corresponding to the prediction interface updates (#2225)
+- Add white spaces to the emacs dispatch table (#2223)
+- Add the `SelectCommandArgument` bind-able function (#2222) (Thanks @ThePSAdmin for the idea!)
+- Move prediction functions to a new group (#2211)
+- Remove `LineIsMultiline` in favor of multi-line agnostic algorithms (#1125) (#2047) (Thanks @springcomp!)
+- Add the "Dynamic Help" feature to PSReadLine (#1777)
+- Prevent crash in `GotoFirstNonBlankOfLine` (#2050) (#2051) (Thanks @springcomp!)
+- Refactor the usage of `_clipboard` (#2022) (Thanks @springcomp!)
+- Make `d0` to delete to the start of the current logical line in a multiline buffer in VI mode (#2002) (Thanks @springcomp!)
+- Add github action to pre-triage new issues (#2117, #2118)
+- Highlight the install command in README.md (#2088) (Thanks @jiriurban21!)
+- Deleting backward to or until a character should preserve the character under the cursor (#2007) (Thanks @springcomp!)
+- Use `d^` to delete from the first non-blank character of a logical line (#2001) (Thanks @springcomp!)
+- Update nuget.config based on guidance (#2003)
+- Update the release build to use ESRP signing and unify the compliance job (#1983)
+- Add readonly modifier to some private fields (#1984)
+- Add argument selection handler to the sample profile (#1947) (Thanks @ThePSAdmin!)
+- Fix three issues with the menu completion (#1946)
+
+[2.2.0-beta2]: https://github.com/PowerShell/PSReadLine/compare/v2.2.0-beta1...v2.2.0-beta2
+
 ### Version 2.2.0-beta1
 
 Changes:

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -7,7 +7,7 @@
     <NoWarn>$(NoWarn);CA1416</NoWarn>
     <AssemblyVersion>2.2.0.0</AssemblyVersion>
     <FileVersion>2.2.0</FileVersion>
-    <InformationalVersion>2.2.0-beta1</InformationalVersion>
+    <InformationalVersion>2.2.0-beta2</InformationalVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
@@ -16,7 +16,8 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0" />
-    <PackageReference Include="Microsoft.CSharp" version="4.5.0" />
+    <PackageReference Include="Microsoft.CSharp" version="4.7.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
     <ProjectReference Include="..\Polyfill\Polyfill.csproj" />
   </ItemGroup>
 

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="System.Xml.XDocument" version="4.3.0" />
     <PackageReference Include="System.Data.DataSetExtensions" version="4.5.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
-    <PackageReference Include="Microsoft.CSharp" version="4.5.0" />
+    <PackageReference Include="Microsoft.CSharp" version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0" />
   </ItemGroup>

--- a/tools/releaseTools.psm1
+++ b/tools/releaseTools.psm1
@@ -1,0 +1,259 @@
+#requires -Version 6.0
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+class CommitNode {
+    [string] $Hash
+    [string[]] $Parents
+    [string] $AuthorName
+    [string] $AuthorGitHubLogin
+    [string] $AuthorEmail
+    [string] $Subject
+    [string] $Body
+    [string] $PullRequest
+    [string] $ChangeLogMessage
+    [string] $ThankYouMessage
+
+    CommitNode($hash, $parents, $name, $email, $subject, $body) {
+        $this.Hash = $hash
+        $this.Parents = $parents
+        $this.AuthorName = $name
+        $this.AuthorEmail = $email
+        $this.Subject = $subject
+        $this.Body = $body
+
+        if ($subject -match "\(#(\d+)\)$") {
+            $this.PullRequest = $Matches[1]
+        }
+    }
+}
+
+# These powershell team members don't use 'microsoft.com' for Github email or choose to not show their emails.
+# We have their names in this array so that we don't need to query GitHub to find out if they are powershell team members.
+$Script:powershell_team = @(
+    "Robert Holt"
+    "Travis Plunk"
+    "Joey Aiello"
+)
+
+# They are very active contributors, so we keep their email-login mappings here to save a few queries to Github.
+$Script:community_login_map = @{
+    "springcomp@users.noreply.github.com" = "springcomp"
+}
+
+# Ignore dependency bumping bot (Dependabot):
+$Script:attribution_ignore_list = @(
+    'dependabot[bot]@users.noreply.github.com'
+)
+
+##############################
+#.SYNOPSIS
+#In the release workflow, the release branch will be merged back to master after the release is done,
+#and a merge commit will be created as the child of the release tag commit.
+#This cmdlet takes a release tag or the corresponding commit hash, find its child merge commit, and
+#return its metadata in this format: <merge-commit-hash>|<parent-commit-hashes>
+#
+#.PARAMETER LastReleaseTag
+#The last release tag
+#
+#.PARAMETER CommitHash
+#The commit hash of the last release tag
+#
+#.OUTPUTS
+#Return the metadata of the child merge commit, in this format: <merge-commit-hash>|<parent-commit-hashes>
+##############################
+function Get-ChildMergeCommit
+{
+    [CmdletBinding(DefaultParameterSetName="TagName")]
+    param(
+        [Parameter(Mandatory, ParameterSetName="TagName")]
+        [string]$LastReleaseTag,
+
+        [Parameter(Mandatory, ParameterSetName="CommitHash")]
+        [string]$CommitHash
+    )
+
+    $tag_hash = $CommitHash
+    if ($PSCmdlet.ParameterSetName -eq "TagName") { $tag_hash = git rev-parse "$LastReleaseTag^0" }
+
+    ## Get the merge commits that are reachable from 'HEAD' but not from the release tag
+    $merge_commits_not_in_release_branch = git --no-pager log --merges "$tag_hash..HEAD" --format='%H||%P'
+    ## Find the child merge commit, whose parent-commit-hashes contains the release tag hash
+    $child_merge_commit = $merge_commits_not_in_release_branch | Select-String -SimpleMatch $tag_hash
+    return $child_merge_commit.Line
+}
+
+##############################
+#.SYNOPSIS
+#Create a CommitNode instance to represent a commit.
+#
+#.PARAMETER CommitMetadata
+#The commit metadata. It's in this format:
+#<commit-hash>|<parent-hashes>|<author-name>|<author-email>|<commit-subject>
+#
+#.PARAMETER CommitMetadata
+#The commit metadata, in this format:
+#<commit-hash>|<parent-hashes>|<author-name>|<author-email>|<commit-subject>
+#
+#.OUTPUTS
+#Return the 'CommitNode' object
+##############################
+function New-CommitNode
+{
+    param(
+        [Parameter(ValueFromPipeline)]
+        [ValidatePattern("^.+\|.+\|.+\|.+\|.+$")]
+        [string]$CommitMetadata
+    )
+
+    Process {
+        $hash, $parents, $name, $email, $subject = $CommitMetadata.Split("||")
+        $body = (git --no-pager show $hash -s --format=%b) -join "`n"
+        return [CommitNode]::new($hash, $parents, $name, $email, $subject, $body)
+    }
+}
+
+##############################
+#.SYNOPSIS
+#Generate the draft change log.
+#
+#.PARAMETER LastReleaseTag
+#The last release tag
+#
+#.PARAMETER HasCherryPick
+#Indicate whether there are any commits in the last release branch that were cherry-picked from the master branch
+#
+#.PARAMETER Token
+#The authentication token to use for retrieving the GitHub user log-in names for external contributors
+#
+#.OUTPUTS
+#The generated change log draft.
+##############################
+function Get-ChangeLog
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LastReleaseTag,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ThisReleaseTag,
+
+        [Parameter(Mandatory)]
+        [string]$Token,
+
+        [Parameter()]
+        [switch]$HasCherryPick
+    )
+
+    $tag_hash = git rev-parse "$LastReleaseTag^0"
+    $format = '%H||%P||%aN||%aE||%s'
+    $header = @{"Authorization"="token $Token"}
+
+    # Find the merge commit that merged the release branch to master.
+    $child_merge_commit = Get-ChildMergeCommit -CommitHash $tag_hash
+    if($child_merge_commit)
+    {
+        $commit_hash, $parent_hashes = $child_merge_commit.Split("||")
+    }
+    # Find the other parent of the merge commit, which represents the original head of master right before merging.
+    $other_parent_hash = ($parent_hashes -replace $tag_hash).Trim()
+
+    if ($HasCherryPick) {
+        ## Sometimes we need to cherry-pick some commits from the master branch to the release branch during the release,
+        ## and eventually merge the release branch back to the master branch. This will result in different commit nodes
+        ## in master branch that actually represent same set of changes.
+        ##
+        ## In this case, we cannot simply use the revision range "$tag_hash..HEAD" because it will include the original
+        ## commits in the master branch that were cherry-picked to the release branch -- they are reachable from 'HEAD'
+        ## but not reachable from the last release tag. Instead, we need to exclude the commits that were cherry-picked,
+        ## and only include the commits that are not in the last release into the change log.
+
+        # Find the commits that were only in the orginal master, excluding those that were cherry-picked to release branch.
+        $new_commits_from_other_parent = git --no-pager log --first-parent --cherry-pick --right-only "$tag_hash...$other_parent_hash" --format=$format | New-CommitNode
+        # Find the commits that were only in the release branch, excluding those that were cherry-picked from master branch.
+        $new_commits_from_last_release = git --no-pager log --first-parent --cherry-pick --left-only "$tag_hash...$other_parent_hash" --format=$format | New-CommitNode
+        # Find the commits that are actually duplicate but having different patch-ids due to resolving conflicts during the cherry-pick.
+        $duplicate_commits = $null
+        if($new_commits_from_last_release -and $new_commits_from_other_parent)
+        {
+            $duplicate_commits = Compare-Object $new_commits_from_last_release $new_commits_from_other_parent -Property PullRequest -ExcludeDifferent -IncludeEqual -PassThru
+        }
+        if ($duplicate_commits) {
+            $duplicate_pr_numbers = @($duplicate_commits | ForEach-Object -MemberName PullRequest)
+            $new_commits_from_other_parent = $new_commits_from_other_parent | Where-Object PullRequest -NotIn $duplicate_pr_numbers
+        }
+
+        # Find the commits that were made after the merge commit.
+        $new_commits_after_merge_commit = @(git --no-pager log --first-parent "$commit_hash..HEAD" --format=$format | New-CommitNode)
+        $new_commits = $new_commits_after_merge_commit + $new_commits_from_other_parent
+    } else {
+        ## No cherry-pick was involved in the last release branch.
+        ## Using a ref rang like "$tag_hash..HEAD" with 'git log' means getting the commits that are reachable from 'HEAD' but not reachable from the last release tag.
+
+        ## We use '--first-parent' for 'git log'. It means for any merge node, only follow the parent node on the master branch side.
+        ## In case we merge a branch to master for a PR, only the merge node will show up in this way, the individual commits from that branch will be ignored.
+        ## This is what we want because the merge commit itself already represents the PR.
+
+        ## First, we want to get all new commits merged during the last release
+        $new_commits_during_last_release = @(git --no-pager log --first-parent "$tag_hash..$other_parent_hash" --format=$format | New-CommitNode)
+        ## Then, we want to get all new commits merged after the last release
+        $new_commits_after_last_release  = @(git --no-pager log --first-parent "$commit_hash..HEAD" --format=$format | New-CommitNode)
+        ## Last, we get the full list of new commits
+        $new_commits = $new_commits_during_last_release + $new_commits_after_last_release
+    }
+
+    foreach ($commit in $new_commits) {
+        Write-Verbose "authorname: $($commit.AuthorName)"
+        if ($commit.AuthorEmail.EndsWith("@microsoft.com") -or $powershell_team -contains $commit.AuthorName -or $Script:attribution_ignore_list -contains $commit.AuthorEmail) {
+            $commit.ChangeLogMessage = "- {0}" -f (Get-ChangeLogMessage $commit.Subject)
+        } else {
+            if ($community_login_map.ContainsKey($commit.AuthorEmail)) {
+                $commit.AuthorGitHubLogin = $community_login_map[$commit.AuthorEmail]
+            } else {
+                $uri = "https://api.github.com/repos/PowerShell/PSReadLine/commits/$($commit.Hash)"
+                try{
+                    $response = Invoke-WebRequest -Uri $uri -Method Get -Headers $header -ErrorAction Ignore
+                } catch{}
+                if($response)
+                {
+                    $content = ConvertFrom-Json -InputObject $response.Content
+                    $commit.AuthorGitHubLogin = $content.author.login
+                    $community_login_map[$commit.AuthorEmail] = $commit.AuthorGitHubLogin
+                }
+            }
+            $commit.ChangeLogMessage = ("- {0} (Thanks @{1}!)" -f (Get-ChangeLogMessage $commit.Subject), $commit.AuthorGitHubLogin)
+            $commit.ThankYouMessage = ("@{0}" -f ($commit.AuthorGitHubLogin))
+        }
+    }
+
+    # Write output
+
+    $version = $ThisReleaseTag.TrimStart('v')
+    Write-Output "### [${version}] - $(Get-Date -Format yyyy-MM-dd)`n"
+
+    foreach ($commit in $new_commits) {
+        Write-Output $commit.ChangeLogMessage
+    }
+
+    Write-Output "`n[${version}]: https://github.com/PowerShell/PSReadLine/compare/${LastReleaseTag}...${ThisReleaseTag}`n"
+}
+
+function Get-ChangeLogMessage
+{
+    param($OriginalMessage)
+
+    switch -regEx ($OriginalMessage)
+    {
+        '^Merged PR (\d*): ' {
+            return $OriginalMessage.replace($Matches.0,'') + " (Internal $($Matches.1))"
+        }
+        '^Build\(deps\): ' {
+            return $OriginalMessage.replace($Matches.0,'')
+        }
+        default {
+            return $OriginalMessage
+        }
+    }
+}
+
+Export-ModuleMember -Function Get-ChangeLog


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Prepare for the 2.2.0-beta2 release.
- Update version and change log
- Use newer version of a couple NuGet packages
- Alter the `Get-ChangeLog` script from PowerShell repo to make it work for PSReadlLine release.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->
