### PR TITLE
Fix the exception format to make it work better with the new bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yaml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yaml
@@ -30,6 +30,8 @@ body:
         Instead, please scroll up to above the exception report, and take a screenshot of the console state right before the exception happened.
         Also, please keep your terminal window size unchanged when taking screenshot.
       - If no exception was involved, please upload images or animations that you think may be helpful, or put "N/A" below.
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Environment data

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -900,14 +900,14 @@ namespace Microsoft.PowerShell.PSReadLine {
         ///BufferHeight: {4}
 
         ///Last {5} Keys
-        ///```
+        ///
         ///{6}
-        ///```
+        ///
 
         ///### Exception
-        ///```
+        ///
         ///{7}
-        ///```
+        ///
         /// </summary>
         internal static string OopsAnErrorMessage2 {
             get {
@@ -1664,7 +1664,7 @@ namespace Microsoft.PowerShell.PSReadLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invokes the console compatible editor specified by $env:VISUAL or $env:$EDITOR on the current command line..
+        ///   Looks up a localized string similar to Invokes the console compatible editor specified by $env:VISUAL or $env:EDITOR on the current command line..
         /// </summary>
         internal static string ViEditVisuallyDescription {
             get {

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -412,15 +412,14 @@ OS: {2}
 BufferWidth: {3}
 BufferHeight: {4}
 
-Last {5} Keys
-```
+Last {5} Keys:
+
 {6}
-```
 
 ### Exception
-```
+
 {7}
-```
+
 </value>
   </data>
   <data name="NextLineDescription" xml:space="preserve">
@@ -713,7 +712,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Invokes TabCompletePrevious after doing some vi-specific clean up.</value>
   </data>
   <data name="ViEditVisuallyDescription" xml:space="preserve">
-    <value>Invokes the console compatible editor specified by $env:VISUAL or $env:$EDITOR on the current command line.</value>
+    <value>Invokes the console compatible editor specified by $env:VISUAL or $env:EDITOR on the current command line.</value>
   </data>
   <data name="ViAppendLineDescription" xml:space="preserve">
     <value>Appends a new multi-line edit mode line to the current line.</value>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

With the new bug template, the exception report printed by PSReadLine is supposed to be copied to the "Exception report" section which uses console render. So there is no need to warp the keys and exception stack trace in code blocks (backticks).
Also fix a typo.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2917)