### PR TITLE
Fix parameter dynamic help when the help content is specified in `ParameterAttribute`

### DIFF
--- a/PSReadLine/DynamicHelp.cs
+++ b/PSReadLine/DynamicHelp.cs
@@ -198,7 +198,12 @@ namespace Microsoft.PowerShell
         {
             Collection<string> helpBlock;
 
-            if (string.IsNullOrEmpty(helpContent?.Description?[0]?.Text))
+            if (helpContent?.Description is not string descriptionText)
+            {
+                descriptionText = helpContent?.Description?[0]?.Text;
+            }
+
+            if (descriptionText is null)
             {
                 helpBlock = new Collection<string>()
                 {
@@ -216,7 +221,7 @@ namespace Microsoft.PowerShell
                     string.Empty
                 };
 
-                string text = helpContent.Description[0].Text;
+                string text = descriptionText;
                 if (text.Contains("\n"))
                 {
                     string[] lines = text.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
# PR Summary

Fix #3367
Fix parameter dynamic help when the help content is specified in `ParameterAttribute`.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3370)