### PR TITLE
Changes F7 sample to use Out-ConsoleGridView

### DIFF
--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -20,62 +20,90 @@ Set-PSReadLineOption -HistorySearchCursorMovesToEnd
 Set-PSReadLineKeyHandler -Key UpArrow -Function HistorySearchBackward
 Set-PSReadLineKeyHandler -Key DownArrow -Function HistorySearchForward
 
-# This key handler shows the entire or filtered history using Out-GridView. The
+# Use F7 as "Show Command History" in Powershell
+#
+# Requires `Out-ConsoleGridView` from [PowerShell/GraphicalTools](https://github.com/PowerShell/GraphicalTools). 
+#
+#  1. Install `ConsoleGuiTools` by typing the command `Install-Module -Name Microsoft.PowerShell.ConsoleGuiTools`
+#  2. Include the `F7History.ps1` script in your $profile:
+#
+#      # Include (don't RUN) the script by prefixing it with `. `.
+#      . ~/source/F7History/F7History.ps1
+#
+# This key handler shows the entire or filtered history using Out-ConsoleGridView. The
 # typed text is used as the substring pattern for filtering. A selected command
-# is inserted to the command line without invoking. Multiple command selection
-# is supported, e.g. selected by Ctrl + Click.
-Set-PSReadLineKeyHandler -Key F7 `
-                         -BriefDescription History `
-                         -LongDescription 'Show command history' `
-                         -ScriptBlock {
-    $pattern = $null
-    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$pattern, [ref]$null)
-    if ($pattern)
-    {
-        $pattern = [regex]::Escape($pattern)
+# is inserted to the command line without invoking. 
+#
+# Below is a copy of F7History.ps1 - See: https://github.com/gui-cs/F7History
+################################################################################
+# ocgv_history -Global $true | $false
+#
+# Uses Out-ConsoleGridView to display either the local or global command history
+# If an item is selected in OCGV, it will be returned as output and placed on 
+# the command line.
+# 
+# Anything on the command line when this function is executed will be used as the 
+# -Filter for OCGV. E.g. to search the command line for all commands starting 
+# with "git", type "git" on the command line and press F7 or Shift-F7.
+#
+# Run this script from your Powershell Profile
+# 
+function ocgv_history {
+  param(
+    [parameter(Mandatory=$true)]
+    [Boolean]
+    $global
+  )
+
+  $line = $null
+  $cursor = $null
+  [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
+  if ($global) {
+    # Global history
+    $history = [Microsoft.PowerShell.PSConsoleReadLine]::GetHistoryItems().CommandLine 
+    # reverse the items so most recent is on top
+    [array]::Reverse($history) 
+    $selection = $history | Select-Object -Unique | Out-ConsoleGridView -OutputMode Single -Filter $line -Title "Global Command Line History"
+
+  } else {
+    # Local history
+    $history = Get-History | Sort-Object -Descending -Property Id -Unique | Select-Object CommandLine -ExpandProperty CommandLine 
+    $selection = $history | Out-ConsoleGridView -OutputMode Single -Filter $line -Title "Command Line History"
+  }
+
+  if ($selection) {
+    [Microsoft.PowerShell.PSConsoleReadLine]::DeleteLine()
+    [Microsoft.PowerShell.PSConsoleReadLine]::Insert($selection)
+    if ($selection.StartsWith($line)) {
+      [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($cursor)
     }
-
-    $history = [System.Collections.ArrayList]@(
-        $last = ''
-        $lines = ''
-        foreach ($line in [System.IO.File]::ReadLines((Get-PSReadLineOption).HistorySavePath))
-        {
-            if ($line.EndsWith('`'))
-            {
-                $line = $line.Substring(0, $line.Length - 1)
-                $lines = if ($lines)
-                {
-                    "$lines`n$line"
-                }
-                else
-                {
-                    $line
-                }
-                continue
-            }
-
-            if ($lines)
-            {
-                $line = "$lines`n$line"
-                $lines = ''
-            }
-
-            if (($line -cne $last) -and (!$pattern -or ($line -match $pattern)))
-            {
-                $last = $line
-                $line
-            }
-        }
-    )
-    $history.Reverse()
-
-    $command = $history | Out-GridView -Title History -PassThru
-    if ($command)
-    {
-        [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
-        [Microsoft.PowerShell.PSConsoleReadLine]::Insert(($command -join "`n"))
-    }
+    else {
+      [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($selection.Length)
+    }    
+  }      
 }
+
+# When F7 is pressed, show the local command line history in OCGV
+$parameters = @{
+  Key = 'F7'
+  BriefDescription = 'Show Matching History'
+  LongDescription = 'Show Matching History using Out-ConsoleGridView'
+  ScriptBlock = {
+    ocgv_history -Global $false 
+  }
+}
+Set-PSReadLineKeyHandler @parameters
+
+# When Shift-F7 is pressed, show the local command line history in OCGV
+$parameters = @{
+  Key = 'Shift-F7'
+  BriefDescription = 'Show Matching Global History'
+  LongDescription = 'Show Matching History for all PowerShell instances using Out-ConsoleGridView'
+  ScriptBlock = {
+    ocgv_history -Global $true
+  }
+}
+Set-PSReadLineKeyHandler @parameters
 
 # This is an example of a macro that you might use to execute a command.
 # This will add the command to history.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Updates the PSReadLine sample code to use `Out-ConsoleGridView` instead of the defunct (and not cross platform) `Out-GridView`.

Note that the old sample supported multi-select and the F7History.ps1 sample does not. It is possible to modify it to support multi-select, but doing so exposes a big question:

- In what order should the selected history items be executed. Neither `Out-GridView` or `Out-ConsoleGridView` support a way for the user to determine this. 

## PR Checklist

- [ X] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [ X] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ X] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3435)