### PR TITLE
Change default color for inline prediction to `dim`

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -95,10 +95,10 @@ namespace Microsoft.PowerShell
 
         // Find the most suitable color using https://stackoverflow.com/a/33206814
         // Default prediction color settings:
-        //  - use FG color 'dark black' for the inline-view suggestion text
+        //  - use FG color 'dim' for the inline-view suggestion text
         //  - use FG color 'yellow' for the list-view suggestion text
         //  - use BG color 'dark black' for the selected list-view suggestion text
-        public const string DefaultInlinePredictionColor       = "\x1b[38;5;238m";
+        public const string DefaultInlinePredictionColor       = "\x1b[2m";
         public const string DefaultListPredictionColor         = "\x1b[33m";
         public const string DefaultListPredictionSelectedColor = "\x1b[48;5;238m";
 

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -95,10 +95,10 @@ namespace Microsoft.PowerShell
 
         // Find the most suitable color using https://stackoverflow.com/a/33206814
         // Default prediction color settings:
-        //  - use FG color 'dim' for the inline-view suggestion text
+        //  - use FG color 'dim yellow' for the inline-view suggestion text
         //  - use FG color 'yellow' for the list-view suggestion text
         //  - use BG color 'dark black' for the selected list-view suggestion text
-        public const string DefaultInlinePredictionColor       = "\x1b[2m";
+        public const string DefaultInlinePredictionColor       = "\x1b[93;2m";
         public const string DefaultListPredictionColor         = "\x1b[33m";
         public const string DefaultListPredictionSelectedColor = "\x1b[48;5;238m";
 

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -95,10 +95,10 @@ namespace Microsoft.PowerShell
 
         // Find the most suitable color using https://stackoverflow.com/a/33206814
         // Default prediction color settings:
-        //  - use FG color 'dim yellow' for the inline-view suggestion text
+        //  - use FG color 'dim white italic' for the inline-view suggestion text
         //  - use FG color 'yellow' for the list-view suggestion text
         //  - use BG color 'dark black' for the selected list-view suggestion text
-        public const string DefaultInlinePredictionColor       = "\x1b[93;2m";
+        public const string DefaultInlinePredictionColor       = "\x1b[97;2;3m";
         public const string DefaultListPredictionColor         = "\x1b[33m";
         public const string DefaultListPredictionSelectedColor = "\x1b[48;5;238m";
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The current default inline prediction color doesn't provide sufficient contrast in terminals that don't use a pure black background (like VSCode terminal).  Fix is to use `dim white italic` escape sequence.  Just using `dim` would result in the color changing depending on the token currently being rendered and for the dark-grey color for parameters it makes it even darker.

Fix https://github.com/PowerShell/PSReadLine/issues/3477

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3493)