### PR TITLE
Temporarily add back the API that is depended by PSES

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -311,6 +311,15 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
+        /// Temporary entry point for PowerShell VSCode extension to avoid breaking the existing PSES.
+        /// PSES will need to move away from this entry point to actually provide information about 'lastRunStatus'.
+        /// </summary>
+        public static string ReadLine(Runspace runspace, EngineIntrinsics engineIntrinsics, CancellationToken cancellationToken)
+        {
+            return ReadLine(runspace, engineIntrinsics, _defaultCancellationToken, lastRunStatus: null);
+        }
+
+        /// <summary>
         /// Entry point - called by custom PSHost implementations that require the
         /// ability to cancel ReadLine.
         /// </summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Temporarily add back the API that is depended by PSES, so that the 2.2.0-beta3 release of PSReadLine can work with the existing PowerShell VSCode extensions.

We will remove the API after PSES locks to the PSReadLine version that is bundled with it.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2533)