### PR TITLE
No need to clear lines when it's not a menu completion rendering

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -506,26 +506,26 @@ namespace Microsoft.PowerShell
                     }
                 }
 
-                // if the menu has moved, we need to clear the lines under it
-                if (Top < PreviousTop)
-                {
-                    // In either of the following two cases, we will need to move the cursor to the next line:
-                    //  - if extra rows from previous menu were cleared, then we know the current line was erased
-                    //    but the cursor was not moved to the next line.
-                    //  - if 'CursorLeft != 0', then the rest of the last menu row was erased, but the cursor
-                    //    was not moved to the next line.
-                    if (extraPreRowsCleared || console.CursorLeft != 0)
-                    {
-                        // There are lines from the previous rendering that need to be cleared,
-                        // so we are sure there is no need to scroll.
-                        MoveCursorDown(1);
-                    }
-
-                    Singleton.WriteBlankLines(PreviousTop - Top);
-                }
-
                 if (menuSelect)
                 {
+                    // if the menu has moved, we need to clear the lines under it
+                    if (Top < PreviousTop)
+                    {
+                        // In either of the following two cases, we will need to move the cursor to the next line:
+                        //  - if extra rows from previous menu were cleared, then we know the current line was erased
+                        //    but the cursor was not moved to the next line.
+                        //  - if 'CursorLeft != 0', then the rest of the last menu row was erased, but the cursor
+                        //    was not moved to the next line.
+                        if (extraPreRowsCleared || console.CursorLeft != 0)
+                        {
+                            // There are lines from the previous rendering that need to be cleared,
+                            // so we are sure there is no need to scroll.
+                            MoveCursorDown(1);
+                        }
+
+                        Singleton.WriteBlankLines(PreviousTop - Top);
+                    }
+
                     RestoreCursor();
                     console.CursorVisible = true;
                 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3196
No need to clear lines when it's not a menu completion rendering.

The fix is simply moving the code that handles line cleanup for menu movement to the `if (menuSelect)` block.
It's much easier to review when ignoring white space changes: https://github.com/PowerShell/PSReadLine/pull/3199/files?w=1

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3199)