### PR TITLE
Update 'CreateCharInfoBuffer' to support continuous 'NextLineToken'

### DIFF
--- a/test/CompletionTest.cs
+++ b/test/CompletionTest.cs
@@ -741,7 +741,6 @@ namespace Test
             _console.Clear();
             int width = _console.BufferWidth;
             string placeholderCommand = new string('A', width - 12); // 12 = "Get-Module".Length + 2
-            string emptyLine = new string(' ', width);
 
             Test($"{placeholderCommand};Get-Module", Keys(
                 placeholderCommand, ';',
@@ -751,10 +750,12 @@ namespace Test
                     TokenClassification.Command, placeholderCommand,
                     TokenClassification.None, ';',
                     TokenClassification.Command, "Get-Mo",
-                    TokenClassification.Selection, "ckDynamicParameters", NextLine,
+                    TokenClassification.Selection, "ckDynamicParameters",
+                    NextLine,
                     TokenClassification.Selection, "Get-MockDynamicParameters  ",
-                    TokenClassification.None, "Get-Module                 ", NextLine,
-                    TokenClassification.None, emptyLine)),
+                    TokenClassification.None, "Get-Module                 ",
+                    NextLine,
+                    NextLine)),
                 _.RightArrow,
                 // Navigating to the next item will cause the editing line to fit in
                 // one physical line, so the new menu is moved up and lines from the
@@ -763,28 +764,34 @@ namespace Test
                     TokenClassification.Command, placeholderCommand,
                     TokenClassification.None, ';',
                     TokenClassification.Command, "Get-Mo",
-                    TokenClassification.Selection, "dule", NextLine,
+                    TokenClassification.Selection, "dule",
+                    NextLine,
                     TokenClassification.None, "Get-MockDynamicParameters  ",
-                    TokenClassification.Selection, "Get-Module                 ", NextLine,
-                    TokenClassification.None, emptyLine)),
+                    TokenClassification.Selection, "Get-Module                 ",
+                    NextLine,
+                    NextLine)),
                 _.LeftArrow,
                 CheckThat(() => AssertScreenIs(4,
                     TokenClassification.Command, placeholderCommand,
                     TokenClassification.None, ';',
                     TokenClassification.Command, "Get-Mo",
-                    TokenClassification.Selection, "ckDynamicParameters", NextLine,
+                    TokenClassification.Selection, "ckDynamicParameters",
+                    NextLine,
                     TokenClassification.Selection, "Get-MockDynamicParameters  ",
-                    TokenClassification.None, "Get-Module                 ", NextLine,
-                    TokenClassification.None, emptyLine)),
+                    TokenClassification.None, "Get-Module                 ",
+                    NextLine,
+                    NextLine)),
                 _.DownArrow,
                 CheckThat(() => AssertScreenIs(3,
                     TokenClassification.Command, placeholderCommand,
                     TokenClassification.None, ';',
                     TokenClassification.Command, "Get-Mo",
-                    TokenClassification.Selection, "dule", NextLine,
+                    TokenClassification.Selection, "dule",
+                    NextLine,
                     TokenClassification.None, "Get-MockDynamicParameters  ",
-                    TokenClassification.Selection, "Get-Module                 ", NextLine,
-                    TokenClassification.None, emptyLine)),
+                    TokenClassification.Selection, "Get-Module                 ",
+                    NextLine,
+                    NextLine)),
                 _.Enter,
                 _.Enter
                 ));
@@ -795,9 +802,8 @@ namespace Test
         {
             TestSetup(KeyMode.Cmd, new KeyHandler("Ctrl+Spacebar", PSConsoleReadLine.MenuComplete));
 
-            var (listWidth, windowWidth) = CheckWindowSize();
+            int listWidth = CheckWindowSize();
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
-            string emptyLine = new string(' ', windowWidth);
             using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.ListView);
 
             _console.Clear();
