### PR TITLE
Fix `ViModeIndicator = Cursor` for Windows Terminal

### DIFF
--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.Internal
                 // This is because this API works fine in console host, but not in Windows Terminal. The escape sequence will configure the
                 // cursor as expected in Windows Terminal, while in console host, the escape sequence works after it's written out, but then
                 // will be overwritten by 'CursorSize' when the user continues typing.
-                // We use blinking block and blinking underscore, so as to mimic the cursor size 100 and 25.
+                // We use blinking block and blinking underscore, so as to mimic the cursor size 100 and 25 in console host.
                 Write(value > 50 ? "\x1b[1 q" : "\x1b[3 q");
             }
         }

--- a/PSReadLine/ConsoleLib.cs
+++ b/PSReadLine/ConsoleLib.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.Internal
             set => Console.CursorTop = value;
         }
 
-        // .NET doesn't implement this API, so we fake it with a commonly supported escape sequence.
+        // .NET doesn't fully implement this API on all platforms, so we fake it with a commonly supported escape sequence.
         protected int _unixCursorSize = 25;
         public virtual int CursorSize
         {
@@ -45,9 +45,15 @@ namespace Microsoft.PowerShell.Internal
                 else
                 {
                     _unixCursorSize = value;
-                    // Solid blinking block or blinking vertical bar
-                    Write(value > 50 ? "\x1b[2 q" : "\x1b[5 q");
                 }
+
+                // See the cursor ANSI codes at https://www.real-world-systems.com/docs/ANSIcode.html, searching for 'blinking block'.
+                // We write out the ANSI escape sequence even if we are on Windows, where the 'Console.CursorSize' API is supported by .NET.
+                // This is because this API works fine in console host, but not in Windows Terminal. The escape sequence will configure the
+                // cursor as expected in Windows Terminal, while in console host, the escape sequence works after it's written out, but then
+                // will be overwritten by 'CursorSize' when the user continues typing.
+                // We use blinking block and blinking underscore, so as to mimic the cursor size 100 and 25.
+                Write(value > 50 ? "\x1b[1 q" : "\x1b[3 q");
             }
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Fix #3334 
Fix #1233

Fix `ViModeIndicator = Cursor` for Windows Terminal by writing out escape sequences that configure cursor shape.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3374)