### PR TITLE
Place the built-in key-binding function `ViDGChord` in the right group

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -585,6 +585,7 @@ namespace Microsoft.PowerShell
             case nameof(ViEditVisually):
             case nameof(ViExit):
             case nameof(ViInsertMode):
+            case nameof(ViDGChord):
             case nameof(WhatIsKey):
             case nameof(ShowCommandHelp):
             case nameof(ShowParameterHelp):


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Place the built-in key-binding function `ViDGChord` in the right group.
Today, this binding shows up as the "user defined functions" in Vi mode, which is incorrect. Put it in the `Miscellaneous` group instead.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3422)