### PR TITLE
Don't ignore ConsoleKey.Packet type as that is simply Unicode

### DIFF
--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -215,7 +215,7 @@ namespace Microsoft.PowerShell
                 // Keys I'm not familiar with, presumably we'd want to ignore.
                 case ConsoleKey.Clear: case ConsoleKey.Pause: case ConsoleKey.Select: case ConsoleKey.Print:
                 case ConsoleKey.Execute: case ConsoleKey.Help: case ConsoleKey.Sleep: case ConsoleKey.Process:
-                case ConsoleKey.Packet: case ConsoleKey.Attention: case ConsoleKey.CrSel: case ConsoleKey.ExSel:
+                case ConsoleKey.Attention: case ConsoleKey.CrSel: case ConsoleKey.ExSel:
                 case ConsoleKey.EraseEndOfFile: case ConsoleKey.Play: case ConsoleKey.Zoom: case ConsoleKey.NoName:
                 case ConsoleKey.Pa1:
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When using IOS Remote Desktop client, the virtual keyboard sends keypresses as ConsoleKey.Packet which per [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.consolekey?view=net-5.0) is used to pass Unicode characters, so we should not be ignoring those.  The previous code ignored this, so those characters were dropped.  Tested manually.

Fix https://github.com/PowerShell/PSReadLine/issues/1428

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2632)