@@ -828,19 +834,23 @@ namespace Test
                 _.Ctrl_Spacebar,
                 CheckThat(() => AssertScreenIs(4,
                     TokenClassification.Command, "Get-Mo",
-                    TokenClassification.Selection, "ckDynamicParameters", NextLine,
+                    TokenClassification.Selection, "ckDynamicParameters",
+                    NextLine,
                     TokenClassification.Selection, "Get-MockDynamicParameters  ",
-                    TokenClassification.None, "Get-Module", NextLine,
-                    TokenClassification.None, emptyLine,
-                    TokenClassification.None, emptyLine)),
+                    TokenClassification.None, "Get-Module",
+                    NextLine,
+                    NextLine,
+                    NextLine)),
                 _.RightArrow,
                 CheckThat(() => AssertScreenIs(4,
                     TokenClassification.Command, "Get-Mo",
-                    TokenClassification.Selection, "dule", NextLine,
+                    TokenClassification.Selection, "dule",
+                    NextLine,
                     TokenClassification.None, "Get-MockDynamicParameters  ",
-                    TokenClassification.Selection, "Get-Module                 ", NextLine,
-                    TokenClassification.None, emptyLine,
-                    TokenClassification.None, emptyLine)),
+                    TokenClassification.Selection, "Get-Module                 ",
+                    NextLine,
+                    NextLine,
+                    NextLine)),
                 _.Enter,
                 _.Enter
             ));

