### PR TITLE
Fix the regex matching in the issue-triage script

### DIFF
--- a/tools/issue-mgmt/CloseDupIssues.ps1
+++ b/tools/issue-mgmt/CloseDupIssues.ps1
@@ -60,10 +60,8 @@ If you want to remove that beta version of PSReadLine and use the 2.1.0 version 
     }
     elseif ($title.Contains('https://github.com/PowerShell/PSReadLine/issues/new') -or
             $body.Contains('https://github.com/PowerShell/PSReadLine/issues/new') -or
-            $body -match 'PSReadLine: 2\.\d\.\d(-\w+)?' -or
-            $body -match 'PSReadline version: 2\.\d\.\d(-\w+)?' -or
-            $body -match 'PowerShell: 7\.\d\.\d' -or
-            $body -match 'PS version: 7\.\d\.\d')
+            $body -match 'PSReadLine( version)?: (2\.[01]\.\d$)|(2\.[2-5]\.\d(-\w+)?$)' -or
+            $body -match '(PowerShell|PS version): 7\.\d\.\d')
     {
         ## The issue reported a recent version of PSReadLine, so leave it as is.
         continue


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix the regex matching in the issue-triage script. The old regex filtered out issues reported about `2.0.0-beta2` version of PSReadLine by mistake.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3082)