### PR TITLE
Fix the escaping of double quotes on Ubuntu agent

### DIFF
--- a/tools/issue-mgmt/CloseDupIssues.ps1
+++ b/tools/issue-mgmt/CloseDupIssues.ps1
@@ -49,7 +49,7 @@ foreach ($item in $issues)
         $comment = @'
 This issue was fixed in 2.2.0-beta3 version of PSReadLine. You can fix this by upgrading to the latest [2.2.0-beta4 version of PSReadLine](https://www.powershellgallery.com/packages/PSReadLine/2.2.0-beta4). Instructions for doing so:
 1. stop all instances of `pwsh`.
-2. from `cmd.exe` on Windows or `bash` on Linux, run: `pwsh -noprofile -command """Install-Module PSReadLine -AllowPrerelease -Force"""`
+2. from `cmd.exe` on Windows or `bash` on Linux, run: `pwsh -noprofile -command \"Install-Module PSReadLine -AllowPrerelease -Force\"`
 
 --------
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix the escaping of double quotes on Ubuntu agent.
The previous fix was incorrect because I assumed GitHub action is running on Windows ...

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3030)