### PR TITLE
Update build agent per requirement

### DIFF
--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -21,7 +21,7 @@ stages:
   pool:
     name: PowerShell1ES
     demands:
-    - ImageOverride -equals MMS2019
+    - ImageOverride -equals MMSWindows2019-Secure
   jobs:
   - job: build_windows
     displayName: Build PSReadLine
@@ -137,7 +137,7 @@ stages:
   pool:
     name: PowerShell1ES
     demands:
-    - ImageOverride -equals MMS2019
+    - ImageOverride -equals MMSWindows2019-Secure
   jobs:
   - job: Compliance_Job
     displayName: PSReadLine Compliance


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update build agent per requirement.
It's required to update the build agent to use `MMSWindows2019-Secure`. Test build: https://dev.azure.com/mscodehub/PSReadLine/_build/results?buildId=235174&view=results (build failed as expected, but the build agent works)

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3174)