### PR TITLE
Fix GotoBrace to handle the case when the text buffer is empty

### DIFF
--- a/PSReadLine/Movement.vi.cs
+++ b/PSReadLine/Movement.vi.cs
@@ -234,6 +234,11 @@ namespace Microsoft.PowerShell
 
         private int ViFindBrace(int i)
         {
+            if (_buffer.Length == 0)
+            {
+                return i;
+            }
+
             switch (_buffer[i])
             {
                 case '{':

--- a/test/MovementTest.VI.cs
+++ b/test/MovementTest.VI.cs
@@ -453,6 +453,11 @@ namespace Test
                     "ddi"
                     ));
             }
+
+            // <%> with empty text buffer should work fine.
+            Test("", Keys(
+                _.Escape, _.Percent,
+                CheckThat(() => AssertCursorLeftIs(0))));
         }
 
         [SkippableFact]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #2348

Two changes:
1. Fix GotoBrace to handle the case when the text buffer is empty
2. Use Unix line ending in `movement.vi.cs` instead of mix of `LF` and `CRLF`

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2879)