### PR TITLE
Update the use of the prediction interface to adapt to the breaking changes introduced in PowerShell 7.2.0-preview.6

### DIFF
--- a/MockPSConsole/MockPSConsole.csproj
+++ b/MockPSConsole/MockPSConsole.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.0-preview.3" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.0-preview.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MockPSConsole/Program.cs
+++ b/MockPSConsole/Program.cs
@@ -99,7 +99,7 @@ namespace MockPSConsole
                     ps.Commands.Clear();
                     Console.Write(string.Join("", ps.AddCommand("prompt").Invoke<string>()));
 
-                    var line = PSConsoleReadLine.ReadLine(rs, executionContext);
+                    var line = PSConsoleReadLine.ReadLine(rs, executionContext, lastRunStatus: null);
                     Console.WriteLine(line);
                     line = line.Trim();
                     if (line.Equals("exit"))

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.99" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.3" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.99" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.psm1
+++ b/PSReadLine/PSReadLine.psm1
@@ -1,5 +1,8 @@
 function PSConsoleHostReadLine
 {
+    ## Get the execution status of the last accepted user input.
+    ## This needs to be done as the first thing because any script run will flush $?.
+    $lastRunStatus = $?
     Microsoft.PowerShell.Core\Set-StrictMode -Off
-    [Microsoft.PowerShell.PSConsoleReadLine]::ReadLine($host.Runspace, $ExecutionContext)
+    [Microsoft.PowerShell.PSConsoleReadLine]::ReadLine($host.Runspace, $ExecutionContext, $lastRunStatus)
 }

--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -33,12 +33,12 @@ namespace Microsoft.PowerShell
             /// <summary>
             /// Gets whether to use plugin as a source.
             /// </summary>
-            protected bool UsePlugin => (_singleton._options.PredictionSource & PredictionSource.Plugin) != 0;
+            internal bool UsePlugin => (_singleton._options.PredictionSource & PredictionSource.Plugin) != 0;
 
             /// <summary>
             /// Gets whether to use history as a source.
             /// </summary>
-            protected bool UseHistory => (_singleton._options.PredictionSource & PredictionSource.History) != 0;
+            internal bool UseHistory => (_singleton._options.PredictionSource & PredictionSource.History) != 0;
 
             /// <summary>
             /// Gets whether an update to the view is pending.
@@ -78,17 +78,6 @@ namespace Microsoft.PowerShell
             {
                 _inputText = null;
                 _predictionTask = null;
-            }
-
-            /// <summary>
-            /// Get called when a command line is accepted.
-            /// </summary>
-            internal void OnCommandLineAccepted(string commandLine)
-            {
-                if (UsePlugin && !string.IsNullOrWhiteSpace(commandLine))
-                {
-                    _singleton._mockableMethods.OnCommandLineAccepted(_singleton._recentHistory.ToArray());
-                }
             }
 
             /// <summary>

--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
-using System.Management.Automation.Subsystem;
+using System.Management.Automation.Subsystem.Prediction;
 using Microsoft.PowerShell.Internal;
 
 namespace Microsoft.PowerShell
@@ -182,7 +182,7 @@ namespace Microsoft.PowerShell
             /// </summary>
             protected void PredictInput()
             {
-                _predictionTask = _singleton._mockableMethods.PredictInput(_singleton._ast, _singleton._tokens);
+                _predictionTask = _singleton._mockableMethods.PredictInputAsync(_singleton._ast, _singleton._tokens);
             }
 
             /// <summary>

--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -45,9 +45,9 @@ namespace Microsoft.PowerShell
         }
 
         [ExcludeFromCodeCoverage]
-        void IPSConsoleReadLineMockableMethods.OnCommandLineExecuted(string commandLine, bool status)
+        void IPSConsoleReadLineMockableMethods.OnCommandLineExecuted(string commandLine, bool success)
         {
-            CommandPrediction.OnCommandLineExecuted(s_predictionClient, commandLine, status);
+            CommandPrediction.OnCommandLineExecuted(s_predictionClient, commandLine, success);
         }
 
         private readonly Prediction _prediction;

