### PR TITLE
Reset all attributes before changing color in rendering

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -177,7 +177,12 @@ namespace Microsoft.PowerShell
             {
                 if (!object.ReferenceEquals(newColor, activeColor))
                 {
-                    if (!inSelectedRegion) _consoleBufferLines[currentLogicalLine].Append(newColor);
+                    if (!inSelectedRegion)
+                    {
+                        _consoleBufferLines[currentLogicalLine]
+                            .Append(VTColorUtils.AnsiReset)
+                            .Append(newColor);
+                    }
                     activeColor = newColor;
                 }
             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #1888

Reset all attributes before changing color in rendering. Otherwise, the effects from the previous color sequence may leak to the subsequent text.

Before the fix, the Faint (decreased intensity) effect for command name token leaks to other tokens:
![image](https://user-images.githubusercontent.com/127450/138190289-b58c5ef2-1092-476d-8acf-0ccd1c59ea8b.png)

After the fix, the Faint effect for command name token doesn't leak:
![image](https://user-images.githubusercontent.com/127450/138190233-2e5530b4-8ee5-454c-a3a2-106c9f4a6b4b.png)


## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests 
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2925)