### PR TITLE
[WIP] Make PredictionListView adapt to the height of the window

### DIFF
--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -207,12 +207,14 @@ namespace Microsoft.PowerShell
         /// </summary>
         private class PredictionListView : PredictionViewBase
         {
+            internal const int MaxPromptLineCount = 2;
             internal const int ListMaxCount = 10;
+            internal const int ListMinCount = 3;
             internal const int ListMaxWidth = 100;
             internal const int SourceMaxWidth = 15;
 
             internal const int MinWindowWidth = 54;
-            internal const int MinWindowHeight = 15;
+            internal const int MinWindowHeight = MaxPromptLineCount + ListMinCount;
 
             private List<SuggestionEntry> _listItems;
             private int _listItemWidth;
@@ -236,6 +238,17 @@ namespace Microsoft.PowerShell
                 {
                     var console = _singleton._console;
                     return console.WindowWidth >= MinWindowWidth && console.WindowHeight >= MinWindowHeight;
+                }
+            }
+
+            private int ListCount
+            {
+                get
+                {
+                    var console = _singleton._console;
+                    var availableLines = console.WindowHeight - MaxPromptLineCount;
+                    // Math.Clamp doesn't exist in .NET Framework or .NET 3.1 and earlier
+                    return Math.Min(Math.Max(availableLines, ListMinCount), ListMaxCount);
                 }
             }
 
@@ -323,7 +336,7 @@ namespace Microsoft.PowerShell
 
                     if (UseHistory)
                     {
-                        _listItems = GetHistorySuggestions(userInput, ListMaxCount);
+                        _listItems = GetHistorySuggestions(userInput, ListCount);
                     }
                 }
                 catch


### PR DESCRIPTION
Closes #3557

# PR Summary

This PR changes the `PredictionListView` to allow for suggestions to show up on terminals that have a height less than 15 lines tall. Instead of having a hard limit of 15 lines (and 10 suggestions), this PR makes it so there is no longer a limit of 15 lines. Instead there is a min limit of 5 lines (3 suggestions + 2 lines reserved for the terminal prompt). As the terminal gets taller, more suggestions will be displayed, up to a max of 10 (which is the current limit).

Some improvements that could possibly be made are:
- Making the upper and lower bounds configurable instead of hard coded allowing users to change the default behavior.
- Add an option to have PSReadLine automatically switch to `PredictionInlineView` when the windows is smaller than `PredictionListView.MinWindowHeight` and switch back when the terminal window is increased in size

I haven't added tests yet since this is a draft PR. I wanted to get feedback before I write the tests to make sure this is something that might actually get merged :)

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [ ] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3558)