--- a/test/DynamicHelpTest.cs
+++ b/test/DynamicHelpTest.cs
@@ -126,7 +126,6 @@ PARAMETERS
         public void DynHelp_GetParameterHelp_And_Clear()
         {
             TestSetup(KeyMode.Cmd);
-            string emptyLine = new string(' ', _console.BufferWidth);
 
             Test("Get-Date -Date", Keys(
                 "Get-Date -Date", _.Alt_h,
@@ -135,10 +134,10 @@ PARAMETERS
                         TokenClassification.None, " ",
                         TokenClassification.Parameter, "-Date",
                         NextLine,
-                        emptyLine,
+                        NextLine,
                         TokenClassification.None, $"-Date <name>",
                         NextLine,
-                        emptyLine,
+                        NextLine,
                         TokenClassification.None, "DESC: Specifies a date and time.",
                         NextLine,
                         TokenClassification.None, "Required: false, Position: 0, Default Value: None, Pipeline ",
@@ -157,7 +156,6 @@ PARAMETERS
         public void DynHelp_GetParameterHelpMultiLine_And_Clear()
         {
             TestSetup(KeyMode.Cmd);
-            string emptyLine = new string(' ', _console.BufferWidth);
 
             Test("Get-MultiLineHelp -OneAndHalf", Keys(
                 "Get-MultiLineHelp -OneAndHalf", _.Alt_h,
@@ -166,10 +164,10 @@ PARAMETERS
                         TokenClassification.None, " ",
                         TokenClassification.Parameter, "-OneAndHalf",
                         NextLine,
-                        emptyLine,
+                        NextLine,
                         TokenClassification.None, $"-Date <name>",
                         NextLine,
-                        emptyLine,
+                        NextLine,
                         TokenClassification.None, "DESC: Some very long description that is over the buffer width of ",
                         TokenClassification.None, "60 characters but shorter than 120.",
                         NextLine,
@@ -189,7 +187,6 @@ PARAMETERS
         public void DynHelp_GetParameterHelpTwoLines_And_Clear()
         {
             TestSetup(KeyMode.Cmd);
-            string emptyLine = new string(' ', _console.BufferWidth);
 
             Test("Get-MultiLineHelp -ExactlyTwo", Keys(
                 "Get-MultiLineHelp -ExactlyTwo", _.Alt_h,
@@ -198,10 +195,10 @@ PARAMETERS
                         TokenClassification.None, " ",
                         TokenClassification.Parameter, "-ExactlyTwo",
                         NextLine,
-                        emptyLine,
+                        NextLine,
                         TokenClassification.None, $"-Date <name>",
                         NextLine,
-                        emptyLine,
+                        NextLine,
                         TokenClassification.None, "DESC: Some very long description that is over the buffer wid",
                         TokenClassification.None, "th of 60 characters and exactly the length of 120 characters",
                         NextLine,
@@ -221,7 +218,6 @@ PARAMETERS
         public void DynHelp_GetParameterHelpTwoLines_And_Clear_Emacs()
         {
             TestSetup(KeyMode.Emacs);
-            string emptyLine = new string(' ', _console.BufferWidth);
 
             Test("Get-MultiLineHelp -ExactlyTwo", Keys(
                 "Get-MultiLineHelp -ExactlyTwo", _.Alt_h,
@@ -230,10 +226,10 @@ PARAMETERS
                         TokenClassification.None, " ",
                         TokenClassification.Parameter, "-ExactlyTwo",
                         NextLine,
-                        emptyLine,
+                        NextLine,
                         TokenClassification.None, $"-Date <name>",
                         NextLine,
-                        emptyLine,
+                        NextLine,
                         TokenClassification.None, "DESC: Some very long description that is over the buffer wid",
                         TokenClassification.None, "th of 60 characters and exactly the length of 120 characters",
                         NextLine,
@@ -253,7 +249,6 @@ PARAMETERS
         public void DynHelp_GetParameterHelpTwoLines_And_Clear_Vi()
         {
             TestSetup(KeyMode.Vi);
-            string emptyLine = new string(' ', _console.BufferWidth);
 
             Test("Get-MultiLineHelp -ExactlyTwo", Keys(
                 "Get-MultiLineHelp -ExactlyTwo", _.Alt_h,
@@ -262,10 +257,10 @@ PARAMETERS
                         TokenClassification.None, " ",
                         TokenClassification.Parameter, "-ExactlyTwo",
                         NextLine,
-                        emptyLine,
+                        NextLine,
                         TokenClassification.None, $"-Date <name>",
                         NextLine,
-                        emptyLine,
+                        NextLine,
                         TokenClassification.None, "DESC: Some very long description that is over the buffer wid",
                         TokenClassification.None, "th of 60 characters and exactly the length of 120 characters",
                         NextLine,
@@ -285,7 +280,6 @@ PARAMETERS
         public void DynHelp_GetParameterHelpErrorMessage()
         {
             TestSetup(KeyMode.Cmd);
-            string emptyLine = new string(' ', _console.BufferWidth);
 
             Test("Get-FakeHelp -Fake", Keys(
                 "Get-FakeHelp -Fake", _.Alt_h,
@@ -294,7 +288,7 @@ PARAMETERS
                     TokenClassification.None, " ",
                     TokenClassification.Parameter, "-Fake",
                     NextLine,
-                    emptyLine,
+                    NextLine,
                     TokenClassification.None, "No help content available. Please use Update-Help to downloa",
                     NextLine,
                     "d the latest help content.")),

--- a/test/ListPredictionTest.cs
+++ b/test/ListPredictionTest.cs
@@ -13,7 +13,7 @@ namespace Test
         private const int ListMaxWidth = 100;
         private const int SourceMaxWidth = 15;
 
-        private (int, int) CheckWindowSize()
+        private int CheckWindowSize()
         {
             // The buffer/window size of 'TestConsole' is currently fixed to be width 60 and height 1000.
             // This is a precaution check, just in case that things change.
@@ -23,7 +23,7 @@ namespace Test
             Assert.True(winHeight >= 15, $"list-view prediction requires minimum window height {MinWindowHeight}. Make sure the TestConsole's height is set properly.");
 
             int listWidth = winWidth > ListMaxWidth ? ListMaxWidth : winWidth;
-            return (listWidth, winWidth);
+            return listWidth;
         }
 
         private Disposable SetPrediction(PredictionSource source, PredictionViewStyle view)
@@ -68,7 +68,7 @@ namespace Test
         public void List_RenderSuggestion_ListUpdatesWhileTyping()
         {
             TestSetup(KeyMode.Cmd);
-            var (listWidth, windowWidth) = CheckWindowSize();
+            int listWidth = CheckWindowSize();
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
             using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.ListView);
 
@@ -133,7 +133,7 @@ namespace Test
                 _.Enter, CheckThat(() => AssertScreenIs(2,
                         TokenClassification.Command, "ech",
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)))
+                        NextLine))
             ));
         }
 
@@ -141,7 +141,7 @@ namespace Test
         public void List_RenderSuggestion_NavigateInList()
         {
             TestSetup(KeyMode.Cmd);
-            var (listWidth, windowWidth) = CheckWindowSize();
+            int listWidth = CheckWindowSize();
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
             using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.ListView);
 
@@ -313,7 +313,7 @@ namespace Test
                 _.Enter, CheckThat(() => AssertScreenIs(2,
                         TokenClassification.Command, "e",
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)))
+                        NextLine))
             ));
         }
 
@@ -321,7 +321,7 @@ namespace Test
         public void List_RenderSuggestion_Escape()
         {
             TestSetup(KeyMode.Cmd);
-            var (listWidth, windowWidth) = CheckWindowSize();
+            int listWidth = CheckWindowSize();
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
             using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.ListView);
 
@@ -390,7 +390,7 @@ namespace Test
                         TokenClassification.None, ' ',
                         TokenClassification.Parameter, "-bar",
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)))
+                        NextLine))
             ));
 
             // Press 'Escape' after selecting an item.
