### PR TITLE
Fix the regex for matching 7.2.x PS versions for GitHub action

### DIFF
--- a/tools/issue-mgmt/CloseDupIssues.ps1
+++ b/tools/issue-mgmt/CloseDupIssues.ps1
@@ -44,7 +44,7 @@ foreach ($item in $issues)
 
     if ($body.Contains("System.TypeLoadException: Could not load type 'System.Management.Automation.Subsystem.PredictionResult'") -and
         $body -match 'PSReadLine: 2\.2\.0-beta[12]' -and
-        $body -match 'PowerShell: 7\.2\.0')
+        $body -match 'PowerShell: 7\.2\.\d')
     {
         $comment = @'
 This issue was fixed in 2.2.0-beta3 version of PSReadLine. You can fix this by upgrading to the latest [2.2.0-beta4 version of PSReadLine](https://www.powershellgallery.com/packages/PSReadLine/2.2.0-beta4). Instructions for doing so:


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix the regex for matching 7.2.x PS versions for GitHub action

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3110)