### PR TITLE
Make PSReadLine script hidden from debugger

### DIFF
--- a/PSReadLine/PSReadLine.psm1
+++ b/PSReadLine/PSReadLine.psm1
@@ -1,5 +1,8 @@
 function PSConsoleHostReadLine
 {
+    [System.Diagnostics.DebuggerHidden()]
+    param()
+
     ## Get the execution status of the last accepted user input.
     ## This needs to be done as the first thing because any script run will flush $?.
     $lastRunStatus = $?

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -238,7 +238,7 @@ namespace Microsoft.PowerShell
                             if (ps == null)
                             {
                                 ps = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace);
-                                ps.AddScript("0", useLocalScope: true);
+                                ps.AddScript("[System.Diagnostics.DebuggerHidden()]param() 0", useLocalScope: true);
                             }
 
                             // To detect output during possible event processing, see if the cursor moved
@@ -674,7 +674,7 @@ namespace Microsoft.PowerShell
             {
                 try
                 {
-                    var results = ps.AddScript("$Host", useLocalScope: true).Invoke<PSHost>();
+                    var results = ps.AddScript("[System.Diagnostics.DebuggerHidden()]param() $Host", useLocalScope: true).Invoke<PSHost>();
                     PSHost host = results.Count == 1 ? results[0] : null;
                     hostName = host?.Name;
                 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3260

PowerShell has a handler for `Ctrl+Break`, to break into debugger on the currently running script. This makes it possible to cause debugger to stop on the script that PSReadLine is running internally while it's idle (not processing any input keys). For example, it may be triggering the pulse pipeline for event processing by running the script `"0"`, and `Ctrl+Break` causes the debugger to break in the script and pause the execution.

When this happens, a nested prompt will be provided to the user, which calls PSReadLine again to process input, which causes the re-entry of PSReadLine and make it crash.

The fix is to make the internal PSReadLine script hidden from PowerShell debugger, just like the built-in functions in PowerShell, such as `prompt`. Then `Ctrl+Break` won't cause debugger to interrupt the script execution in PSReadLine.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3629)