### PR TITLE
Fix incorrect cursor position in menu completion

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -561,6 +561,7 @@ namespace Microsoft.PowerShell
                     // Determine if showing the tooltip would scroll the top of our buffer off the screen.
 
                     int lineLength = 0;
+                    bool fullLine = false;
                     for (var i = 0; i < toolTip.Length; i++)
                     {
                         char c = toolTip[i];
@@ -572,8 +573,13 @@ namespace Microsoft.PowerShell
 
                         if (c == '\r' || c == '\n')
                         {
-                            toolTipLines += 1;
-                            lineLength = 0;
+                            // If we happened to have a full line right before the newline character, then we
+                            // skip this newline character because we already increased the line count.
+                            if (!fullLine)
+                            {
+                                toolTipLines += 1;
+                                lineLength = 0;
+                            }
                         }
                         else
                         {
@@ -582,8 +588,14 @@ namespace Microsoft.PowerShell
                             {
                                 toolTipLines += 1;
                                 lineLength = 0;
+
+                                // Indicate that we just had a full line.
+                                fullLine = true;
+                                continue;
                             }
                         }
+
+                        fullLine = false;
                     }
 
                     // The +1 is for the blank line between the menu and tooltips.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3369
Fix incorrect cursor position in menu completion.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3373)