### PR TITLE
Fix a null-ref exception in `DynamicHelpImpl`

### DIFF
--- a/PSReadLine/DynamicHelp.cs
+++ b/PSReadLine/DynamicHelp.cs
@@ -151,6 +151,9 @@ namespace Microsoft.PowerShell
             string commandName = null;
             string parameterName = null;
 
+            // Simply return if nothing is rendered yet.
+            if (_singleton._tokens == null) { return; }
+
             foreach(var token in _singleton._tokens)
             {
                 var extent = token.Extent;

--- a/test/DynamicHelpTest.cs
+++ b/test/DynamicHelpTest.cs
@@ -98,6 +98,13 @@ PARAMETERS
         }
 
         [SkippableFact]
+        public void DynHelp_GetFullHelp_OnEmptyLine()
+        {
+            TestSetup(KeyMode.Cmd);
+            Test("", Keys(_.F1, _.Enter));
+        }
+
+        [SkippableFact]
         public void DynHelp_GetFullHelp()
         {
             TestSetup(KeyMode.Cmd);
@@ -106,6 +113,13 @@ PARAMETERS
                 CheckThat(() => Assert.Equal(fullHelp, _mockedMethods.helpContentRendered)),
                 _.Enter
                 ));
+        }
+
+        [SkippableFact]
+        public void DynHelp_GetParameterHelp_OnEmptyLine()
+        {
+            TestSetup(KeyMode.Cmd);
+            Test("", Keys(_.Alt_h, _.Enter));
         }
 
         [SkippableFact]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #2283
Fix a null-ref exception in `DynamicHelpImpl`.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2292)