### PR TITLE
Fix rendering when continuation prompt is an empty string

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -205,8 +205,11 @@ namespace Microsoft.PowerShell
                     // the previous rendering string.
                     activeColor = string.Empty;
 
-                    UpdateColorsIfNecessary(Options._continuationPromptColor);
-                    _consoleBufferLines[currentLogicalLine].Append(Options.ContinuationPrompt);
+                    if (Options.ContinuationPrompt.Length > 0)
+                    {
+                        UpdateColorsIfNecessary(Options._continuationPromptColor);
+                        _consoleBufferLines[currentLogicalLine].Append(Options.ContinuationPrompt);
+                    }
 
                     if (inSelectedRegion)
                     {
@@ -465,6 +468,13 @@ namespace Microsoft.PowerShell
         /// </summary>
         private int PhysicalLineCount(int columns, bool isFirstLogicalLine, out int lenLastPhysicalLine)
         {
+            if (columns == 0)
+            {
+                // This could happen for a new logical line with an empty-string continuation prompt.
+                lenLastPhysicalLine = 0;
+                return 1;
+            }
+
             int cnt = 1;
             int bufferWidth = _console.BufferWidth;
 

--- a/test/RenderTest.cs
+++ b/test/RenderTest.cs
@@ -204,6 +204,65 @@ namespace Test
         }
 
         [SkippableFact]
+        public void MultiLine_ScreenCheck()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            var defaultContinuationPrompt = PSConsoleReadLineOptions.DefaultContinuationPrompt;
+            var defaultContinuationPromptColors = Tuple.Create(_console.ForegroundColor, _console.BackgroundColor);
+
+            Test("@'\n\n hello\n\n world\n'@",
+                 Keys(
+                    "@'",     _.Enter, _.Enter,
+                    " hello", _.Enter, _.Enter,
+                    " world", _.Enter, "'@",
+                        CheckThat(() => AssertScreenIs(6,
+                            TokenClassification.String, "@'",
+                            NextLine,
+                            defaultContinuationPromptColors, defaultContinuationPrompt,
+                            NextLine,
+                            defaultContinuationPromptColors, defaultContinuationPrompt,
+                            TokenClassification.String, " hello",
+                            NextLine,
+                            defaultContinuationPromptColors, defaultContinuationPrompt,
+                            NextLine,
+                            defaultContinuationPromptColors, defaultContinuationPrompt,
+                            TokenClassification.String, " world",
+                            NextLine,
+                            defaultContinuationPromptColors, defaultContinuationPrompt,
+                            TokenClassification.String, "'@"))
+                 ));
+
+            string emptyLine = new string(' ', _console.BufferWidth);
+            // Set the continuation prompt to be an empty string.
+            var setOption = new SetPSReadLineOption { ContinuationPrompt = string.Empty };
+            PSConsoleReadLine.SetOptions(setOption);
+
+            try
+            {
+                Test("@'\n\n hello\n\n world\n'@",
+                     Keys(
+                        "@'", _.Enter, _.Enter,
+                        " hello", _.Enter, _.Enter,
+                        " world", _.Enter, "'@",
+                            CheckThat(() => AssertScreenIs(6,
+                                TokenClassification.String, "@'", NextLine,
+                                TokenClassification.None, emptyLine,
+                                TokenClassification.String, " hello", NextLine,
+                                TokenClassification.None, emptyLine,
+                                TokenClassification.String, " world", NextLine,
+                                TokenClassification.String, "'@"))
+                 ));
+            }
+            finally
+            {
+                // Restore to the default continuation prompt.
+                setOption.ContinuationPrompt = defaultContinuationPrompt;
+                PSConsoleReadLine.SetOptions(setOption);
+            }
+        }
+
+        [SkippableFact]
         public void LongLine()
         {
             TestSetup(KeyMode.Cmd);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #2723

Fix physical line calculation when the logical line is empty. This could happen when the continuation prompt gets set to be an empty string. Also, in `RenderOneChar`, avoid adding the color continuation prompt color ANSI codes when the continuation prompt is an empty string.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2875)