### PR TITLE
Improve the default sensitive history scrubbing to allow safe property access

### DIFF
--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -202,7 +202,16 @@ namespace Test
                 "Set-SecretInfo -Name apikey; Set-SecretVaultDefault; Test-SecretVault; Unlock-SecretVault -password $pwd; Unregister-SecretVault -SecretVault vaultInfo",
                 "Get-ResultFromTwo -Secret1 (Get-Secret -Name blah -AsPlainText) -Secret2 $secret2",
                 "Get-ResultFromTwo -Secret1 (Get-Secret -Name blah -AsPlainText) -Secret2 sdv87ysdfayf798hfasd8f7ha", // '-Secret2' has expr-value argument. Not saved to file.
-                "$environment -brand $brand -userBitWardenEmail $bwuser -userBitWardenPassword $bwpass" // '-userBitWardenPassword' matches sensitive pattern and it has parsing error. Not save to file.
+                "$environment -brand $brand -userBitWardenEmail $bwuser -userBitWardenPassword $bwpass", // '-userBitWardenPassword' matches sensitive pattern and it has parsing error. Not save to file.
+                "(Import-Clixml \"${Env:HOME}\\credential.clixml\").GetNetworkCredential().Password | Set-Clipboard", // 'Password' is a property not in assignment.
+                "$a.Password = 'abcd'", // setting the 'Password' property with string value. Not saved to file.
+                "$a.Password.Value = 'abcd'", // indirectly setting the 'Password' property with string value. Not saved to file.
+                "$a.Secret = Get-Secret -Name github-token -Vault MySecret",
+                "$a.Secret = $secret",
+                "$a.Password = 'ab' + 'cd'", // setting the 'Password' property with string values. Not saved to file.
+                "$a.Password.Secret | Set-Value",
+                "Write-Host $a.Password.Secret",
+                "($a.Password, $b) = ('aa', 'bb')", // setting the 'Password' property with string value. Not saved to file.
             };
 
             string[] expectedSavedItems = new[] {
@@ -218,6 +227,11 @@ namespace Test
                 "Get-SecretInfo -Name mytoken; Get-SecretVault; Register-SecretVault; Remove-Secret apikey",
                 "Set-SecretInfo -Name apikey; Set-SecretVaultDefault; Test-SecretVault; Unlock-SecretVault -password $pwd; Unregister-SecretVault -SecretVault vaultInfo",
                 "Get-ResultFromTwo -Secret1 (Get-Secret -Name blah -AsPlainText) -Secret2 $secret2",
+                "(Import-Clixml \"${Env:HOME}\\credential.clixml\").GetNetworkCredential().Password | Set-Clipboard",
+                "$a.Secret = Get-Secret -Name github-token -Vault MySecret",
+                "$a.Secret = $secret",
+                "$a.Password.Secret | Set-Value",
+                "Write-Host $a.Password.Secret",
             };
 
             try


### PR DESCRIPTION


<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3318

Improve the default sensitive history scrubbing to allow safe property access.
When the sensitive string is part of a property access:
- If this member access operation is not part of an assignment, then we consider it safe;
- Otherwise, if the right-hand side is a pipeline or a variable, we also consider it safe.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3630)