### PR TITLE
Skip the AST analysis when command-line input has any parsing errors

### DIFF
--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -565,10 +565,24 @@ namespace Microsoft.PowerShell
                 return AddToHistoryOption.MemoryAndFile;
             }
 
+            // The input contains at least one match of some sensitive patterns, so now we need to further
+            // analyze the input using the ASTs to see if it should actually be considered sensitive.
             bool isSensitive = false;
+            ParseError[] parseErrors = _singleton._parseErrors;
+
+            // We need to compare the text here, instead of simply checking whether or not '_ast' is null.
+            // This is because we may need to update from history file in the middle of editing an input,
+            // and in that case, the '_ast' may be not-null, but it was not parsed from 'line'.
             Ast ast = string.Equals(_singleton._ast?.Extent.Text, line)
                 ? _singleton._ast
-                : Parser.ParseInput(line, out _, out _);
+                : Parser.ParseInput(line, out _, out parseErrors);
+
+            if (parseErrors != null && parseErrors.Length > 0)
+            {
+                // If the input has any parsing errors, we cannot reliably analyze the AST. We just consider
+                // it sensitive in this case, given that it contains matches of our sensitive pattern.
+                return AddToHistoryOption.MemoryOnly;
+            }
 
             do
             {

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -721,6 +721,7 @@ namespace Microsoft.PowerShell
             _mark = 0;
             _emphasisStart = -1;
             _emphasisLength = 0;
+            _ast = null;
             _tokens = null;
             _parseErrors = null;
             _inputAccepted = false;

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -201,7 +201,8 @@ namespace Test
                 "Get-SecretInfo -Name mytoken; Get-SecretVault; Register-SecretVault; Remove-Secret apikey; Set-Secret", // 'Set-Secret' Not saved to file.
                 "Set-SecretInfo -Name apikey; Set-SecretVaultDefault; Test-SecretVault; Unlock-SecretVault -password $pwd; Unregister-SecretVault -SecretVault vaultInfo",
                 "Get-ResultFromTwo -Secret1 (Get-Secret -Name blah -AsPlainText) -Secret2 $secret2",
-                "Get-ResultFromTwo -Secret1 (Get-Secret -Name blah -AsPlainText) -Secret2 sdv87ysdfayf798hfasd8f7ha" // '-Secret2' has expr-value argument. Not saved to file.
+                "Get-ResultFromTwo -Secret1 (Get-Secret -Name blah -AsPlainText) -Secret2 sdv87ysdfayf798hfasd8f7ha", // '-Secret2' has expr-value argument. Not saved to file.
+                "$environment -brand $brand -userBitWardenEmail $bwuser -userBitWardenPassword $bwpass" // '-userBitWardenPassword' matches sensitive pattern and it has parsing error. Not save to file.
             };
 
             string[] expectedSavedItems = new[] {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3066

Skip the AST analysis when command-line input has any parsing errors in the default sensitive history scrubbing function.
When a command-line input matches sensitive pattern and has parsing error, we don't further analyze its AST because we cannot reliably do so with incorrect ASTs. In that case, we just consider it sensitive, given that it contains matches of our sensitive patterns.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3075)