### PR TITLE
Update comment message to use 2.2.2 as the latest version

### DIFF
--- a/tools/issue-mgmt/CloseDupIssues.ps1
+++ b/tools/issue-mgmt/CloseDupIssues.ps1
@@ -11,7 +11,7 @@ class issue
 $repo_name = "PowerShell/PSReadLine"
 $root_url = "https://github.com/PowerShell/PSReadLine/issues"
 $msg_upgrade = @"
-Please upgrade to the [2.1.0 version of PSReadLine](https://www.powershellgallery.com/packages/PSReadLine/2.1.0) from PowerShell Gallery.
+Please upgrade to the [2.2.2 version of PSReadLine](https://www.powershellgallery.com/packages/PSReadLine/2.2.2) from PowerShell Gallery.
 See the [upgrading section](https://github.com/PowerShell/PSReadLine#upgrading) for instructions. Please let us know if you run into the same issue with the latest version.
 "@
 
@@ -46,7 +46,7 @@ foreach ($item in $issues)
         $body -match 'PSReadLine: 2\.2\.0-beta[12]')
     {
         $comment = @'
-This issue was fixed in 2.2.0-beta3 version of PSReadLine. You can fix this by upgrading to the latest [2.2.1-rc1 version of PSReadLine](https://www.powershellgallery.com/packages/PSReadLine/2.2.1-rc1).
+This issue was fixed in 2.2.0-beta3 version of PSReadLine. You can fix this by upgrading to the latest [2.2.2 version of PSReadLine](https://www.powershellgallery.com/packages/PSReadLine/2.2.2).
 To upgrade, simply run `Install-Module PSReadLine -AllowPrerelease -Force` from your PowerShell console.
 
 --------


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Update the comments for auto-triage to recommend the latest 2.2 GA version of PSReadLine.
## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3218)