--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -17,33 +17,49 @@ namespace Microsoft.PowerShell
     public partial class PSConsoleReadLine
     {
         private const string PSReadLine = "PSReadLine";
+        private static PredictionClient s_predictionClient = new(PSReadLine, PredictionClient.ClientKind.Terminal);
 
         // Stub helper methods so prediction can be mocked
         [ExcludeFromCodeCoverage]
         Task<List<PredictionResult>> IPSConsoleReadLineMockableMethods.PredictInput(Ast ast, Token[] tokens)
         {
-            return CommandPrediction.PredictInput(PSReadLine, ast, tokens);
+            return CommandPrediction.PredictInput(s_predictionClient, ast, tokens);
         }
 
         [ExcludeFromCodeCoverage]
         void IPSConsoleReadLineMockableMethods.OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex)
         {
-            CommandPrediction.OnSuggestionDisplayed(PSReadLine, predictorId, session, countOrIndex);
+            CommandPrediction.OnSuggestionDisplayed(s_predictionClient, predictorId, session, countOrIndex);
         }
 
         [ExcludeFromCodeCoverage]
         void IPSConsoleReadLineMockableMethods.OnSuggestionAccepted(Guid predictorId, uint session, string suggestionText)
         {
-            CommandPrediction.OnSuggestionAccepted(PSReadLine, predictorId, session, suggestionText);
+            CommandPrediction.OnSuggestionAccepted(s_predictionClient, predictorId, session, suggestionText);
         }
 
         [ExcludeFromCodeCoverage]
         void IPSConsoleReadLineMockableMethods.OnCommandLineAccepted(IReadOnlyList<string> history)
         {
-            CommandPrediction.OnCommandLineAccepted(PSReadLine, history);
+            CommandPrediction.OnCommandLineAccepted(s_predictionClient, history);
+        }
+
+        [ExcludeFromCodeCoverage]
+        void IPSConsoleReadLineMockableMethods.OnCommandLineExecuted(string commandLine, bool status)
+        {
+            CommandPrediction.OnCommandLineExecuted(s_predictionClient, commandLine, status);
         }
 
         private readonly Prediction _prediction;
+
+        /// <summary>
+        /// Report the execution result (success or failure) of the last accepted command line.
+        /// </summary>
+        /// <param name="status"></param>
+        private void ReportExecutionStatus(bool status)
+        {
+            _prediction.OnCommandLineExecuted(_acceptedCommandLine, status);
+        }
 
         /// <summary>
         /// Accept the suggestion text if there is one.
@@ -380,6 +396,28 @@ namespace Microsoft.PowerShell
                 }
 
                 return retValue;
+            }
+
+            /// <summary>
+            /// Get called when a command line is accepted.
+            /// </summary>
+            internal void OnCommandLineAccepted(string commandLine)
+            {
+                if (ActiveView.UsePlugin && !string.IsNullOrWhiteSpace(commandLine))
+                {
+                    _singleton._mockableMethods.OnCommandLineAccepted(_singleton._recentHistory.ToArray());
+                }
+            }
+
+            /// <summary>
+            /// Get called when the last accepted command line finished execution.
+            /// </summary>
+            internal void OnCommandLineExecuted(string commandLine, bool status)
+            {
+                if (ActiveView.UsePlugin && !string.IsNullOrWhiteSpace(commandLine))
+                {
+                    _singleton._mockableMethods.OnCommandLineExecuted(commandLine, status);
+                }
             }
         }
     }

--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Management.Automation;
 using System.Management.Automation.Language;
-using System.Management.Automation.Subsystem;
+using System.Management.Automation.Subsystem.Prediction;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.PowerShell.Internal;
 using Microsoft.PowerShell.PSReadLine;