@@ -446,7 +446,7 @@ namespace Test
                      CheckThat(() => AssertScreenIs(2,
                         TokenClassification.Command, 'c',
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // 'UpArrow' and 'DownArrow' should navigate history after 'Escape' cleared the list view
                 _.UpArrow, CheckThat(() => AssertLineIs("eca -zoo")),
@@ -459,7 +459,7 @@ namespace Test
         public void List_RenderSuggestion_DigitArgument()
         {
             TestSetup(KeyMode.Cmd);
-            var (listWidth, windowWidth) = CheckWindowSize();
+            int listWidth = CheckWindowSize();
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
             using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.ListView);
 
@@ -586,7 +586,7 @@ namespace Test
                 _.Enter, CheckThat(() => AssertScreenIs(2,
                         TokenClassification.Command, 'c',
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)))
+                        NextLine))
             ));
         }
 
@@ -594,7 +594,7 @@ namespace Test
         public void List_RenderSuggestion_CtrlZ()
         {
             TestSetup(KeyMode.Cmd);
-            var (listWidth, windowWidth) = CheckWindowSize();
+            int listWidth = CheckWindowSize();
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
             using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.ListView);
 
@@ -698,7 +698,7 @@ namespace Test
                 _.Enter, CheckThat(() => AssertScreenIs(2,
                         TokenClassification.Command, 'e',
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)))
+                        NextLine))
             ));
         }
 
@@ -706,7 +706,7 @@ namespace Test
         public void List_RenderSuggestion_Selection()
         {
             TestSetup(KeyMode.Cmd);
-            var (listWidth, windowWidth) = CheckWindowSize();
+            int listWidth = CheckWindowSize();
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
             using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.ListView);
 
@@ -863,7 +863,7 @@ namespace Test
                         TokenClassification.Selection, "eca -",
                         TokenClassification.Parameter, "zoo",
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)))
+                        NextLine))
             ));
         }
 
@@ -871,7 +871,7 @@ namespace Test
         public void List_HistorySource_NoAcceptanceCallback()
         {
             TestSetup(KeyMode.Cmd);
-            var (listWidth, windowWidth) = CheckWindowSize();
+            int listWidth = CheckWindowSize();
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
 
             // Using the 'History' source will not trigger 'acceptance' callbacks.
@@ -911,7 +911,7 @@ namespace Test
                         TokenClassification.Parameter, "-zooa",
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 CheckThat(() => Assert.Equal(Guid.Empty, _mockedMethods.acceptedPredictorId)),
                 CheckThat(() => Assert.Null(_mockedMethods.acceptedSuggestion)),
@@ -928,7 +928,7 @@ namespace Test
         public void List_PluginSource_Acceptance()
         {
             TestSetup(KeyMode.Cmd);
-            var (listWidth, windowWidth) = CheckWindowSize();
+            int listWidth = CheckWindowSize();
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
 
             // Using the 'Plugin' source will make PSReadLine get prediction from the plugin only.
@@ -965,7 +965,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
                 CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
@@ -1001,7 +1001,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should not be fired when navigating the list.
                 CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
@@ -1034,7 +1034,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should not be fired when selecting the input.
                 CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
@@ -1067,7 +1067,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
                 CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
@@ -1108,7 +1108,7 @@ namespace Test
                         TokenClassification.ListPredictionSelected, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should not be fired when navigating the input.
                 CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
@@ -1144,7 +1144,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
                 CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
@@ -1186,7 +1186,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should not be fired when navigating the input.
                 CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
@@ -1195,7 +1195,7 @@ namespace Test
                         TokenClassification.Command, "SOME",
                         TokenClassification.None, " NEW TEX SOME TEXT AFTER",
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)))
+                        NextLine))
             ));
 
             // `OnSuggestionDisplayed` should not be fired when 'Enter' accepting the input.
