### PR TITLE
Migrate the release build to use the 1ES agent pool and also fix the API scan

### DIFF
--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -133,6 +133,8 @@ stages:
   jobs:
   - job: Compliance_Job
     displayName: PSReadLine Compliance
+    variables:
+      - group: APIScan
     # APIScan can take a long time
     timeoutInMinutes: 240
 
@@ -178,3 +180,4 @@ stages:
         softwareFolder: '$(Pipeline.Workspace)\PSReadLine'
         softwareName: 'PSReadLine'
         softwareVersion: '$(ModuleVersion)'
+        connectionString: 'RunAs=App;AppId=$(APIScanClient);TenantId=$(APIScanTenant);AppKey=$(APIScanSecret)'

--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -41,7 +41,7 @@ stages:
         Write-Host "PS Version: $($($PSVersionTable.PSVersion))"
         Set-Location -Path '$(Build.SourcesDirectory)\PSReadLine'
         .\build.ps1 -Bootstrap
-        .\build.ps1 -Configuration Release -Framework net461 -CheckHelpContent
+        .\build.ps1 -Configuration Release -Framework net461
 
         # Set target folder paths
         New-Item -Path .\bin\Release\NuGetPackage -ItemType Directory > $null

--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -1,8 +1,6 @@
 name: PSReadLine-ModuleBuild-$(Build.BuildId)
-trigger:
-  branches:
-    include:
-    - master
+trigger: none
+pr: none
 
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -20,7 +18,9 @@ stages:
 - stage: Build
   displayName: Build and Sign
   pool:
-    name: Package ES CodeHub Lab E
+    name: 1ES
+    demands:
+    - ImageOverride -equals MMS2019
   jobs:
   - job: build_windows
     displayName: Build PSReadLine
@@ -127,7 +127,9 @@ stages:
   displayName: Compliance
   dependsOn: Build
   pool:
-    name: Package ES CodeHub Lab E
+    name: 1ES
+    demands:
+    - ImageOverride -equals MMS2019
   jobs:
   - job: Compliance_Job
     displayName: PSReadLine Compliance

--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -41,7 +41,7 @@ stages:
         Write-Host "PS Version: $($($PSVersionTable.PSVersion))"
         Set-Location -Path '$(Build.SourcesDirectory)\PSReadLine'
         .\build.ps1 -Bootstrap
-        .\build.ps1 -Configuration Release -Framework net461
+        .\build.ps1 -Configuration Release -Framework net461 -CheckHelpContent
 
         # Set target folder paths
         New-Item -Path .\bin\Release\NuGetPackage -ItemType Directory > $null

--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -18,7 +18,7 @@ stages:
 - stage: Build
   displayName: Build and Sign
   pool:
-    name: 1ES
+    name: PowerShell1ES
     demands:
     - ImageOverride -equals MMS2019
   jobs:
@@ -127,7 +127,7 @@ stages:
   displayName: Compliance
   dependsOn: Build
   pool:
-    name: 1ES
+    name: PowerShell1ES
     demands:
     - ImageOverride -equals MMS2019
   jobs:

--- a/MockPSConsole/MockPSConsole.csproj
+++ b/MockPSConsole/MockPSConsole.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.0-preview.6" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.0-preview.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.6" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Polyfill/Polyfill.csproj
+++ b/Polyfill/Polyfill.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.6" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.0-preview.9" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.0-preview.6" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.0-preview.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Migrate the release build to use the 1ES agent pool and also fix the API scan.
The change has been verified with a ADO pipeline run:
https://dev.azure.com/mscodehub/PSReadLine/_build/results?buildId=210359&view=results

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2859)