@@ -17,13 +17,13 @@ namespace Microsoft.PowerShell
     public partial class PSConsoleReadLine
     {
         private const string PSReadLine = "PSReadLine";
-        private static PredictionClient s_predictionClient = new(PSReadLine, PredictionClient.ClientKind.Terminal);
+        private static PredictionClient s_predictionClient = new(PSReadLine, PredictionClientKind.Terminal);
 
         // Stub helper methods so prediction can be mocked
         [ExcludeFromCodeCoverage]
-        Task<List<PredictionResult>> IPSConsoleReadLineMockableMethods.PredictInput(Ast ast, Token[] tokens)
+        Task<List<PredictionResult>> IPSConsoleReadLineMockableMethods.PredictInputAsync(Ast ast, Token[] tokens)
         {
-            return CommandPrediction.PredictInput(s_predictionClient, ast, tokens);
+            return CommandPrediction.PredictInputAsync(s_predictionClient, ast, tokens);
         }
 
         [ExcludeFromCodeCoverage]
@@ -55,10 +55,10 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Report the execution result (success or failure) of the last accepted command line.
         /// </summary>
-        /// <param name="status"></param>
-        private void ReportExecutionStatus(bool status)
+        /// <param name="success">Whether the execution was successful.</param>
+        private void ReportExecutionStatus(bool success)
         {
-            _prediction.OnCommandLineExecuted(_acceptedCommandLine, status);
+            _prediction.OnCommandLineExecuted(_acceptedCommandLine, success);
         }
 
         /// <summary>
@@ -412,11 +412,11 @@ namespace Microsoft.PowerShell
             /// <summary>
             /// Get called when the last accepted command line finished execution.
             /// </summary>
-            internal void OnCommandLineExecuted(string commandLine, bool status)
+            internal void OnCommandLineExecuted(string commandLine, bool success)
             {
                 if (ActiveView.UsePlugin && !string.IsNullOrWhiteSpace(commandLine))
                 {
-                    _singleton._mockableMethods.OnCommandLineExecuted(commandLine, status);
+                    _singleton._mockableMethods.OnCommandLineExecuted(commandLine, success);
                 }
             }
         }

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -9,7 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
-using System.Management.Automation.Subsystem;
+using System.Management.Automation.Subsystem.Prediction;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.PSReadLine;
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell
             void Ding();
             CommandCompletion CompleteInput(string input, int cursorIndex, Hashtable options, System.Management.Automation.PowerShell powershell);
             bool RunspaceIsRemote(Runspace runspace);
-            Task<List<PredictionResult>> PredictInput(Ast ast, Token[] tokens);
+            Task<List<PredictionResult>> PredictInputAsync(Ast ast, Token[] tokens);
             void OnCommandLineAccepted(IReadOnlyList<string> history);
             void OnCommandLineExecuted(string commandLine, bool status);
             void OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex);

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -28,6 +28,7 @@ namespace Microsoft.PowerShell
             bool RunspaceIsRemote(Runspace runspace);
             Task<List<PredictionResult>> PredictInput(Ast ast, Token[] tokens);
             void OnCommandLineAccepted(IReadOnlyList<string> history);
+            void OnCommandLineExecuted(string commandLine, bool status);
             void OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex);
             void OnSuggestionAccepted(Guid predictorId, uint session, string suggestionText);
             void RenderFullHelp(string content, string regexPatternToScrollTo);

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell
             bool RunspaceIsRemote(Runspace runspace);
             Task<List<PredictionResult>> PredictInputAsync(Ast ast, Token[] tokens);
             void OnCommandLineAccepted(IReadOnlyList<string> history);
-            void OnCommandLineExecuted(string commandLine, bool status);
+            void OnCommandLineExecuted(string commandLine, bool success);
             void OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex);
             void OnSuggestionAccepted(Guid predictorId, uint session, string suggestionText);
             void RenderFullHelp(string content, string regexPatternToScrollTo);

