### PR TITLE
Update comment message to use `2.2.1-rc1` as the latest version

### DIFF
--- a/tools/issue-mgmt/CloseDupIssues.ps1
+++ b/tools/issue-mgmt/CloseDupIssues.ps1
@@ -46,9 +46,8 @@ foreach ($item in $issues)
         $body -match 'PSReadLine: 2\.2\.0-beta[12]')
     {
         $comment = @'
-This issue was fixed in 2.2.0-beta3 version of PSReadLine. You can fix this by upgrading to the latest [2.2.0-beta5 version of PSReadLine](https://www.powershellgallery.com/packages/PSReadLine/2.2.0-beta5). Instructions for doing so:
-1. stop all instances of `pwsh`.
-2. from `cmd.exe` on Windows or `bash` on Linux, run: `pwsh -noprofile -command \"Install-Module PSReadLine -AllowPrerelease -Force\"`
+This issue was fixed in 2.2.0-beta3 version of PSReadLine. You can fix this by upgrading to the latest [2.2.1-rc1 version of PSReadLine](https://www.powershellgallery.com/packages/PSReadLine/2.2.1-rc1).
+To upgrade, simply run `Install-Module PSReadLine -AllowPrerelease -Force` from your PowerShell console.
 
 --------
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update comment message to use `2.2.1-rc1` as the latest PSReadLine version.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3189)