### PR TITLE
Add Prediction Timeout Option

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************++
+/********************************************************************++
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
@@ -356,6 +356,11 @@ namespace Microsoft.PowerShell
         /// Sets the view style for rendering predictive suggestions.
         /// </summary>
         public PredictionViewStyle PredictionViewStyle { get; set; }
+
+		/// <summary>
+		/// Sets the timeout for prediction completers in milliseconds to be silently ignored if they take longer than the specified duration to return a result. If not specified, uses the PowerShell engine default timeout which is currently hardcoded to 20ms.
+		/// </summary>
+		public int? PredictionTimeout { get; set; }
 
         /// <summary>
         /// How long in milliseconds should we wait before concluding
@@ -795,7 +800,16 @@ namespace Microsoft.PowerShell
         }
         internal PredictionViewStyle? _predictionViewStyle;
 
-        [Parameter]
+		[Parameter]
+		public int? PredictionTimeout
+		{
+			get => _predictionTimeout;
+			set => _predictionTimeout = value;
+		}
+		internal int? _predictionTimeout;
+
+
+		[Parameter]
         public Hashtable Colors { get; set; }
 
         [ExcludeFromCodeCoverage]
@@ -920,7 +934,7 @@ namespace Microsoft.PowerShell
         }
     }
 
-    [Cmdlet("Get", "PSReadLineKeyHandler", DefaultParameterSetName = "FullListing", 
+    [Cmdlet("Get", "PSReadLineKeyHandler", DefaultParameterSetName = "FullListing",
         HelpUri = "https://go.microsoft.com/fwlink/?LinkId=528807")]
     [OutputType(typeof(KeyHandler))]
     public class GetKeyHandlerCommand : PSCmdlet

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -156,6 +156,10 @@ namespace Microsoft.PowerShell
                 Options.PredictionViewStyle = options.PredictionViewStyle;
                 _prediction.SetViewStyle(options.PredictionViewStyle);
             }
+			if (options._predictionTimeout.HasValue)
+			{
+				Options.PredictionTimeout = options._predictionTimeout;
+			}
             if (options.Colors != null)
             {
                 IDictionaryEnumerator e = options.Colors.GetEnumerator();

--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -180,8 +180,18 @@ namespace Microsoft.PowerShell
             /// </summary>
             protected void PredictInput()
             {
-                _predictionTask = _singleton._mockableMethods.PredictInputAsync(_singleton._ast, _singleton._tokens);
-            }
+				// Is it breaking abstraction too much to pull this directly from the singleton options? Should this be a separate property on the class itself?
+				var predictionTimeout = _singleton._options.PredictionTimeout;
+				if (predictionTimeout is null)
+				{
+					_singleton._mockableMethods.PredictInputAsync(_singleton._ast, _singleton._tokens);
+				}
+				else
+				{
+					//TODO: Is there a better way to handle the nullable conversion here? I would think the pattern matching would allow it to be. Zero will throw an exception with this particular method which is what we want as this should never be null.
+					_singleton._mockableMethods.PredictInputAsync(_singleton._ast, _singleton._tokens, predictionTimeout ?? 0);
+				}
+			}
 
             /// <summary>
             /// Gets the results from the prediction task.

--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -180,17 +180,13 @@ namespace Microsoft.PowerShell
             /// </summary>
             protected void PredictInput()
             {
-				// Is it breaking abstraction too much to pull this directly from the singleton options? Should this be a separate property on the class itself?
-				var predictionTimeout = _singleton._options.PredictionTimeout;
-				if (predictionTimeout is null)
-				{
-					_singleton._mockableMethods.PredictInputAsync(_singleton._ast, _singleton._tokens);
-				}
-				else
-				{
-					//TODO: Is there a better way to handle the nullable conversion here? I would think the pattern matching would allow it to be. Zero will throw an exception with this particular method which is what we want as this should never be null.
-					_singleton._mockableMethods.PredictInputAsync(_singleton._ast, _singleton._tokens, predictionTimeout ?? 0);
-				}
+				// Is it breaking abstraction too much to pull this directly from the singleton options? Should this be a separate property on the class itself? I see this done in other classes so I assume its OK.
+				var predictionTimeout = _singleton.Options.PredictionTimeout;
+
+				//TODO: Is there a better way to handle the nullable conversion here? I would think the pattern matching would allow it since I already tested for null but it still shows a compiler error here (can't convert int? to int) if I dont handle the nullable. -1 will throw an exception with this particular method which is what we want as this should never be null.
+				_predictionTask = (predictionTimeout is null)
+					? _singleton._mockableMethods.PredictInputAsync(_singleton._ast, _singleton._tokens)
+					: _predictionTask = _singleton._mockableMethods.PredictInputAsync(_singleton._ast, _singleton._tokens, predictionTimeout ?? -1);
 			}
 
             /// <summary>

--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -26,6 +26,11 @@ namespace Microsoft.PowerShell
             return CommandPrediction.PredictInputAsync(s_predictionClient, ast, tokens);
         }
 
+        Task<List<PredictionResult>> IPSConsoleReadLineMockableMethods.PredictInputAsync(Ast ast, Token[] tokens, int timeoutMilliseconds)
+        {
+            return CommandPrediction.PredictInputAsync(s_predictionClient, ast, tokens, timeoutMilliseconds);
+        }
+
         [ExcludeFromCodeCoverage]
         void IPSConsoleReadLineMockableMethods.OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex)
         {

--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************++
+/********************************************************************++
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
@@ -27,6 +27,7 @@ namespace Microsoft.PowerShell
             CommandCompletion CompleteInput(string input, int cursorIndex, Hashtable options, System.Management.Automation.PowerShell powershell);
             bool RunspaceIsRemote(Runspace runspace);
             Task<List<PredictionResult>> PredictInputAsync(Ast ast, Token[] tokens);
+			Task<List<PredictionResult>> PredictInputAsync(Ast ast, Token[] tokens, int millisecondsTimeout);
             void OnCommandLineAccepted(IReadOnlyList<string> history);
             void OnCommandLineExecuted(string commandLine, bool success);
             void OnSuggestionDisplayed(Guid predictorId, uint session, int countOrIndex);

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -55,12 +55,17 @@ namespace Test
 
         public Task<List<PredictionResult>> PredictInputAsync(Ast ast, Token[] tokens)
         {
-            var result = ReadLine.MockedPredictInput(ast, tokens);
-            var source = new TaskCompletionSource<List<PredictionResult>>();
+			return PredictInputAsync(ast, tokens, timeoutMilliseconds: 20);
+		}
 
-            source.SetResult(result);
-            return source.Task;
-        }
+		public Task<List<PredictionResult>> PredictInputAsync(Ast ast, Token[] tokens, int timeoutMilliseconds)
+		{
+			var result = ReadLine.MockedPredictInput(ast, tokens);
+			var source = new TaskCompletionSource<List<PredictionResult>>();
+
+			source.SetResult(result);
+			return source.Task;
+		}
 
         public void OnCommandLineAccepted(IReadOnlyList<string> history)
         {


### PR DESCRIPTION
Closes #3607 

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adds a `-PredictionTimeout` that allows the user to configure how long Predictive Intellisense will wait for providers.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3610)