### PR TITLE
Make `HistorySearchBackward` and `HistorySearchForward` able to navigate the prediction list view

### DIFF
--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -958,6 +958,11 @@ namespace Microsoft.PowerShell
                 numericArg = -numericArg;
             }
 
+            if (UpdateListSelection(numericArg))
+            {
+                return;
+            }
+
             _singleton.SaveCurrentLine();
             _singleton.HistorySearch(numericArg);
         }
@@ -969,6 +974,10 @@ namespace Microsoft.PowerShell
         public static void HistorySearchForward(ConsoleKeyInfo? key = null, object arg = null)
         {
             TryGetArgAsInt(arg, out var numericArg, +1);
+            if (UpdateListSelection(numericArg))
+            {
+                return;
+            }
 
             _singleton.SaveCurrentLine();
             _singleton.HistorySearch(numericArg);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #1933

The <kbd>UpArrow</kbd> and <kbd>DownArrow</kbd> are bound to `PreviousHistory` and `NextHistory` by default, However, it's not uncommon for users to re-bind <kbd>UpArrow</kbd> and <kbd>DownArrow</kbd> to `HistorySearchBackward` and `HistorySearchForward`, and in that case, navigating the prediction list view would be broken.

This PR makes `HistorySearchBackward` and `HistorySearchForward` able to navigate the prediction list view, just like `PreviousHistory` and `NextHistory`.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3144)