### PR TITLE
Improve `RecomputeInitialCoords` to be more robust and handle a couple special cases

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -267,10 +267,6 @@ namespace Microsoft.PowerShell
             _emphasisStart = -1;
             _emphasisLength = 0;
 
-            var insertionPoint = _current;
-            // Make sure cursor is at the end before writing the line
-            _current = _buffer.Length;
-
             if (renderNeeded)
             {
                 ForceRender();
@@ -281,6 +277,7 @@ namespace Microsoft.PowerShell
             // can report an error as it normally does.
             if (validate && !_statusIsErrorMessage)
             {
+                var insertionPoint = _current;
                 var errorMessage = Validate(_ast);
                 if (!string.IsNullOrWhiteSpace(errorMessage))
                 {
@@ -308,8 +305,13 @@ namespace Microsoft.PowerShell
                 ClearStatusMessage(render: true);
             }
 
-            // Let public API set cursor to end of line incase end of line is end of buffer
-            SetCursorPosition(_current);
+            // Make sure cursor is at the end before writing the line.
+            if (_current != _buffer.Length)
+            {
+                // Let public API set cursor to end of line incase end of line is end of buffer.
+                _current = _buffer.Length;
+                SetCursorPosition(_current);
+            }
 
             if (_prediction.ActiveView is PredictionListView listView)
             {

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -2191,5 +2191,16 @@ namespace Microsoft.PowerShell.PSReadLine {
                 return ResourceManager.GetString("SelectCommandArgumentDescription", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to: Cannot locate the offset in the rendered text that was pointed by the original cursor. Initial Coord: ({0}, {1}) Buffer: ({2}, {3}) Cursor: ({4}, {5}).
+        /// </summary>
+        internal static string FailedToConvertPointToRenderDataOffset
+        {
+            get
+            {
+                return ResourceManager.GetString("FailedToConvertPointToRenderDataOffset", resourceCulture);
+            }
+        }
     }
 }

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -855,4 +855,7 @@ Or not saving history with:
   <data name="SelectCommandArgumentDescription" xml:space="preserve">
     <value>Make visual selection of the command arguments.</value>
   </data>
+  <data name="FailedToConvertPointToRenderDataOffset" xml:space="preserve">
+    <value>Cannot locate the offset in the rendered text that was pointed by the original cursor. Initial Coord: ({0}, {1}) Buffer: ({2}, {3}) Cursor: ({4}, {5})</value>
+  </data>
 </root>

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -710,9 +710,7 @@ namespace Microsoft.PowerShell
             }
 
             _previousRender = _initialPrevRender;
-            _previousRender.bufferWidth = _console.BufferWidth;
-            _previousRender.bufferHeight = _console.BufferHeight;
-            _previousRender.errorPrompt = false;
+            _previousRender.UpdateConsoleInfo(_console);
             _buffer.Clear();
             _edits = new List<EditItem>();
             _undoEditIndex = 0;
@@ -1033,6 +1031,7 @@ namespace Microsoft.PowerShell
             _singleton._initialX = console.CursorLeft;
             _singleton._initialY = console.CursorTop;
             _singleton._previousRender = _initialPrevRender;
+            _singleton._previousRender.UpdateConsoleInfo(console);
 
             _singleton.Render();
             console.CursorVisible = true;

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -509,6 +509,10 @@ namespace Microsoft.PowerShell
                 var moveToLineCommandCount = _moveToLineCommandCount;
                 var moveToEndOfLineCommandCount = _moveToEndOfLineCommandCount;
 
+                // We attempt to handle window resizing only once per a keybinding processing, because we assume the
+                // window resizing cannot and shouldn't happen within the processing of a given keybinding.
+                _handlePotentialResizing = true;
+
                 var key = ReadKey();
                 ProcessOneKey(key, _dispatchTable, ignoreIfNoAction: false, arg: null);
                 if (_inputAccepted)
@@ -709,8 +713,6 @@ namespace Microsoft.PowerShell
                 _delayedOneTimeInitCompleted = true;
             }
 
-            _previousRender = _initialPrevRender;
-            _previousRender.UpdateConsoleInfo(_console);
             _buffer.Clear();
             _edits = new List<EditItem>();
             _undoEditIndex = 0;
@@ -726,6 +728,9 @@ namespace Microsoft.PowerShell
             _initialY = _console.CursorTop;
             _initialForeground = _console.ForegroundColor;
             _initialBackground = _console.BackgroundColor;
+            _previousRender = _initialPrevRender;
+            _previousRender.UpdateConsoleInfo(_console);
+            _previousRender.initialY = _initialY;
             _statusIsErrorMessage = false;
 
             _initialOutputEncoding = _console.OutputEncoding;
@@ -1032,6 +1037,7 @@ namespace Microsoft.PowerShell
             _singleton._initialY = console.CursorTop;
             _singleton._previousRender = _initialPrevRender;
             _singleton._previousRender.UpdateConsoleInfo(console);
+            _singleton._previousRender.initialY = _singleton._initialY;
 
             _singleton.Render();
             console.CursorVisible = true;

--- a/PSReadLine/Render.Helper.cs
+++ b/PSReadLine/Render.Helper.cs
@@ -45,12 +45,12 @@ namespace Microsoft.PowerShell
                 : new string(' ', cnt);
         }
 
