### PR TITLE
Fix 2 menu completion issues that happen when we need to scroll screen buffer

### DIFF
--- a/PSReadLine/DisplayBlockBase.cs
+++ b/PSReadLine/DisplayBlockBase.cs
@@ -23,6 +23,16 @@ namespace Microsoft.PowerShell
                 }
             }
 
+            protected void AdjustForActualScroll(int scrollCnt)
+            {
+                if (scrollCnt > 0)
+                {
+                    Top -= scrollCnt;
+                    _singleton._initialY -= scrollCnt;
+                    _savedCursorTop -= scrollCnt;
+                }
+            }
+
             protected void AdjustForPossibleScroll(int cnt)
             {
                 IConsole console = Singleton._console;
@@ -32,6 +42,34 @@ namespace Microsoft.PowerShell
                     Top -= scrollCnt;
                     _singleton._initialY -= scrollCnt;
                     _savedCursorTop -= scrollCnt;
+                }
+            }
+
+            protected void MoveCursorToStartDrawingPosition(IConsole console)
+            {
+                // Calculate the coord to place the cursor at the end of current input.
+                Point bufferEndPoint = Singleton.ConvertOffsetToPoint(Singleton._buffer.Length);
+                // Top must be initialized before any possible adjustion by 'AdjustForPossibleScroll' or 'AdjustForActualScroll',
+                // otherwise its value would be corrupted and cause rendering issue.
+                Top = bufferEndPoint.Y + 1;
+
+                if (bufferEndPoint.Y == console.BufferHeight)
+                {
+                    // The input happens to end at the very last cell of the current buffer, so 'bufferEndPoint' is pointing to
+                    // the first cell at one line below the current buffer, and thus we need to scroll up the buffer.
+                    console.SetCursorPosition(console.BufferWidth - 1, console.BufferHeight - 1);
+                    // We scroll the buffer by 2 lines here, so the cursor is placed at the start of the first line after 'bufferEndPoint'.
+                    MoveCursorDown(2);
+                    bufferEndPoint.Y -= 2;
+                    AdjustForActualScroll(2);
+                }
+                else
+                {
+                    // Move the cursor to the end of our input.
+                    console.SetCursorPosition(bufferEndPoint.X, bufferEndPoint.Y);
+                    // Move cursor to the start of the first line after our input (after 'bufferEndPoint').
+                    AdjustForPossibleScroll(1);
+                    MoveCursorDown(1);
                 }
             }
 

--- a/PSReadLine/DynamicHelp.cs
+++ b/PSReadLine/DynamicHelp.cs
@@ -241,21 +241,11 @@ namespace Microsoft.PowerShell
 
                 multilineItems = 0;
 
-                this.SaveCursor();
-
-                // Move cursor to the start of the first line after our input.
-                var bufferEndPoint = Singleton.ConvertOffsetToPoint(Singleton._buffer.Length);
-                console.SetCursorPosition(bufferEndPoint.X, bufferEndPoint.Y);
-                // Top must be initialized before calling AdjustForPossibleScroll, otherwise
-                // on the last line of the buffer, the scroll operation causes Top to point
-                // past the buffer, which in turn causes the menu to be printed twice.
-                this.Top = bufferEndPoint.Y + 1;
-                AdjustForPossibleScroll(1);
-                MoveCursorDown(1);
+                SaveCursor();
+                MoveCursorToStartDrawingPosition(console);
 
                 var bufferWidth = console.BufferWidth;
-
-                var items = this.ItemsToDisplay;
+                var items = ItemsToDisplay;
 
                 for (var index = 0; index < items.Count; index++)
                 {
@@ -282,7 +272,7 @@ namespace Microsoft.PowerShell
                     }
                 }
 
-                this.RestoreCursor();
+                RestoreCursor();
             }
 
             public void Clear()


### PR DESCRIPTION
# PR Summary

Fix #2928
Fix #2948

The details of the issues and root cause can be found at https://github.com/PowerShell/PSReadLine/issues/2928#issuecomment-961295959 and https://github.com/PowerShell/PSReadLine/issues/2948#issuecomment-961313213

Major changes in this PR:
1. Handle moving the cursor to the start-drawing position appropriately, taking screen buffer scrolling in consideration.
2. Move duplicate code into the function `MoveCursorToStartDrawingPosition` and used it for both menu completion and dynamic help.
3. Initialize `PreviousTop` correctly before `Top` is changed, and get rid of `bufferEndPoint.Y` because we should compare `Top` with `PreviousTop` to determine if menu moved.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
      - **Cannot add tests because we cannot mimic buffer scrolling with the testing console, but I manually validated the fix**
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2949)