@@ -1212,7 +1212,7 @@ namespace Test
         public void List_HistoryAndPluginSource_Acceptance()
         {
             TestSetup(KeyMode.Cmd);
-            var (listWidth, windowWidth) = CheckWindowSize();
+            int listWidth = CheckWindowSize();
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
 
             // Using the 'HistoryAndPlugin' source will make PSReadLine get prediction from both history and plugin.
@@ -1267,7 +1267,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
                 CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
@@ -1320,7 +1320,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should not be fired when navigating the list.
                 CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
@@ -1361,7 +1361,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
                 CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
@@ -1410,7 +1410,7 @@ namespace Test
                         TokenClassification.ListPredictionSelected, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should not be fired when navigating the list.
                 CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
@@ -1446,7 +1446,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should be fired for both predictors.
                 CheckThat(() => AssertDisplayedSuggestions(count: 2, predictorId_1, MiniSessionId, 2)),
@@ -1488,7 +1488,7 @@ namespace Test
                         TokenClassification.None, ']',
                         // List view is done, no more list item following.
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)
+                        NextLine
                      )),
                 // `OnSuggestionDisplayed` should not be fired when navigating the list.
                 CheckThat(() => Assert.Empty(_mockedMethods.displayedSuggestions)),
@@ -1497,7 +1497,7 @@ namespace Test
                         TokenClassification.Command, "SOME",
                         TokenClassification.None, " NEW TEX SOME TEXT AFTER",
                         NextLine,
-                        TokenClassification.None, new string(' ', windowWidth)))
+                        NextLine))
             ));
 
             Assert.Empty(_mockedMethods.displayedSuggestions);

--- a/test/MovementTest.cs
+++ b/test/MovementTest.cs
@@ -12,16 +12,15 @@ namespace Test
 
             Test("", Keys( _.End, CheckThat(() => AssertCursorLeftIs(0)) ));
 
-            var buffer = new string(' ', _console.BufferWidth);
-            Test(buffer, Keys(
-                buffer,
+            Test(_emptyLine, Keys(
+                _emptyLine,
                 _.Home,
                 CheckThat(() => AssertCursorLeftIs(0)),
                 _.End,
                 CheckThat(() => AssertCursorLeftTopIs(0, 1))
                 ));
 
-            buffer = new string(' ', _console.BufferWidth + 5);
+            var buffer = new string(' ', _console.BufferWidth + 5);
             Test(buffer, Keys(
                 buffer,
                 _.Home,

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -11,7 +11,7 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/test/RenderTest.cs
+++ b/test/RenderTest.cs
@@ -233,7 +233,6 @@ namespace Test
                             TokenClassification.String, "'@"))
                  ));
 
-            string emptyLine = new string(' ', _console.BufferWidth);
             // Set the continuation prompt to be an empty string.
             var setOption = new SetPSReadLineOption { ContinuationPrompt = string.Empty };
             PSConsoleReadLine.SetOptions(setOption);
@@ -246,11 +245,14 @@ namespace Test
                         " hello", _.Enter, _.Enter,
                         " world", _.Enter, "'@",
                             CheckThat(() => AssertScreenIs(6,
-                                TokenClassification.String, "@'", NextLine,
-                                TokenClassification.None, emptyLine,
-                                TokenClassification.String, " hello", NextLine,
-                                TokenClassification.None, emptyLine,
-                                TokenClassification.String, " world", NextLine,
+                                TokenClassification.String, "@'",
+                                NextLine,
+                                NextLine,
+                                TokenClassification.String, " hello",
+                                NextLine,
+                                NextLine,
+                                TokenClassification.String, " world",
+                                NextLine,
                                 TokenClassification.String, "'@"))
                  ));
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update 'CreateCharInfoBuffer' to support continuous `NextLineToken`.
The first 'NextLineToken' pads the current line to the end, and the following `NextLineToken's` will be interpreted as requests for empty lines.

This avoids the empty line strings created in many places in our tests, and makes the `AssertScreenIs` works more intuitively.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2880)