### PR TITLE
Sync ReadKeyProc thread with pipeline thread

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -143,8 +143,7 @@ namespace Microsoft.PowerShell
                 }
                 while (_charMap.KeyAvailable)
                 {
-                    ConsoleKeyInfo keyInfo = _charMap.ReadKey();
-                    var key = PSKeyInfo.FromConsoleKeyInfo(keyInfo);
+                    var key = PSKeyInfo.FromConsoleKeyInfo(_charMap.ReadKey());
                     _lastNKeys.Enqueue(key);
                     _queuedKeys.Enqueue(key);
                 }

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -33,8 +33,6 @@ namespace Microsoft.PowerShell
     {
         private const int ConsoleExiting = 1;
 
-        private const int CancellationRequested = 2;
-
         // *must* be initialized in the static ctor
         // because the static member _clipboard depends upon it
         // for its own initialization
@@ -194,7 +192,6 @@ namespace Microsoft.PowerShell
                     //   - a key is pressed
                     //   - the console is exiting
                     //   - 300ms timeout - to process events if we're idle
-                    //   - ReadLine cancellation is requested externally
                     handleId = WaitHandle.WaitAny(_singleton._requestKeyWaitHandles, 300);
                     if (handleId != WaitHandle.WaitTimeout)
                     {

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -38,8 +38,6 @@ namespace Microsoft.PowerShell
         // for its own initialization
         private static readonly PSConsoleReadLine _singleton;
 
-        private static readonly CancellationToken _defaultCancellationToken = new CancellationTokenSource().Token;
-
         // This is used by PowerShellEditorServices (the backend of the PowerShell VSCode extension)
         // so that it can call PSReadLine from a delegate and not hit nested pipeline issues.
         #pragma warning disable CS0649
@@ -316,9 +314,7 @@ namespace Microsoft.PowerShell
         /// <returns>The complete command line.</returns>
         public static string ReadLine(Runspace runspace, EngineIntrinsics engineIntrinsics, bool? lastRunStatus)
         {
-            // Use a default cancellation token instead of CancellationToken.None because the
-            // WaitHandle is shared and could be triggered accidently.
-            return ReadLine(runspace, engineIntrinsics, _defaultCancellationToken, lastRunStatus);
+            return ReadLine(runspace, engineIntrinsics, CancellationToken.None, lastRunStatus);
         }
 
         /// <summary>


### PR DESCRIPTION

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3292

The pipeline thread was returning before the `ReadKeyProc` thread had finished processing the dummy input. This was occurring somewhat frequently when `ReadLine` was invoked multiple times in a row, surfacing a race condition.

With these changes, the pipeline thread will wait for dummy input to be received, dequeue the key, and continue with normal cancellation logic.


## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3294)