--- a/Polyfill/CommandPrediction.cs
+++ b/Polyfill/CommandPrediction.cs
@@ -7,6 +7,49 @@ using System.Management.Automation.Language;
 namespace System.Management.Automation.Subsystem
 {
     /// <summary>
+    /// The class represents a client that interacts with predictors.
+    /// </summary>
+    public class PredictionClient
+    {
+        /// <summary>
+        /// Kinds of the client.
+        /// </summary>
+        public enum ClientKind
+        {
+            /// <summary>
+            /// A terminal client, representing the command-line experience.
+            /// </summary>
+            Terminal,
+
+            /// <summary>
+            /// An editor client, representing the editor experience.
+            /// </summary>
+            Editor,
+        }
+
+        /// <summary>
+        /// Gets the client name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the client kind.
+        /// </summary>
+        public ClientKind Kind { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PredictionClient"/> class.
+        /// </summary>
+        /// <param name="name">Name of the interactive client.</param>
+        /// <param name="kind">Kind of the interactive client.</param>
+        public PredictionClient(string name, ClientKind kind)
+        {
+            Name = name;
+            Kind = kind;
+        }
+    }
+
+    /// <summary>
     /// The class represents the prediction result from a predictor.
     /// </summary>
     public sealed class PredictionResult
@@ -103,7 +146,7 @@ namespace System.Management.Automation.Subsystem
         /// <param name="astTokens">The <see cref="Token"/> objects from parsing the current command line input.</param>
         /// <returns>A list of <see cref="PredictionResult"/> objects.</returns>
         [HiddenAttribute]
-        public static Task<List<PredictionResult>> PredictInput(string client, Ast ast, Token[] astTokens)
+        public static Task<List<PredictionResult>> PredictInput(PredictionClient client, Ast ast, Token[] astTokens)
         {
             return null;
         }
@@ -117,7 +160,7 @@ namespace System.Management.Automation.Subsystem
         /// <param name="millisecondsTimeout">The milliseconds to timeout.</param>
         /// <returns>A list of <see cref="PredictionResult"/> objects.</returns>
         [HiddenAttribute]
-        public static Task<List<PredictionResult>> PredictInput(string client, Ast ast, Token[] astTokens, int millisecondsTimeout)
+        public static Task<List<PredictionResult>> PredictInput(PredictionClient client, Ast ast, Token[] astTokens, int millisecondsTimeout)
         {
             return null;
         }
@@ -128,7 +171,18 @@ namespace System.Management.Automation.Subsystem
         /// <param name="client">Represents the client that initiates the call.</param>
         /// <param name="history">History command lines provided as references for prediction.</param>
         [HiddenAttribute]
-        public static void OnCommandLineAccepted(string client, IReadOnlyList<string> history)
+        public static void OnCommandLineAccepted(PredictionClient client, IReadOnlyList<string> history)
+        {
+        }
+
+        /// <summary>
+        /// Allow registered predictors to know the execution result (success/failure) of the last accepted command line.
+        /// </summary>
+        /// <param name="client">Represents the client that initiates the call.</param>
+        /// <param name="commandLine">The last accepted command line.</param>
+        /// <param name="status">The execution status of the last command line. True for success, False for failure</param>
+        [HiddenAttribute]
+        public static void OnCommandLineExecuted(PredictionClient client, string commandLine, bool status)
         {
         }
 
@@ -143,7 +197,7 @@ namespace System.Management.Automation.Subsystem
         /// When the value is <code><= 0</code>, it means a single suggestion from the list got displayed, and the index is the absolute value.
         /// </param>
         [HiddenAttribute]
-        public static void OnSuggestionDisplayed(string client, Guid predictorId, uint session, int countOrIndex)
+        public static void OnSuggestionDisplayed(PredictionClient client, Guid predictorId, uint session, int countOrIndex)
         {
         }
 
@@ -155,7 +209,7 @@ namespace System.Management.Automation.Subsystem
         /// <param name="session">The mini-session where the accepted suggestion came from.</param>
         /// <param name="suggestionText">The accepted suggestion text.</param>
         [HiddenAttribute]
-        public static void OnSuggestionAccepted(string client, Guid predictorId, uint session, string suggestionText)
+        public static void OnSuggestionAccepted(PredictionClient client, Guid predictorId, uint session, string suggestionText)
         {
         }
     }

--- a/Polyfill/CommandPrediction.cs
+++ b/Polyfill/CommandPrediction.cs
@@ -4,29 +4,29 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Management.Automation.Language;
 
-namespace System.Management.Automation.Subsystem
+namespace System.Management.Automation.Subsystem.Prediction
 {
+    /// <summary>
+    /// Kinds of prediction clients.
+    /// </summary>
+    public enum PredictionClientKind
+    {
+        /// <summary>
+        /// A terminal client, representing the command-line experience.
+        /// </summary>
+        Terminal,
+
+        /// <summary>
+        /// An editor client, representing the editor experience.
+        /// </summary>
+        Editor,
+    }
+
     /// <summary>
     /// The class represents a client that interacts with predictors.
     /// </summary>
     public class PredictionClient
     {
-        /// <summary>
-        /// Kinds of the client.
-        /// </summary>
-        public enum ClientKind
-        {
-            /// <summary>
-            /// A terminal client, representing the command-line experience.
-            /// </summary>
-            Terminal,
-
-            /// <summary>
-            /// An editor client, representing the editor experience.
-            /// </summary>
-            Editor,
-        }
-
         /// <summary>
         /// Gets the client name.
         /// </summary>
@@ -35,14 +35,14 @@ namespace System.Management.Automation.Subsystem
         /// <summary>
         /// Gets the client kind.
         /// </summary>
-        public ClientKind Kind { get; }
+        public PredictionClientKind Kind { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PredictionClient"/> class.
         /// </summary>
         /// <param name="name">Name of the interactive client.</param>
         /// <param name="kind">Kind of the interactive client.</param>
-        public PredictionClient(string name, ClientKind kind)
+        public PredictionClient(string name, PredictionClientKind kind)
         {
             Name = name;
             Kind = kind;
@@ -146,7 +146,7 @@ namespace System.Management.Automation.Subsystem
         /// <param name="astTokens">The <see cref="Token"/> objects from parsing the current command line input.</param>
         /// <returns>A list of <see cref="PredictionResult"/> objects.</returns>
         [HiddenAttribute]
-        public static Task<List<PredictionResult>> PredictInput(PredictionClient client, Ast ast, Token[] astTokens)
+        public static Task<List<PredictionResult>> PredictInputAsync(PredictionClient client, Ast ast, Token[] astTokens)
         {
             return null;
         }
@@ -160,7 +160,7 @@ namespace System.Management.Automation.Subsystem
         /// <param name="millisecondsTimeout">The milliseconds to timeout.</param>
         /// <returns>A list of <see cref="PredictionResult"/> objects.</returns>
         [HiddenAttribute]
-        public static Task<List<PredictionResult>> PredictInput(PredictionClient client, Ast ast, Token[] astTokens, int millisecondsTimeout)
+        public static Task<List<PredictionResult>> PredictInputAsync(PredictionClient client, Ast ast, Token[] astTokens, int millisecondsTimeout)
         {
             return null;
         }
@@ -180,9 +180,9 @@ namespace System.Management.Automation.Subsystem
         /// </summary>
         /// <param name="client">Represents the client that initiates the call.</param>
         /// <param name="commandLine">The last accepted command line.</param>
-        /// <param name="status">The execution status of the last command line. True for success, False for failure</param>
+        /// <param name="success">Whether the execution of the last command line was successful.</param>
         [HiddenAttribute]
-        public static void OnCommandLineExecuted(PredictionClient client, string commandLine, bool status)
+        public static void OnCommandLineExecuted(PredictionClient client, string commandLine, bool success)
         {
         }
 
@@ -217,9 +217,11 @@ namespace System.Management.Automation.Subsystem
 
 #else
 
-using System.Management.Automation.Subsystem;
+using System.Management.Automation.Subsystem.Prediction;
 using System.Runtime.CompilerServices;
 
+[assembly: TypeForwardedTo(typeof(PredictionClientKind))]
+[assembly: TypeForwardedTo(typeof(PredictionClient))]
 [assembly: TypeForwardedTo(typeof(PredictiveSuggestion))]
 [assembly: TypeForwardedTo(typeof(PredictionResult))]
 [assembly: TypeForwardedTo(typeof(CommandPrediction))]

--- a/Polyfill/CommandPrediction.cs
+++ b/Polyfill/CommandPrediction.cs
@@ -25,16 +25,18 @@ namespace System.Management.Automation.Subsystem.Prediction
     /// <summary>
     /// The class represents a client that interacts with predictors.
     /// </summary>
-    public class PredictionClient
+    public sealed class PredictionClient
     {
         /// <summary>
         /// Gets the client name.
         /// </summary>
+        [HiddenAttribute]
         public string Name { get; }
 
         /// <summary>
         /// Gets the client kind.
         /// </summary>
+        [HiddenAttribute]
         public PredictionClientKind Kind { get; }
 
         /// <summary>
@@ -42,6 +44,7 @@ namespace System.Management.Automation.Subsystem.Prediction
         /// </summary>
         /// <param name="name">Name of the interactive client.</param>
         /// <param name="kind">Kind of the interactive client.</param>
+        [HiddenAttribute]
         public PredictionClient(string name, PredictionClientKind kind)
         {
             Name = name;

--- a/Polyfill/Polyfill.csproj
+++ b/Polyfill/Polyfill.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.3" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.99" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/Polyfill/Polyfill.csproj
+++ b/Polyfill/Polyfill.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.99" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.6" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="local" value="C:\arena\tmp\NugetPackages" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="local" value="C:\arena\tmp\NugetPackages" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>

--- a/test/InlinePredictionTest.cs
+++ b/test/InlinePredictionTest.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation.Language;
-using System.Management.Automation.Subsystem;
+using System.Management.Automation.Subsystem.Prediction;
 using System.Reflection;
 using Microsoft.PowerShell;
 using Xunit;

--- a/test/InlinePredictionTest.cs
+++ b/test/InlinePredictionTest.cs
@@ -566,5 +566,136 @@ namespace Test
             Assert.Equal(1, _mockedMethods.commandHistory.Count);
             Assert.Equal("netsh show me", _mockedMethods.commandHistory[0]);
         }
+
+        [SkippableFact]
+        public void Inline_NoneSource_ExecutionStatus()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var disp = SetPrediction(PredictionSource.None, PredictionViewStyle.InlineView);
+
+            // The last accepted command line would be "yay" after this.
+            Test("yay", Keys("yay"));
+            _mockedMethods.ClearPredictionFields();
+
+            // We always pass in 'true' as the execution status of the last command line,
+            // and that feedback will be reported when
+            //  1. the plugin source is in use;
+            //  2. the last accepted command is not a whitespace string.
+            Test("   ", Keys(
+                // Since we set the prediction source to be 'None', this feedback won't be reported.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "   "));
+
+            Test("abc", Keys(
+                // The prediction source is 'None', and the last accepted command is a whitespace string,
+                // so this feedback won't be reported.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "abc"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+        }
+
+        [SkippableFact]
+        public void Inline_HistorySource_ExecutionStatus()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.InlineView);
+
+            // The last accepted command line would be "yay" after this.
+            Test("yay", Keys("yay"));
+            _mockedMethods.ClearPredictionFields();
+
+            // We always pass in 'true' as the execution status of the last command line,
+            // and that feedback will be reported when
+            //  1. the plugin source is in use;
+            //  2. the last accepted command is not a whitespace string.
+            Test("   ", Keys(
+                // Since we set the prediction source to be 'History', this feedback won't be reported.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "   "));
+
+            Test("abc", Keys(
+                // The plugin source is in use, but the last accepted command is a whitespace string.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "abc"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+        }
+
+        [SkippableFact]
+        public void Inline_PluginSource_ExecutionStatus()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var disp = SetPrediction(PredictionSource.Plugin, PredictionViewStyle.InlineView);
+
+            // The last accepted command line would be an empty string after this.
+            Test("", Keys(_.Enter));
+            _mockedMethods.ClearPredictionFields();
+
+            // We always pass in 'true' as the execution status of the last command line,
+            // and that feedback will be reported when
+            //  1. the plugin source is in use;
+            //  2. the last accepted command is not a whitespace string.
+            Test("yay", Keys(
+                // The plugin source is in use, but the last accepted command is an empty string.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "yay"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+
+            // The last accepted command line would be a whitespace string with 3 space characters after this.
+            Test("   ", Keys(
+                // The plugin source is in use, and the last accepted command is "yay".
+                CheckThat(() => Assert.True(_mockedMethods.lastCommandRunStatus)),
+                "   "));
+
+            Assert.True(_mockedMethods.lastCommandRunStatus);
+            _mockedMethods.ClearPredictionFields();
+
+            Test("abc", Keys(
+                // The plugin source is in use, but the last accepted command is a whitespace string.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "abc"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+        }
+
+        [SkippableFact]
+        public void Inline_HistoryAndPluginSource_ExecutionStatus()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var disp = SetPrediction(PredictionSource.HistoryAndPlugin, PredictionViewStyle.InlineView);
+
+            // The last accepted command line would be an empty string after this.
+            Test("", Keys(_.Enter));
+            _mockedMethods.ClearPredictionFields();
+
+            // We always pass in 'true' as the execution status of the last command line,
+            // and that feedback will be reported when
+            //  1. the plugin source is in use;
+            //  2. the last accepted command is not a whitespace string.
+            Test("yay", Keys(
+                // The plugin source is in use, but the last accepted command is an empty string.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "yay"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+
+            // The last accepted command line would be a whitespace string with 3 space characters after this.
+            Test("   ", Keys(
+                // The plugin source is in use, and the last accepted command is "yay".
+                CheckThat(() => Assert.True(_mockedMethods.lastCommandRunStatus)),
+                "   "));
+
+            Assert.True(_mockedMethods.lastCommandRunStatus);
+            _mockedMethods.ClearPredictionFields();
+
+            Test("abc", Keys(
+                // The plugin source is in use, but the last accepted command is a whitespace string.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "abc"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+        }
     }
 }

--- a/test/ListPredictionTest.cs
+++ b/test/ListPredictionTest.cs
@@ -1509,5 +1509,137 @@ namespace Test
             Assert.Equal("eca -zoo", _mockedMethods.commandHistory[2]);
             Assert.Equal("SOME NEW TEX SOME TEXT AFTER", _mockedMethods.commandHistory[3]);
         }
+
+        [SkippableFact]
+        public void List_NoneSource_ExecutionStatus()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var disp = SetPrediction(PredictionSource.None, PredictionViewStyle.ListView);
+
+            // The last accepted command line would be "yay" after this.
+            Test("yay", Keys("yay"));
+            _mockedMethods.ClearPredictionFields();
+
+            // We always pass in 'true' as the execution status of the last command line,
+            // and that feedback will be reported when
+            //  1. the plugin source is in use;
+            //  2. the last accepted command is not a whitespace string.
+            Test("   ", Keys(
+                // Since we set the prediction source to be 'None', this feedback won't be reported.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "   "));
+
+            Test("abc", Keys(
+                // The prediction source is 'None', and the last accepted command is a whitespace string,
+                // so this feedback won't be reported.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "abc"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+        }
+
+        [SkippableFact]
+        public void List_HistorySource_ExecutionStatus()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.InlineView);
+
+            // The last accepted command line would be "yay" after this.
+            Test("yay", Keys("yay"));
+            _mockedMethods.ClearPredictionFields();
+
+            // We always pass in 'true' as the execution status of the last command line,
+            // and that feedback will be reported when
+            //  1. the plugin source is in use;
+            //  2. the last accepted command is not a whitespace string.
+            Test("   ", Keys(
+                // Since we set the prediction source to be 'History', this feedback won't be reported.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "   "));
+
+            Test("abc", Keys(
+                // The prediction source is 'History', and the last accepted command is a whitespace string,
+                // so this feedback won't be reported.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "abc"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+        }
+
+        [SkippableFact]
+        public void List_PluginSource_ExecutionStatus()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var disp = SetPrediction(PredictionSource.Plugin, PredictionViewStyle.InlineView);
+
+            // The last accepted command line would be an empty string after this.
+            Test("", Keys(_.Enter));
+            _mockedMethods.ClearPredictionFields();
+
+            // We always pass in 'true' as the execution status of the last command line,
+            // and that feedback will be reported when
+            //  1. the plugin source is in use;
+            //  2. the last accepted command is not a whitespace string.
+            Test("yay", Keys(
+                // The plugin source is in use, but the last accepted command is an empty string.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "yay"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+
+            // The last accepted command line would be a whitespace string with 3 space characters after this.
+            Test("   ", Keys(
+                // The plugin source is in use, and the last accepted command is "yay".
+                CheckThat(() => Assert.True(_mockedMethods.lastCommandRunStatus)),
+                "   "));
+
+            Assert.True(_mockedMethods.lastCommandRunStatus);
+            _mockedMethods.ClearPredictionFields();
+
+            Test("abc", Keys(
+                // The plugin source is in use, but the last accepted command is a whitespace string.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "abc"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+        }
+
+        [SkippableFact]
+        public void List_HistoryAndPluginSource_ExecutionStatus()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var disp = SetPrediction(PredictionSource.HistoryAndPlugin, PredictionViewStyle.InlineView);
+
+            // The last accepted command line would be an empty string after this.
+            Test("", Keys(_.Enter));
+            _mockedMethods.ClearPredictionFields();
+
+            // We always pass in 'true' as the execution status of the last command line,
+            // and that feedback will be reported when
+            //  1. the plugin source is in use;
+            //  2. the last accepted command is not a whitespace string.
+            Test("yay", Keys(
+                // The plugin source is in use, but the last accepted command is an empty string.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "yay"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+
+            // The last accepted command line would be a whitespace string with 3 space characters after this.
+            Test("   ", Keys(
+                // The plugin source is in use, and the last accepted command is "yay".
+                CheckThat(() => Assert.True(_mockedMethods.lastCommandRunStatus)),
+                "   "));
+
+            Assert.True(_mockedMethods.lastCommandRunStatus);
+            _mockedMethods.ClearPredictionFields();
+
+            Test("abc", Keys(
+                // The plugin source is in use, but the last accepted command is a whitespace string.
+                CheckThat(() => Assert.Null(_mockedMethods.lastCommandRunStatus)),
+                "abc"));
+
+            Assert.Null(_mockedMethods.lastCommandRunStatus);
+        }
     }
 }

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.0-preview.3" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.0-preview.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -23,6 +23,7 @@ namespace Test
     {
         internal bool didDing;
         internal IReadOnlyList<string> commandHistory;
+        internal bool? lastCommandRunStatus;
         internal Guid acceptedPredictorId;
         internal string acceptedSuggestion;
         internal string helpContentRendered;
@@ -31,6 +32,7 @@ namespace Test
         internal void ClearPredictionFields()
         {
             commandHistory = null;
+            lastCommandRunStatus = null;
             acceptedPredictorId = Guid.Empty;
             acceptedSuggestion = null;
             displayedSuggestions.Clear();
@@ -63,6 +65,11 @@ namespace Test
         public void OnCommandLineAccepted(IReadOnlyList<string> history)
         {
             commandHistory = history;
+        }
+
+        public void OnCommandLineExecuted(string commandLine, bool status)
+        {
+            lastCommandRunStatus = status;
         }
 
         public void OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex)
@@ -474,7 +481,10 @@ namespace Test
 
             _console.Init(items);
 
-            var result = PSConsoleReadLine.ReadLine(null, null);
+            var result = PSConsoleReadLine.ReadLine(
+                runspace: null,
+                engineIntrinsics: null,
+                lastRunStatus: true);
 
             if (_console.validationFailure != null)
             {

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -67,9 +67,9 @@ namespace Test
             commandHistory = history;
         }
 
-        public void OnCommandLineExecuted(string commandLine, bool status)
+        public void OnCommandLineExecuted(string commandLine, bool success)
         {
-            lastCommandRunStatus = status;
+            lastCommandRunStatus = success;
         }
 
         public void OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex)

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
-using System.Management.Automation.Subsystem;
+using System.Management.Automation.Subsystem.Prediction;
 using System.Threading.Tasks;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -53,7 +53,7 @@ namespace Test
             return false;
         }
 
-        public Task<List<PredictionResult>> PredictInput(Ast ast, Token[] tokens)
+        public Task<List<PredictionResult>> PredictInputAsync(Ast ast, Token[] tokens)
         {
             var result = ReadLine.MockedPredictInput(ast, tokens);
             var source = new TaskCompletionSource<List<PredictionResult>>();


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #2495
Update the use of the prediction interface to adapt to the breaking changes introduced in PowerShell 7.2.0-preview.6.

1. Use a `PredictionClient` instance to represent the client information. Today it includes the client name and the client type.
2. Send the feedback about the execution result of the last accepted command (success or failure).

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2524)