### PR TITLE
Avoid triggering list view prediction when the first line was scrolled up off the screen buffer

### DIFF
--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -275,6 +275,13 @@ namespace Microsoft.PowerShell
 
             internal override void GetSuggestion(string userInput)
             {
+                if (_singleton._initialY < 0)
+                {
+                    // Do not trigger list view prediction when the first line has already been scrolled up off the buffer.
+                    // See https://github.com/PowerShell/PSReadLine/issues/3347 for an example where this may happen.
+                    return;
+                }
+
                 bool inputUnchanged = string.Equals(_inputText, userInput, _singleton._options.HistoryStringComparison);
                 if (!inputUnchanged && _selectedIndex > -1)
                 {


### PR DESCRIPTION
# PR Summary

Fix #3347

Avoid triggering the list view prediction when the first line was scrolled up off the screen buffer.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3372)