### PR TITLE
Updating Fabric bot for closing issues with particular labels

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -50,8 +50,7 @@
           "issues",
           "project_card"
         ]
-      },
-      "id": "i3BHh5Qe9F"
+      }
     },
     {
       "taskType": "trigger",
@@ -107,8 +106,7 @@
         "eventNames": [
           "issue_comment"
         ]
-      },
-      "id": "x_h9ia7zwG"
+      }
     },
     {
       "taskType": "trigger",
@@ -117,8 +115,7 @@
       "version": "1.0",
       "config": {
         "taskName": "Add a CodeFlow link to new pull requests"
-      },
-      "id": "z2P6L1OkC4"
+      }
     },
     {
       "taskType": "trigger",
@@ -156,8 +153,7 @@
         "eventNames": [
           "pull_request_review"
         ]
-      },
-      "id": "s_Q6W352PU"
+      }
     },
     {
       "taskType": "trigger",
@@ -210,8 +206,7 @@
           "issues",
           "project_card"
         ]
-      },
-      "id": "2rzxLdRUQ7h"
+      }
     },
     {
       "taskType": "trigger",
@@ -251,8 +246,7 @@
         "eventNames": [
           "issue_comment"
         ]
-      },
-      "id": "p7EkOxE_g3T"
+      }
     },
     {
       "taskType": "trigger",
@@ -292,8 +286,7 @@
         "eventNames": [
           "pull_request_review"
         ]
-      },
-      "id": "xIoNg4bVKyA"
+      }
     },
     {
       "taskType": "trigger",
@@ -338,8 +331,7 @@
           "issues",
           "project_card"
         ]
-      },
-      "id": "o_mQ1sO0zdO"
+      }
     },
     {
       "taskType": "trigger",
@@ -371,8 +363,7 @@
         "eventNames": [
           "issue_comment"
         ]
-      },
-      "id": "ibqxdSfreaD"
+      }
     },
     {
       "taskType": "trigger",
@@ -404,8 +395,7 @@
         "eventNames": [
           "pull_request_review"
         ]
-      },
-      "id": "7_EH-4ffdtY"
+      }
     },
     {
       "taskType": "scheduled",
@@ -520,8 +510,7 @@
             "parameters": {}
           }
         ]
-      },
-      "id": "X3R7HwIUme_"
+      }
     },
     {
       "taskType": "scheduled",
@@ -644,8 +633,7 @@
             }
           }
         ]
-      },
-      "id": "zYmFzaIHtT8"
+      }
     },
     {
       "taskType": "trigger",
@@ -661,15 +649,13 @@
         "allowAutoMergeInstructionsWithoutLabel": false,
         "deleteBranches": true,
         "removeLabelOnPush": true
-      },
-      "id": "BPA0tvDiHBN"
+      }
     },
     {
       "taskType": "trigger",
       "capabilityId": "IssueResponder",
       "subCapability": "IssuesOnlyResponder",
       "version": "1.0",
-      "id": "kvB9kCm1d",
       "config": {
         "conditions": {
           "operator": "and",
@@ -709,7 +695,6 @@
       "capabilityId": "ScheduledSearch",
       "subCapability": "ScheduledSearch",
       "version": "1.1",
-      "id": "28wu6aj_J",
       "config": {
         "frequency": [
           {
@@ -796,6 +781,12 @@
             "parameters": {
               "days": 7
             }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Needs-Repro"
+            }
           }
         ],
         "taskName": "Close stale issues",
@@ -818,7 +809,6 @@
       "capabilityId": "InPrLabel",
       "subCapability": "InPrLabel",
       "version": "1.0",
-      "id": "dfYD-29Up",
       "config": {
         "taskName": "Add 'In-PR' label to issue",
         "label_inPr": "In-PR",
@@ -831,7 +821,6 @@
       "capabilityId": "ReleaseAnnouncement",
       "subCapability": "ReleaseAnnouncement",
       "version": "1.0",
-      "id": "_vafvxO3x",
       "config": {
         "taskName": "Release announcement for Issue/PR",
         "prReply": ":tada: [`${version}`](https://github.com/PowerShell/PSReadLine/releases/tag/${version}) has been released which incorporates this pull request. :tada:\n",
@@ -846,7 +835,6 @@
       "capabilityId": "ScheduledSearch",
       "subCapability": "ScheduledSearch",
       "version": "1.1",
-      "id": "HDx9Yd09Z1iue7fv7A22t",
       "config": {
         "frequency": [
           {
@@ -926,6 +914,54 @@
             "parameters": {
               "days": 1
             }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Resolution-Answered"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Resolution-Duplicate"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Resolution-External"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Resolution-By Design"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Resolution-Declined"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Resolution-Fixed"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Resolution-Wont Fix"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Resolution-Not Repro"
+            }
           }
         ],
         "taskName": "Close answered issues",
@@ -933,7 +969,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "This issue has been marked as answered and has not had any activity for **1 day**. It has been closed for housekeeping purposes."
+              "comment": "This issue has been marked as answered or resolved and has not had any activity for **1 day**. It has been closed for housekeeping purposes."
             }
           },
           {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Updating fabric bot to close stale issues after 7 days that need author repro. Also close issues with any Resolution-* labels. 

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3540)