### PR TITLE
Change Default member color back to original default of gray

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -526,7 +526,7 @@ namespace Microsoft.PowerShell
             ParameterColor    = DefaultParameterColor;
             TypeColor         = DefaultTypeColor;
             NumberColor       = DefaultNumberColor;
-            MemberColor       = DefaultNumberColor;
+            MemberColor       = DefaultMemberColor;
             EmphasisColor     = DefaultEmphasisColor;
             ErrorColor        = DefaultErrorColor;
             InlinePredictionColor       = DefaultInlinePredictionColor;


### PR DESCRIPTION
# PR Summary

Making member color go to default member color instead of default number color. This changes member color to be Brought to attention by #3445 

Changes current member color from white to grey. Originally in the code `DefaultMemberColor` is `ConsoleColor.Gray` and seems to just be a typo mistake. If this was intentional we can ignore this PR.

cc: @daxian-dbw @theJasonHelmick 


## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3450)