### PR TITLE
Fix the description of `CapitalizeWord`

### DIFF
--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -2204,7 +2204,7 @@ namespace Microsoft.PowerShell.PSReadLine {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to: Find the next word starting from the current position and then make it Pascal case.
+        ///   Looks up a localized string similar to: Find the next word starting from the current position and then upcase the first character and downcase the remaining characters.
         /// </summary>
         internal static string CapitalizeWordDescription
         {

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -859,7 +859,7 @@ Or not saving history with:
     <value>Cannot locate the offset in the rendered text that was pointed by the original cursor. Initial Coord: ({0}, {1}) Buffer: ({2}, {3}) Cursor: ({4}, {5})</value>
   </data>
   <data name="CapitalizeWordDescription" xml:space="preserve">
-    <value>Find the next word starting from the current position and then make it Pascal case.</value>
+    <value>Find the next word starting from the current position and then upcase the first character and downcase the remaining characters.</value>
   </data>
   <data name="DowncaseWordDescription" xml:space="preserve">
     <value>Find the next word starting from the current position and then make it lower case.</value>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix the description of `CapitalizeWord` to not use "Pascal case" in it.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3384)