### PR TITLE
Feat: add support for upcasing, downcasing, and capitalizing word

### DIFF
--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -246,6 +246,72 @@ namespace Microsoft.PowerShell
             _singleton.DeleteCharImpl(1, orExit: true);
         }
 
+        /// <summary>
+        /// A helper function to change the case of the current word.
+        /// </summary>
+        private static void UpdateWordCase(bool toUpper, ConsoleKeyInfo? key = null, object arg = null)
+        {
+            if (_singleton._current >= _singleton._buffer.Length)
+            {
+                Ding();
+                return;
+            }
+
+            int endOfWord = _singleton.FindForwardWordPoint(_singleton.Options.WordDelimiters);
+            int wordlen = endOfWord - _singleton._current;
+
+            string word = _singleton._buffer.ToString(_singleton._current, wordlen);
+            word = toUpper ? word.ToUpper() : word.ToLower();
+
+            Replace(_singleton._current, wordlen, word);
+
+            _singleton.MoveCursor(endOfWord);
+            _singleton.Render();
+        }
+
+        /// <summary>
+        /// Upcase the current word and move to the next one.
+        /// </summary>
+        public static void UpcaseWord(ConsoleKeyInfo? key = null, object arg = null)
+        {
+          UpdateWordCase(true, key, arg);
+        }
+
+        /// <summary>
+        /// Downcase the current word and move to the next one.
+        /// </summary>
+        public static void DowncaseWord(ConsoleKeyInfo? key = null, object arg = null)
+        {
+          UpdateWordCase(false, key, arg);
+        }
+
+        /// <summary>
+        /// Capitalize the current word and move to the next one.
+        /// </summary>
+        public static void CapitalizeWord(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            if (_singleton._current >= _singleton._buffer.Length)
+            {
+                Ding();
+                return;
+            }
+
+            int endOfWord = _singleton.FindForwardWordPoint(_singleton.Options.WordDelimiters);
+            int wordlen = endOfWord - _singleton._current;
+
+            char[] word = _singleton._buffer.ToString(_singleton._current, wordlen).ToLower().ToCharArray();
+            int idxFirstLetter = Array.FindIndex(word, x => char.IsLetter(x));
+
+            if (idxFirstLetter >= 0)
+            {
+              word[idxFirstLetter] = Char.ToUpper(word[idxFirstLetter]);
+              Replace(_singleton._current, wordlen, new string(word));
+            }
+
+            _singleton.MoveCursor(endOfWord);
+            _singleton.Render();
+        }
+
         private bool AcceptLineImpl(bool validate)
         {
             using var _ = _prediction.DisableScoped();

--- a/PSReadLine/BasicEditing.cs
+++ b/PSReadLine/BasicEditing.cs
@@ -249,7 +249,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// A helper function to change the case of the current word.
         /// </summary>
-        private static void UpdateWordCase(bool toUpper, ConsoleKeyInfo? key = null, object arg = null)
+        private static void UpdateWordCase(bool toUpper)
         {
             if (_singleton._current >= _singleton._buffer.Length)
             {
@@ -274,7 +274,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void UpcaseWord(ConsoleKeyInfo? key = null, object arg = null)
         {
-          UpdateWordCase(true, key, arg);
+            UpdateWordCase(toUpper: true);
         }
 
         /// <summary>
@@ -282,7 +282,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void DowncaseWord(ConsoleKeyInfo? key = null, object arg = null)
         {
-          UpdateWordCase(false, key, arg);
+            UpdateWordCase(toUpper: false);
         }
 
         /// <summary>
@@ -300,12 +300,12 @@ namespace Microsoft.PowerShell
             int wordlen = endOfWord - _singleton._current;
 
             char[] word = _singleton._buffer.ToString(_singleton._current, wordlen).ToLower().ToCharArray();
-            int idxFirstLetter = Array.FindIndex(word, x => char.IsLetter(x));
+            int firstLetterIdx = Array.FindIndex(word, static x => char.IsLetter(x));
 
-            if (idxFirstLetter >= 0)
+            if (firstLetterIdx >= 0)
             {
-              word[idxFirstLetter] = Char.ToUpper(word[idxFirstLetter]);
-              Replace(_singleton._current, wordlen, new string(word));
+                word[firstLetterIdx] = char.ToUpper(word[firstLetterIdx]);
+                Replace(_singleton._current, wordlen, new string(word));
             }
 
             _singleton.MoveCursor(endOfWord);

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -339,6 +339,9 @@ namespace Microsoft.PowerShell
                 { Keys.AltH,                   MakeKeyHandler(ShowParameterHelp,         "ShowParameterHelp") },
                 { Keys.F1,                     MakeKeyHandler(ShowCommandHelp,           "ShowCommandHelp") },
                 { Keys.F2,                     MakeKeyHandler(SwitchPredictionView,      "SwitchPredictionView") },
+                { Keys.AltU,                   MakeKeyHandler(UpcaseWord,                "UpcaseWord") },
+                { Keys.AltL,                   MakeKeyHandler(DowncaseWord,              "DowncaseWord") },
+                { Keys.AltC,                   MakeKeyHandler(CapitalizeWord,            "CapitalizeWord") },
             };
 
             // Some bindings are not available on certain platforms
@@ -371,6 +374,9 @@ namespace Microsoft.PowerShell
                     { Keys.F,         MakeKeyHandler(ForwardWord,      "ForwardWord")},
                     { Keys.R,         MakeKeyHandler(RevertLine,       "RevertLine")},
                     { Keys.Y,         MakeKeyHandler(YankPop,          "YankPop")},
+                    { Keys.U,         MakeKeyHandler(UpcaseWord,       "UpcaseWord") },
+                    { Keys.L,         MakeKeyHandler(DowncaseWord,     "DowncaseWord") },
+                    { Keys.C,         MakeKeyHandler(CapitalizeWord,   "CapitalizeWord") },
                     { Keys.CtrlY,     MakeKeyHandler(YankNthArg,       "YankNthArg")},
                     { Keys.Backspace, MakeKeyHandler(BackwardKillWord, "BackwardKillWord")},
                     { Keys.Period,    MakeKeyHandler(YankLastArg,      "YankLastArg")},
@@ -399,14 +405,15 @@ namespace Microsoft.PowerShell
             case nameof(AcceptAndGetNext):
             case nameof(AcceptLine):
             case nameof(AddLine):
-            case nameof(BackwardDeleteInput):
             case nameof(BackwardDeleteChar):
+            case nameof(BackwardDeleteInput):
             case nameof(BackwardDeleteLine):
             case nameof(BackwardDeleteWord):
             case nameof(BackwardKillInput):
             case nameof(BackwardKillLine):
             case nameof(BackwardKillWord):
             case nameof(CancelLine):
+            case nameof(CapitalizeWord):
             case nameof(Copy):
             case nameof(CopyOrCancelLine):
             case nameof(Cut):
@@ -414,13 +421,14 @@ namespace Microsoft.PowerShell
             case nameof(DeleteCharOrExit):
             case nameof(DeleteEndOfBuffer):
             case nameof(DeleteEndOfWord):
-            case nameof(DeleteRelativeLines):
             case nameof(DeleteLine):
             case nameof(DeleteLineToFirstChar):
             case nameof(DeleteNextLines):
             case nameof(DeletePreviousLines):
+            case nameof(DeleteRelativeLines):
             case nameof(DeleteToEnd):
             case nameof(DeleteWord):
+            case nameof(DowncaseWord):
             case nameof(ForwardDeleteInput):
             case nameof(ForwardDeleteLine):
             case nameof(InsertLineAbove):
@@ -442,6 +450,7 @@ namespace Microsoft.PowerShell
             case nameof(Undo):
             case nameof(UndoAll):
             case nameof(UnixWordRubout):
+            case nameof(UpcaseWord):
             case nameof(ValidateAndAcceptLine):
             case nameof(ViAcceptLine):
             case nameof(ViAcceptLineOrExit):

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -2202,5 +2202,38 @@ namespace Microsoft.PowerShell.PSReadLine {
                 return ResourceManager.GetString("FailedToConvertPointToRenderDataOffset", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to: Find the next word starting from the current position and then make it Pascal case.
+        /// </summary>
+        internal static string CapitalizeWordDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("CapitalizeWordDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to: Find the next word starting from the current position and then make it lower case.
+        /// </summary>
+        internal static string DowncaseWordDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("DowncaseWordDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to: Find the next word starting from the current position and then make it upper case.
+        /// </summary>
+        internal static string UpcaseWordDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("UpcaseWordDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -858,4 +858,13 @@ Or not saving history with:
   <data name="FailedToConvertPointToRenderDataOffset" xml:space="preserve">
     <value>Cannot locate the offset in the rendered text that was pointed by the original cursor. Initial Coord: ({0}, {1}) Buffer: ({2}, {3}) Cursor: ({4}, {5})</value>
   </data>
+  <data name="CapitalizeWordDescription" xml:space="preserve">
+    <value>Find the next word starting from the current position and then make it Pascal case.</value>
+  </data>
+  <data name="DowncaseWordDescription" xml:space="preserve">
+    <value>Find the next word starting from the current position and then make it lower case.</value>
+  </data>
+  <data name="UpcaseWordDescription" xml:space="preserve">
+    <value>Find the next word starting from the current position and then make it upper case.</value>
+  </data>
 </root>

--- a/test/BasicEditingTest.cs
+++ b/test/BasicEditingTest.cs
@@ -201,6 +201,37 @@ namespace Test
         }
 
         [SkippableFact]
+        public void UpcaseWord()
+        {
+            TestSetup(KeyMode.Emacs);
+            Test("FOO", Keys("foo", _.Alt_b, _.Alt_u));
+            Test("FOO bar", Keys("foo bar", _.Home, _.Alt_u));
+            Test("foo BAR", Keys("foo bar", _.Alt_b, _.Alt_u));
+            Test("FOO BAR", Keys("foo bar", _.Home, Enumerable.Repeat(_.Alt_u, 2)));
+        }
+
+        [SkippableFact]
+        public void DowncaseWord()
+        {
+            TestSetup(KeyMode.Emacs);
+            Test("foo", Keys("fOO", _.Alt_b, _.Alt_l));
+            Test("FOO bar", Keys("FOO BAR", _.Alt_b, _.Alt_l));
+            Test("foo BAR", Keys("FOO BAR", _.Home, _.Alt_l));
+            Test("foo bar", Keys("FOO BAR", _.Home, Enumerable.Repeat(_.Alt_l, 2)));
+        }
+
+        [SkippableFact]
+        public void CapitalizeWord()
+        {
+            TestSetup(KeyMode.Emacs);
+            Test("Foo", Keys("fOO", _.Alt_b, _.Alt_c));
+            Test("fOO Bar", Keys("fOO bAR", _.Alt_b, _.Alt_c));
+            Test("Foo BAR", Keys("fOO BAR", _.Home, _.Alt_c));
+            Test("Foo Bar", Keys("fOO BAR", _.Home, Enumerable.Repeat(_.Alt_c, 2)));
+            Test("Foo ^&*() Bar", Keys("Foo ^&*() bar", _.Home, Enumerable.Repeat(_.Alt_c, 2)));
+        }
+
+        [SkippableFact]
         public void SelectAndDelete()
         {
             TestSetup(KeyMode.Cmd);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Closes #2912 

GNU Readline provides functionalities which let the user change the case of the word in front of the cursor. They can change the word to upper case or lower case, or they can capitalize it. The keybindings by default provided are as follows.

```bash
bind '"\ec": capitalize-word'    # default is alt-c
bind '"\eu": upcase-word'     # default is alt-u
bind '"\el": downcase-word'  # default is alt-l
```

This PR brings that functionality to PSReadLine.

The newly added bindable functions are in the "Basic editing functions" section:
- CapitalizeWord, bound to <kbd>Alt+c</kbd> and <kbd>Escape,c</kbd> in Emacs mode
- DowncaseWord, bound to <kbd>Alt+l</kbd> and <kbd>Escape,l</kbd> in Emacs mode
- UpcaseWord, bound to <kbd>Alt+u</kbd> and <kbd>Escape,u</kbd> in Emacs mode

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in
    - [x] conhost.exe (with MockPSConsole)
    - [x] Windows Terminal (with MockPSConsole)
    - [ ] Visual Studio Code Integrated Terminal
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/9033


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3365)