### PR TITLE
Fix the menu completion to better handle the backspace key

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -983,14 +983,25 @@ namespace Microsoft.PowerShell
                     // TODO: Shift + Backspace does not fail here?
                     if (menuStack.Count > 1)
                     {
-                        var newMenu = menuStack.Pop();
-
-                        newMenu.DrawMenu(menu, menuSelect: true);
                         previousSelection = -1;
-
-                        menu = newMenu;
-
                         userCompletionText = userCompletionText.Substring(0, userCompletionText.Length - 1);
+
+                        Menu newMenu = menuStack.Peek();
+                        int pos = FindUserCompletionTextPosition(newMenu.CurrentMenuItem, userCompletionText);
+                        if (pos >= 0)
+                        {
+                            newMenu = menuStack.Pop();
+                            newMenu.DrawMenu(menu, menuSelect: true);
+
+                            menu = newMenu;
+                        }
+                        // else {
+                        //     We should not pop the stack yet. The updated user completion text contains characters
+                        //     that are not included in the selected item of the menu at the top of stack. This may
+                        //     happen when the user pressed a 'Tab' before this 'Backspace', which updated the user
+                        //     completion text with the unambiguous common prefix. In this case, we should stay in
+                        //     the current menu.
+                        // }
                     }
                     else if (menuStack.Count == 1)
                     {

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -999,8 +999,8 @@ namespace Microsoft.PowerShell
                         //     We should not pop the stack yet. The updated user completion text contains characters
                         //     that are not included in the selected item of the menu at the top of stack. This may
                         //     happen when the user pressed a 'Tab' before this 'Backspace', which updated the user
-                        //     completion text with the unambiguous common prefix. In this case, we should stay in
-                        //     the current menu.
+                        //     completion text to include the unambiguous common prefix of the available completion
+                        //     candidates. In this case, we should stay in the current menu.
                         // }
                     }
                     else if (menuStack.Count == 1)

--- a/test/CompletionTest.cs
+++ b/test/CompletionTest.cs
@@ -1319,6 +1319,95 @@ namespace Test
                 _.Ctrl_c, InputAcceptedNow));
         }
 
+        [SkippableFact]
+        public void MenuCompletions_Backspace()
+        {
+            TestSetup(KeyMode.Cmd, new KeyHandler("Ctrl+Spacebar", PSConsoleReadLine.MenuComplete));
+
+            _console.Clear();
+            char separator = Path.DirectorySeparatorChar;
+
+            Test("cd stro", Keys(
+                "cd stron", _.Ctrl_Spacebar,
+                CheckThat(() => AssertScreenIs(3,
+                    TokenClassification.Command, "cd",
+                    TokenClassification.None, $" .{separator}strong",
+                    TokenClassification.Selection, separator,
+                    NextLine,
+                    TokenClassification.Selection, "strong      ",
+                    TokenClassification.None, "stronghold  strongholp",
+                    NextLine,
+                    NextLine)),
+                _.h, CheckThat(() => AssertScreenIs(3,
+                    TokenClassification.Command, "cd",
+                    TokenClassification.None, $" .{separator}strongh",
+                    TokenClassification.Selection, $"old{separator}",
+                    NextLine,
+                    TokenClassification.Selection, "stronghold  ",
+                    TokenClassification.None, "strongholp",
+                    NextLine,
+                    NextLine)),
+                // Tab will update the user completion text to include the unambiguous common prefix.
+                _.Tab, CheckThat(() => AssertScreenIs(3,
+                    TokenClassification.Command, "cd",
+                    TokenClassification.None, $" .{separator}stronghol",
+                    TokenClassification.Selection, $"d{separator}",
+                    NextLine,
+                    TokenClassification.Selection, "stronghold  ",
+                    TokenClassification.None, "strongholp",
+                    NextLine,
+                    NextLine)),
+                _.Backspace, CheckThat(() => AssertScreenIs(3,
+                    TokenClassification.Command, "cd",
+                    TokenClassification.None, $" .{separator}strongho",
+                    TokenClassification.Selection, $"ld{separator}",
+                    NextLine,
+                    TokenClassification.Selection, "stronghold  ",
+                    TokenClassification.None, "strongholp",
+                    NextLine,
+                    NextLine)),
+                _.Backspace, CheckThat(() => AssertScreenIs(3,
+                    TokenClassification.Command, "cd",
+                    TokenClassification.None, $" .{separator}strongh",
+                    TokenClassification.Selection, $"old{separator}",
+                    NextLine,
+                    TokenClassification.Selection, "stronghold  ",
+                    TokenClassification.None, "strongholp",
+                    NextLine,
+                    NextLine)),
+                _.Backspace, CheckThat(() => AssertScreenIs(3,
+                    TokenClassification.Command, "cd",
+                    TokenClassification.None, $" .{separator}strong",
+                    TokenClassification.Selection, separator,
+                    NextLine,
+                    TokenClassification.Selection, "strong      ",
+                    TokenClassification.None, "stronghold  strongholp",
+                    NextLine,
+                    NextLine)),
+                _.h, CheckThat(() => AssertScreenIs(3,
+                    TokenClassification.Command, "cd",
+                    TokenClassification.None, $" .{separator}strongh",
+                    TokenClassification.Selection, $"old{separator}",
+                    NextLine,
+                    TokenClassification.Selection, "stronghold  ",
+                    TokenClassification.None, "strongholp",
+                    NextLine,
+                    NextLine)),
+                _.Backspace, CheckThat(() => AssertScreenIs(3,
+                    TokenClassification.Command, "cd",
+                    TokenClassification.None, $" .{separator}strong",
+                    TokenClassification.Selection, separator,
+                    NextLine,
+                    TokenClassification.Selection, "strong      ",
+                    TokenClassification.None, "stronghold  strongholp",
+                    NextLine,
+                    NextLine)),
+                _.Backspace,
+                _.Backspace, CheckThat(() => AssertLineIs("cd stro")),
+                _.Enter
+                ));
+        }
+
         internal static CommandCompletion MockedCompleteInput(string input, int cursor, Hashtable options, PowerShell powerShell)
         {
             var ctor = typeof (CommandCompletion).GetConstructor(
@@ -1418,6 +1507,14 @@ namespace Test
                 completions.Add(new CompletionResult("idden"));
                 break;
             case "none":
+                break;
+            case "cd stron":
+                replacementIndex = 3;
+                replacementLength = 5;
+                char separator = Path.DirectorySeparatorChar;
+                completions.Add(new CompletionResult($".{separator}strong", "strong", CompletionResultType.ProviderContainer, $".{separator}strong"));
+                completions.Add(new CompletionResult($".{separator}stronghold", "stronghold", CompletionResultType.ProviderContainer, $".{separator}stronghold"));
+                completions.Add(new CompletionResult($".{separator}strongholp", "strongholp", CompletionResultType.ProviderContainer, $".{separator}strongholp"));
                 break;
 
             default:


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3559

Fix the menu completion to better handle the backspace key.

Keep this a draft PR until after adding tests.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3574)