### PR TITLE
Prepare for the 2.2.3 release of PSReadLine

### DIFF
--- a/PSReadLine/Changes.txt
+++ b/PSReadLine/Changes.txt
@@ -1,3 +1,9 @@
+### [2.2.3] - 2022-04-20
+
+- Respect cancellation in `ReadOneOrMoreKeys()` (#3274, #3280)
+
+[2.2.3]: https://github.com/PowerShell/PSReadLine/compare/v2.2.2...v2.2.3
+
 ### [2.2.2] - 2022-02-22
 
 - Update to use the 1.0.0 version of `Microsoft.PowerShell.Pager` (#3206)

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -5,9 +5,9 @@
     <RootNamespace>Microsoft.PowerShell.PSReadLine</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.PSReadLine2</AssemblyName>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
-    <AssemblyVersion>2.2.2.0</AssemblyVersion>
-    <FileVersion>2.2.2</FileVersion>
-    <InformationalVersion>2.2.2</InformationalVersion>
+    <AssemblyVersion>2.2.3.0</AssemblyVersion>
+    <FileVersion>2.2.3</FileVersion>
+    <InformationalVersion>2.2.3</InformationalVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>

--- a/PSReadLine/PSReadLine.psd1
+++ b/PSReadLine/PSReadLine.psd1
@@ -1,7 +1,7 @@
 ﻿@{
 RootModule = 'PSReadLine.psm1'
 NestedModules = @("Microsoft.PowerShell.PSReadLine2.dll")
-ModuleVersion = '2.2.2'
+ModuleVersion = '2.2.3'
 GUID = '5714753b-2afd-4492-a5fd-01d9e2cff8b5'
 Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Prepare for the 2.2.3 release of PSReadLine.
The 2.2.3 release is a servicing release that contains only 1 fix, for the [`ReadKey` issue in PowerShell editor service](https://github.com/PowerShell/PowerShellEditorServices/pull/1751).

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3283)