-        private static int LengthInBufferCells(string str)
+        internal static int LengthInBufferCells(string str)
         {
             return LengthInBufferCells(str, 0, str.Length);
         }
 
-        private static int LengthInBufferCells(string str, int start, int end)
+        internal static int LengthInBufferCells(string str, int start, int end)
         {
             var sum = 0;
             for (var i = start; i < end; i++)
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell
             return sum;
         }
 
-        private static int LengthInBufferCells(char c)
+        internal static int LengthInBufferCells(char c)
         {
             if (c < 256)
             {

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -46,18 +46,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="KeyInfo-en-US-windows.json">
+    <Content Include="KeyInfo-en-US-windows.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="KeyInfo-en-windows.json">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include="KeyInfo-fr-FR-windows.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="KeyInfo-fr-FR-windows.json">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include="assets\**\*">
+      <Link>assets\%(RecursiveDir)\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="KeyInfo-fr-windows.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/test/ResizingTest.cs
+++ b/test/ResizingTest.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.PowerShell;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Test.Resizing
+{
+#pragma warning disable 0649
+
+    /// <summary>
+    /// This class is initialized by JSON deserialization.
+    /// </summary>
+    internal sealed class LogicalToPhysicalLineTestData
+    {
+        public string Name;
+        public string Line;
+        public bool IsFirstLogicalLine;
+        public List<LogicalToPhysicalLineTestContext> Context;
+    }
+
+    /// <summary>
+    /// This class is initialized by JSON deserialization.
+    /// </summary>
+    internal sealed class LogicalToPhysicalLineTestContext
+    {
+        public int BufferWidth;
+        public int InitialX;
+        public int LineCount;
+        public int LastLineLen;
+    }
+
+    /// <summary>
+    /// This class is initialized by JSON deserialization.
+    /// </summary>
+    internal sealed class ResizingTestData
+    {
+        public string Name;
+        public List<string> Lines;
+        public int OldBufferWidth;
+        public int NewBufferWidth;
+        public List<ResizingTestContext> Context;
+    }
+
+    /// <summary>
+    /// This class is initialized by JSON deserialization.
+    /// </summary>
+    internal sealed class ResizingTestContext
+    {
+        public Point OldInitial;
+        public Point OldCursor;
+        public Point NewInitial;
+        public Point NewCursor;
+        public RenderOffset Offset;
+
+        internal sealed class RenderOffset
+        {
+            public int LineIndex;
+            public int CharIndex;
+        }
+    }
+
+#pragma warning restore 0649
+}
+
+namespace Test
+{
+    using Test.Resizing;
+
+    public partial class ReadLine
+    {
+        private static List<ResizingTestData> s_resizingTestData;
+
+        private void InitializeTestData()
+        {
+            if (s_resizingTestData is null)
+            {
+                string path = Path.Combine("assets", "resizing", "renderdata-to-cursor-point.json");
+                string text = File.ReadAllText(path);
+                s_resizingTestData = JsonConvert.DeserializeObject<List<ResizingTestData>>(text);
+            }
+        }
+
+        private PSConsoleReadLine GetPSConsoleReadLineSingleton()
+        {
+            return (PSConsoleReadLine)typeof(PSConsoleReadLine)
+                .GetField("_singleton", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
+        }
+
+        [Fact]
+        public void ConvertPointToRenderDataOffset_ShouldWork()
+        {
+            InitializeTestData();
+            PSConsoleReadLine instance = GetPSConsoleReadLineSingleton();
+
+            foreach (ResizingTestData test in s_resizingTestData)
+            {
+                RenderData renderData = new()
+                {
+                    lines = new RenderedLineData[test.Lines.Count],
+                    bufferWidth = test.OldBufferWidth
+                };
+
+                for (int i = 0; i < test.Lines.Count; i++)
+                {
+                    renderData.lines[i] = new RenderedLineData(test.Lines[i], isFirstLogicalLine: i == 0);
+                }
+
+                for (int j = 0; j < test.Context.Count; j++)
+                {
+                    ResizingTestContext context = test.Context[j];
+                    renderData.cursorLeft = context.OldCursor.X;
+                    renderData.cursorTop = context.OldCursor.Y;
+
+                    RenderDataOffset offset = instance.ConvertPointToRenderDataOffset(context.OldInitial.X, context.OldInitial.Y, renderData);
+                    Assert.True(
+                        context.Offset.LineIndex == offset.LogicalLineIndex &&
+                        context.Offset.CharIndex == offset.VisibleCharIndex,
+                        $"{test.Name}-context_{j}: calculated offset is not what's expected [line: {offset.LogicalLineIndex}, char: {offset.VisibleCharIndex}]");
+                }
+            }
+        }
+
+        [Fact]
+        public void ConvertRenderDataOffsetToPoint_ShouldWork()
+        {
+            InitializeTestData();
+            PSConsoleReadLine instance = GetPSConsoleReadLineSingleton();
+
+            foreach (ResizingTestData test in s_resizingTestData)
+            {
+                RenderData renderData = new()
+                {
+                    lines = new RenderedLineData[test.Lines.Count],
+                    bufferWidth = test.OldBufferWidth
+                };
+
+                for (int i = 0; i < test.Lines.Count; i++)
+                {
+                    renderData.lines[i] = new RenderedLineData(test.Lines[i], isFirstLogicalLine: i == 0);
+                }
+
+                for (int j = 0; j < test.Context.Count; j++)
+                {
+                    ResizingTestContext context = test.Context[j];
+                    if (context.Offset.LineIndex != -1)
+                    {
+                        renderData.cursorLeft = context.OldCursor.X;
+                        renderData.cursorTop = context.OldCursor.Y;
+
+                        var offset = new RenderDataOffset(context.Offset.LineIndex, context.Offset.CharIndex);
+                        Point newCursor = instance.ConvertRenderDataOffsetToPoint(context.NewInitial.X, context.NewInitial.Y, test.NewBufferWidth, renderData, offset);
+                        Assert.True(
+                            context.NewCursor.X == newCursor.X &&
+                            context.NewCursor.Y == newCursor.Y,
+                            $"{test.Name}-context_{j}: calculated new cursor is not what's expected [X: {newCursor.X}, Y: {newCursor.Y}]");
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void PhysicalLineCountMethod_ShouldWork()
+        {
+            var path = Path.Combine("assets", "resizing", "physical-line-count.json");
+            var text = File.ReadAllText(path);
+            var testDataList = JsonConvert.DeserializeObject<List<LogicalToPhysicalLineTestData>>(text);
+
+            foreach (LogicalToPhysicalLineTestData test in testDataList)
+            {
+                RenderedLineData lineData = new(test.Line, test.IsFirstLogicalLine);
+                for (int i = 0; i < test.Context.Count; i++)
+                {
+                    LogicalToPhysicalLineTestContext context = test.Context[i];
+                    int lineCount = lineData.PhysicalLineCount(context.BufferWidth, context.InitialX, out int lastLinelen);
+                    Assert.True(
+                        context.LineCount == lineCount &&
+                        context.LastLineLen == lastLinelen,
+                        $"{test.Name}-context_{i}: calculated physical line count or length of last physical line is not what's expected [count: {lineCount}, lastLen: {lastLinelen}]");
+                }
+            }
+        }
+    }
+}

--- a/test/assets/resizing/physical-line-count.json
+++ b/test/assets/resizing/physical-line-count.json
@@ -1,0 +1,225 @@
+[
+  {
+    "Name": "BasicTest_1",
+    // The prompt and input used are actually:
+    // PS:1> new-ilNugetPackage -PackagePath C:\arena\tmp\NugetPackages -PackageVersion 7.2.0-preview.1 -WinFxdBinPath C:\Users\rocky\Downloads\Win\ -LinuxFxdBinPath C:\Users\rocky\Downloads\Linux\ -GenAPIToolPath C:\Users\rocky\Tools\genapi
+    "Line": "\u001b[0m\u001b[93mnew-ILNugetPackage\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackagePath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\arena\\tmp\\NugetPackages\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackageVersion\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m7.2.0-preview.1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-WinFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Win\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-LinuxFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Linux\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-GenAPIToolPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Tools\\genapi",
+    "IsFirstLogicalLine": true,
+    "Context": [
+      {
+        "BufferWidth": 150,
+        "InitialX": 6,
+        "LineCount": 2,
+        "LastLineLen": 84
+      },
+      {
+        "BufferWidth": 102,
+        "InitialX": 6,
+        "LineCount": 3,
+        "LastLineLen": 30
+      },
+      {
+        "BufferWidth": 59,
+        "InitialX": 6,
+        "LineCount": 4,
+        "LastLineLen": 57
+      },
+      {
+        "BufferWidth": 58,
+        "InitialX": 6,
+        "LineCount": 5,
+        "LastLineLen": 2
+      },
+      {
+        "BufferWidth": 117,
+        "InitialX": 6,
+        "LineCount": 2,
+        "LastLineLen": 117
+      },
+      {
+        "BufferWidth": 234,
+        "InitialX": 6,
+        "LineCount": 1,
+        "LastLineLen": 228
+      },
+      {
+        "BufferWidth": 236,
+        "InitialX": 6,
+        "LineCount": 1,
+        "LastLineLen": 228
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_2",
+    // The continuation prompt and input used are actually:
+    // >> new-ilNugetPackage -PackagePath C:\arena\tmp\NugetPackages -PackageVersion 7.2.0-preview.1 -WinFxdBinPath C:\Users\rocky\Downloads\Win\ -LinuxFxdBinPath C:\Users\rocky\Downloads\Linux\ -GenAPIToolPath C:\Users\rocky\Tools\genapi
+    "Line": "\u001b[0m\u001b[37m>> \u001b[0m\u001b[93mnew-ILNugetPackage\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackagePath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\arena\\tmp\\NugetPackages\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackageVersion\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m7.2.0-preview.1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-WinFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Win\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-LinuxFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Linux\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-GenAPIToolPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Tools\\genapi",
+    "IsFirstLogicalLine": false,
+    "Context": [
+      {
+        "BufferWidth": 150,
+        "InitialX": 6,
+        "LineCount": 2,
+        "LastLineLen": 81
+      },
+      {
+        "BufferWidth": 102,
+        "InitialX": 6,
+        "LineCount": 3,
+        "LastLineLen": 27
+      },
+      {
+        "BufferWidth": 77,
+        "InitialX": 6,
+        "LineCount": 3,
+        "LastLineLen": 77
+      },
+      {
+        "BufferWidth": 54,
+        "InitialX": 6,
+        "LineCount": 5,
+        "LastLineLen": 15
+      },
+      {
+        "BufferWidth": 234,
+        "InitialX": 6,
+        "LineCount": 1,
+        "LastLineLen": 231
+      },
+      {
+        "BufferWidth": 236,
+        "InitialX": 6,
+        "LineCount": 1,
+        "LastLineLen": 231
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_3",
+    // Empty prompt, and the input contains no visible character.
+    "Line": "\u001b[0m\u001b[93m",
+    "IsFirstLogicalLine": true,
+    "Context": [
+      {
+        "BufferWidth": 58,
+        "InitialX": 6,
+        "LineCount": 1,
+        "LastLineLen": 0
+      },
+      {
+        "BufferWidth": 54,
+        "InitialX": 0,
+        "LineCount": 1,
+        "LastLineLen": 0
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_4",
+    // Empty prompt, and the input contains no visible character.
+    "Line": "\u001b[0m\u001b[93m",
+    "IsFirstLogicalLine": false,
+    "Context": [
+      {
+        "BufferWidth": 58,
+        "InitialX": 6,
+        "LineCount": 1,
+        "LastLineLen": 0
+      },
+      {
+        "BufferWidth": 54,
+        "InitialX": 0,
+        "LineCount": 1,
+        "LastLineLen": 0
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_5",
+    // Continuation prompt followed by an empty line.
+    "Line": "\u001b[0m\u001b[93m>> ",
+    "IsFirstLogicalLine": false,
+    "Context": [
+      {
+        "BufferWidth": 58,
+        "InitialX": 6,
+        "LineCount": 1,
+        "LastLineLen": 3
+      },
+      {
+        "BufferWidth": 54,
+        "InitialX": 0,
+        "LineCount": 1,
+        "LastLineLen": 3
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_6",
+    // Input is: dir *.psd1 -Recurse | sls -SimpleMatch Desktop-ab
+    "Line": "\u001b[0m\u001b[93mdir\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m*.psd1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-Recurse\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m|\u001b[0m\u001b[39;49m \u001b[0m\u001b[93msls\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-SimpleMatch\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mDesktop-ab",
+    "IsFirstLogicalLine": true,
+    "Context": [
+      {
+        "BufferWidth": 55,
+        "InitialX": 6,
+        "LineCount": 1,
+        "LastLineLen": 49
+      },
+      {
+        "BufferWidth": 54,
+        "InitialX": 6,
+        "LineCount": 2,
+        "LastLineLen": 1
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_7",
+    // Input is: dir *.psd1 -Recurse | sls -SimpleMatch Desktop-有
+    "Line": "\u001b[0m\u001b[93mdir\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m*.psd1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-Recurse\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m|\u001b[0m\u001b[39;49m \u001b[0m\u001b[93msls\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-SimpleMatch\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mDesktop-有",
+    "IsFirstLogicalLine": true,
+    "Context": [
+      {
+        "BufferWidth": 54,
+        "InitialX": 6,
+        "LineCount": 2,
+        "LastLineLen": 2
+      },
+      {
+        "BufferWidth": 54,
+        "InitialX": 7,
+        "LineCount": 2,
+        "LastLineLen": 2
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_8",
+    // dir *.psd1 -Recurse | sls -SimpleMatch Desktop-有人
+    "Line": "\u001b[0m\u001b[93mdir\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m*.psd1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-Recurse\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m|\u001b[0m\u001b[39;49m \u001b[0m\u001b[93msls\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-SimpleMatch\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mDesktop-有人",
+    "IsFirstLogicalLine": true,
+    "Context": [
+      {
+        "BufferWidth": 54,
+        "InitialX": 6,
+        "LineCount": 2,
+        "LastLineLen": 4
+      },
+      {
+        "BufferWidth": 54,
+        "InitialX": 7,
+        "LineCount": 2,
+        "LastLineLen": 4
+      }
+    ]
+  }
+]

--- a/test/assets/resizing/renderdata-to-cursor-point.json
+++ b/test/assets/resizing/renderdata-to-cursor-point.json
@@ -1,0 +1,1008 @@
+[
+  {
+    "Name": "BasicTest_1",
+    "Lines": [
+      "\u001b[0m\u001b[93mnew-ilNugetPackage\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackagePath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\arena\\tmp\\NugetPackages\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackageVersion\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m7.2.0-preview.1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-WinFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Win\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-LinuxFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Linux\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-GenAPIToolPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Tools\\genapi",
+      "\u001b[0m\u001b[37m>> ",
+      "\u001b[0m\u001b[37m>> \u001b[0m\u001b[93mnew-ilNugetPackage\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackagePath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\arena\\tmp\\NugetPackages\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackageVersion\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m7.2.0-preview.1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-WinFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Win\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-LinuxFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Linux\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-GenAPIToolPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Tools\\genapi"
+    ],
+    "OldBufferWidth": 90,
+    "NewBufferWidth": 124,
+    "Context": [
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        // Pointing to the end of the third logical line.
+        "OldCursor": {
+          "X": 51,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 2147483647
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 107,
+          "Y": 13
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        // Pointing to '\' at "Downloads\Linux" of the third logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 180
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 56,
+          "Y": 13
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        // Pointing to the space right after "Downloads\Linux" of the third logical line.
+        "OldCursor": {
+          "X": 7,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 187
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 63,
+          "Y": 13
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        // Pointing to the start of the third logical line.
+        "OldCursor": {
+          "X": 3,
+          "Y": 13
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 3
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 10
+        },
+        "NewCursor": {
+          "X": 3,
+          "Y": 13
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 14
+        },
+        // Pointing to the end of the first physical line -- 'r' from "7.2.0-preview.1" of the first logical line.
+        "OldCursor": {
+          "X": 89,
+          "Y": 14
+        },
+
+        "Offset": {
+          "LineIndex": 0,
+          "CharIndex": 82
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 14
+        },
+        "NewCursor": {
+          "X": 89,
+          "Y": 14
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 14
+        },
+        // Pointing to the start of the second physical line -- first 'e' from "7.2.0-preview.1" of the first logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 0,
+          "CharIndex": 83
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 14
+        },
+        "NewCursor": {
+          "X": 90,
+          "Y": 14
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 14
+        },
+        // Pointing at the start of the second logical line.
+        "OldCursor": {
+          "X": 3,
+          "Y": 17
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 2147483647
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 14
+        },
+        "NewCursor": {
+          "X": 3,
+          "Y": 16
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 14
+        },
+        // Pointing to the initial coordinates.
+        "OldCursor": {
+          "X": 7,
+          "Y": 14
+        },
+
+        "Offset": {
+          "LineIndex": 0,
+          "CharIndex": -1
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 14
+        },
+        "NewCursor": {
+          "X": 7,
+          "Y": 14
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 1
+        },
+        // Pointing to a position that is beyond the end of third logical line.
+        "OldCursor": {
+          "X": 7,
+          "Y": 8
+        },
+
+        "Offset": {
+          "LineIndex": -1,
+          "CharIndex": -1
+        },
+
+        "NewInitial": {
+          "X": -1,
+          "Y": -1
+        },
+        "NewCursor": {
+          "X": -1,
+          "Y": -1
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 1
+        },
+        // Pointing to a position that is beyond the end of first logical line at its last physical line.
+        "OldCursor": {
+          "X": 70,
+          "Y": 3
+        },
+
+        "Offset": {
+          "LineIndex": -1,
+          "CharIndex": -1
+        },
+
+        "NewInitial": {
+          "X": -1,
+          "Y": -1
+        },
+        "NewCursor": {
+          "X": -1,
+          "Y": -1
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 1
+        },
+        // Pointing to a position that is beyond the end of the second logical line, at its last physical line.
+        "OldCursor": {
+          "X": 4,
+          "Y": 4
+        },
+
+        "Offset": {
+          "LineIndex": -1,
+          "CharIndex": -1
+        },
+
+        "NewInitial": {
+          "X": -1,
+          "Y": -1
+        },
+        "NewCursor": {
+          "X": -1,
+          "Y": -1
+        }
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_2",
+    "Lines": [
+      "\u001b[0m\u001b[93mnew-ilNugetPackage\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackagePath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\arena\\tmp\\NugetPackages\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackageVersion\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m7.2.0-preview.1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-WinFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Win\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-LinuxFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Linux\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-GenAPIToolPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Tools\\genapi",
+      "\u001b[0m\u001b[37m>> ",
+      "\u001b[0m\u001b[37m>> \u001b[0m\u001b[93mnew-ilNugetPackage\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackagePath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\arena\\tmp\\NugetPackages\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackageVersion\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m7.2.0-preview.1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-WinFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Win\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-LinuxFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Linux\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-GenAPIToolPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Tools\\genapi"
+    ],
+    "OldBufferWidth": 124,
+    "NewBufferWidth": 90,
+    "Context": [
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 11
+        },
+        // Pointing to the end of the third logical line.
+        "OldCursor": {
+          "X": 107,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 2147483647
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 51,
+          "Y": 15
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 11
+        },
+        // Pointing to '\' at "Downloads\Linux" of the third logical line.
+        "OldCursor": {
+          "X": 56,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 180
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 8
+        },
+        "NewCursor": {
+          "X": 0,
+          "Y": 14
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 11
+        },
+        // Pointing to the space right after "Downloads\Linux" of the third logical line.
+        "OldCursor": {
+          "X": 63,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 187
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 8
+        },
+        "NewCursor": {
+          "X": 7,
+          "Y": 14
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 11
+        },
+        // Pointing to the start of the third logical line.
+        "OldCursor": {
+          "X": 3,
+          "Y": 14
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 3
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 3,
+          "Y": 13
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 11
+        },
+        // Pointing to the 'D' at "Downloads\Win" of the third logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 124
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 34,
+          "Y": 14
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 11
+        },
+        // Pointing to the end of the first physical line -- 'o' at "-WinFxdBinPath C:\Users\ro" of the first logical line.
+        "OldCursor": {
+          "X": 123,
+          "Y": 11
+        },
+
+        "Offset": {
+          "LineIndex": 0,
+          "CharIndex": 116
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 33,
+          "Y": 10
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 7,
+          "Y": 11
+        },
+        // Pointing to the start of the second logical line.
+        "OldCursor": {
+          "X": 3,
+          "Y": 13
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 2147483647
+        },
+
+        "NewInitial": {
+          "X": 7,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 3,
+          "Y": 12
+        }
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_3",
+    // Use empty string as the continuation prompt.
+    "Lines": [
+      "\u001b[0m\u001b[93mnew-ilNugetPackage\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackagePath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\arena\\tmp\\NugetPackages\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackageVersion\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m7.2.0-preview.1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-WinFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Win\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-LinuxFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Linux\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-GenAPIToolPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Tools\\genapi",
+      "",
+      "\u001b[0m\u001b[93mnew-ilNugetPackage\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackagePath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\arena\\tmp\\NugetPackages\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackageVersion\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m7.2.0-preview.1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-WinFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Win\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-LinuxFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Linux\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-GenAPIToolPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Tools\\genapi",
+      "\u001b[0m\u001b[93mhello"
+    ],
+    "OldBufferWidth": 90,
+    "NewBufferWidth": 124,
+    "Context": [
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 9
+        },
+        // Pointing to the start of the third logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 13
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 0
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 0,
+          "Y": 12
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 9
+        },
+        // Pointing to the start of the second logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 12
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 2147483647
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 0,
+          "Y": 11
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 9
+        },
+        // Pointing to the start of the fourth logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 16
+        },
+
+        "Offset": {
+          "LineIndex": 3,
+          "CharIndex": 0
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 0,
+          "Y": 14
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 9
+        },
+        // Pointing to 'e' of the fourth logical line.
+        "OldCursor": {
+          "X": 1,
+          "Y": 16
+        },
+
+        "Offset": {
+          "LineIndex": 3,
+          "CharIndex": 1
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 9
+        },
+        "NewCursor": {
+          "X": 1,
+          "Y": 14
+        }
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_4",
+    // Use empty string as the continuation prompt.
+    "Lines": [
+      "\u001b[0m\u001b[93mhello",
+      "\u001b[0m\u001b[93mworld",
+      "\u001b[0m\u001b[93mnew-ilNugetPackage\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackagePath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\arena\\tmp\\NugetPackages\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-PackageVersion\u001b[0m\u001b[39;49m \u001b[0m\u001b[37m7.2.0-preview.1\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-WinFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Win\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-LinuxFxdBinPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Downloads\\Linux\\\u001b[0m\u001b[39;49m \u001b[0m\u001b[90m-GenAPIToolPath\u001b[0m\u001b[39;49m \u001b[0m\u001b[37mC:\\Users\\rocky\\Tools\\genapi"
+    ],
+    "OldBufferWidth": 90,
+    "NewBufferWidth": 124,
+    "Context": [
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 11
+        },
+        // Pointing to the position right after 'o' in the first logical line.
+        "OldCursor": {
+          "X": 11,
+          "Y": 11
+        },
+
+        "Offset": {
+          "LineIndex": 0,
+          "CharIndex": 2147483647
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 11
+        },
+        "NewCursor": {
+          "X": 11,
+          "Y": 11
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 11
+        },
+        // Pointing to the 'w' in the second logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 12
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 0
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 11
+        },
+        "NewCursor": {
+          "X": 0,
+          "Y": 12
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 11
+        },
+        // Pointing to 'r' in the second logical line.
+        "OldCursor": {
+          "X": 2,
+          "Y": 12
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 2
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 11
+        },
+        "NewCursor": {
+          "X": 2,
+          "Y": 12
+        }
+      }
+    ]
+  },
+
+  {
+    "Name": "BasicTest_5",
+    // Use empty string as the continuation prompt.
+    "Lines": [
+      "\u001b[0m\u001b[93m12345678901234567890123456789012345678901234567890123456789012345678901234567890123有4567890",
+      "\u001b[0m\u001b[93m12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789有准备0"
+    ],
+    "OldBufferWidth": 90,
+    "NewBufferWidth": 124,
+    "Context": [
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        // Pointing to '有' in the first logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 13
+        },
+
+        "Offset": {
+          "LineIndex": 0,
+          "CharIndex": 83
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        "NewCursor": {
+          "X": 89,
+          "Y": 12
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        // Pointing to '4' after the '有' in the first logical line.
+        "OldCursor": {
+          "X": 2,
+          "Y": 13
+        },
+
+        "Offset": {
+          "LineIndex": 0,
+          "CharIndex": 84
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        "NewCursor": {
+          "X": 91,
+          "Y": 12
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        // Pointing to '有' in the second logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 89
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        "NewCursor": {
+          "X": 89,
+          "Y": 13
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        // Pointing to '准' in the second logical line.
+        "OldCursor": {
+          "X": 2,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 90
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        "NewCursor": {
+          "X": 91,
+          "Y": 13
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        // Pointing to '备' in the second logical line.
+        "OldCursor": {
+          "X": 4,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 91
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        "NewCursor": {
+          "X": 93,
+          "Y": 13
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 12
+        },
+        // Pointing to the '0' right after '备' in the second logical line.
+        "OldCursor": {
+          "X": 6,
+          "Y": 15
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 92
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 11
+        },
+        "NewCursor": {
+          "X": 95,
+          "Y": 12
+        }
+      }
+    ]
+  },
+
+  {
+    // Testing scenarios where the logical lines happen to fit in the whole buffer width.
+    "Name": "BasicTest_6",
+    "Lines": [
+      "\u001b[0m\u001b[97m123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
+      "\u001b[0m\u001b[37m>> \u001b[0m\u001b[97m123456789012345678901234567890123456789012345678901234567890123456789012345678901234567",
+      "\u001b[0m\u001b[37m>> \u001b[0m\u001b[97m123456"
+    ],
+    "OldBufferWidth": 90,
+    "NewBufferWidth": 124,
+    "Context": [
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        // Pointing to the end of the the third logical line.
+        "OldCursor": {
+          "X": 9,
+          "Y": 5
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 2147483647
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        "NewCursor": {
+          "X": 9,
+          "Y": 5
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        // Pointing to '3' of the third logical line.
+        "OldCursor": {
+          "X": 5,
+          "Y": 5
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 5
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        "NewCursor": {
+          "X": 5,
+          "Y": 5
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        // Pointing to '1' of the third logical line.
+        "OldCursor": {
+          "X": 3,
+          "Y": 5
+        },
+
+        "Offset": {
+          "LineIndex": 2,
+          "CharIndex": 3
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        "NewCursor": {
+          "X": 3,
+          "Y": 5
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        // Pointing to the end of the second logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 5
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 2147483647
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        "NewCursor": {
+          "X": 90,
+          "Y": 4
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        // Pointing to the end of the second logical line.
+        "OldCursor": {
+          "X": 89,
+          "Y": 4
+        },
+
+        "Offset": {
+          "LineIndex": 1,
+          "CharIndex": 89
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        "NewCursor": {
+          "X": 89,
+          "Y": 4
+        }
+      },
+      {
+        "OldInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        // Pointing to the end of the first logical line.
+        "OldCursor": {
+          "X": 0,
+          "Y": 4
+        },
+
+        "Offset": {
+          "LineIndex": 0,
+          "CharIndex": 2147483647
+        },
+
+        "NewInitial": {
+          "X": 6,
+          "Y": 3
+        },
+        "NewCursor": {
+          "X": 90,
+          "Y": 3
+        }
+      }
+    ]
+  }
+]

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -1,5 +1,5 @@
 
-$MinimalSDKVersion = '6.0.100-preview.1.21103.13'
+$MinimalSDKVersion = '6.0.100'
 $IsWindowsEnv = [System.Environment]::OSVersion.Platform -eq "Win32NT"
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $LocalDotnetDirPath = if ($IsWindowsEnv) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }
@@ -39,7 +39,7 @@ function Find-Dotnet
             $env:PATH = $LocalDotnetDirPath + [IO.Path]::PathSeparator + $env:PATH
         }
         else {
-            throw "Cannot find the dotnet SDK for .NET 5. Please specify '-Bootstrap' to install build dependencies."
+            throw "Cannot find the dotnet SDK with the version $MinimalSDKVersion or higher. Please specify '-Bootstrap' to install build dependencies."
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #2984
Fix `PhysicalLineCount` to take into account that double-cell character may get wrapped to the next line when it cannot fit in the current physical line.

Fix #2954
Handle the special case where the screen is cleared by a terminal UI utility in `RecomputeInitialCoords`.

Fix #1884
Improve `RecomputeInitialCoords` by using the old cursor position in the rendered text on screen to calculate the new initial coordinates when there is any change to `_buffer` and `_current`. Before this change, we always depend on `_buffer` and `_current` to re-calculate the new initial coordinates, but `_buffer` and `_current` may have changed when we are doing the re-calculation, for example, `Escape` is pressed to revert line, in which case `_buffer` will be reset and `_current` will be 0. That would result in wrong calculation and exception being thrown.

Fix #1456
Improve `RecomputeInitialCoords` to handle the `max-size => normal-size => max-size` resizing.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3074)