### PR TITLE
Tab completion doesn't show files whose names differ from others by case only

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -304,9 +304,9 @@ namespace Microsoft.PowerShell
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && _tabCompletions.CompletionMatches.Count > 1)
                     {
                         // Filter out apparent duplicates
-                        var hashSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        var hashSet = new HashSet<string>();
 
-                        foreach (var match in _tabCompletions.CompletionMatches.ToArray())
+                        foreach (var match in _tabCompletions.CompletionMatches)
                         {
                             if (!hashSet.Add(match.ListItemText))
                             {

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -10,7 +10,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using Microsoft.PowerShell.Internal;
@@ -300,17 +299,27 @@ namespace Microsoft.PowerShell
                     if (start < 0 || start > _singleton._buffer.Length) return null;
                     if (length < 0 || length > (_singleton._buffer.Length - start)) return null;
 
-                    // Only filter out duplicates on Windows.
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && _tabCompletions.CompletionMatches.Count > 1)
+                    if (_tabCompletions.CompletionMatches.Count > 1)
                     {
                         // Filter out apparent duplicates
                         var hashSet = new HashSet<string>();
+                        var matches = _tabCompletions.CompletionMatches;
+                        List<int> indices = null;
 
-                        foreach (var match in _tabCompletions.CompletionMatches)
+                        for (int i = 0; i < matches.Count; i++)
                         {
-                            if (!hashSet.Add(match.ListItemText))
+                            if (!hashSet.Add(matches[i].ListItemText))
                             {
-                                _tabCompletions.CompletionMatches.Remove(match);
+                                indices ??= new List<int>();
+                                indices.Add(i);
+                            }
+                        }
+
+                        if (indices is not null)
+                        {
+                            foreach (int index in indices)
+                            {
+                                matches.RemoveAt(index);
                             }
                         }
                     }

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -301,7 +301,7 @@ namespace Microsoft.PowerShell
 
                     if (_tabCompletions.CompletionMatches.Count > 1)
                     {
-                        // Filter out apparent duplicates
+                        // Filter out apparent duplicates -- the 'ListItemText' is exactly the same.
                         var hashSet = new HashSet<string>();
                         var matches = _tabCompletions.CompletionMatches;
                         List<int> indices = null;
@@ -317,9 +317,9 @@ namespace Microsoft.PowerShell
 
                         if (indices is not null)
                         {
-                            foreach (int index in indices)
+                            for (int i = indices.Count - 1; i >= 0; i--)
                             {
-                                matches.RemoveAt(index);
+                                matches.RemoveAt(indices[i]);
                             }
                         }
                     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Fixes #3455 

Remove case-insensitive comparator from suggestion deduplication logic. Unnecessary `ToArray()` removed in neighboring line to improve performance.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3456)