### PR TITLE
Handle multi-line description for parameter help content

### DIFF
--- a/PSReadLine/DynamicHelp.cs
+++ b/PSReadLine/DynamicHelp.cs
@@ -202,28 +202,40 @@ namespace Microsoft.PowerShell
             {
                 helpBlock = new Collection<string>()
                 {
-                    String.Empty,
+                    string.Empty,
                     PSReadLineResources.NeedsUpdateHelp
                 };
             }
             else
             {
                 string syntax = $"-{helpContent.name} <{helpContent.type.name}>";
-                string desc = "DESC: " + helpContent.Description[0].Text;
-
-                // trim new line characters as some help content has it at the end of the first list on the description.
-                desc = desc.Trim('\r', '\n');
-
-                string details = $"Required: {helpContent.required}, Position: {helpContent.position}, Default Value: {helpContent.defaultValue}, Pipeline Input: {helpContent.pipelineInput}, WildCard: {helpContent.globbing}";
-
                 helpBlock = new Collection<string>
                 {
                     string.Empty,
                     syntax,
-                    string.Empty,
-                    desc,
-                    details
+                    string.Empty
                 };
+
+                string text = helpContent.Description[0].Text;
+                if (text.Contains("\n"))
+                {
+                    string[] lines = text.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                    for (int i = 0; i < lines.Length; i++)
+                    {
+                        string prefix = i == 0 ? "DESC: " : "      ";
+                        string s = prefix + lines[i].Trim('\r');
+                        helpBlock.Add(s);
+                    }
+                }
+                else
+                {
+                    string desc = "DESC: " + text;
+                    // trim new line characters as some help content has it at the end of the first list on the description.
+                    helpBlock.Add(desc.Trim('\r', '\n'));
+                }
+
+                string details = $"Required: {helpContent.required}, Position: {helpContent.position}, Default Value: {helpContent.defaultValue}, Pipeline Input: {helpContent.pipelineInput}, WildCard: {helpContent.globbing}";
+                helpBlock.Add(details);
             }
 
             WriteDynamicHelpBlock(helpBlock);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3356

Handle multi-line description for parameter help content.

![CompletionPredictor](https://user-images.githubusercontent.com/127450/175749937-97b11dcb-2dbc-4bf6-b846-4d721fb80935.gif)

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3358)