### PR TITLE
Set the current location in `PredictionClient` when it's supported

### DIFF
--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -4,8 +4,10 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Management.Automation;
+using System.Management.Automation.Runspaces;
 using System.Management.Automation.Language;
 using System.Management.Automation.Subsystem.Prediction;
 using System.Diagnostics.CodeAnalysis;
@@ -17,7 +19,40 @@ namespace Microsoft.PowerShell
     public partial class PSConsoleReadLine
     {
         private const string PSReadLine = "PSReadLine";
-        private static PredictionClient s_predictionClient = new(PSReadLine, PredictionClientKind.Terminal);
+        private static readonly PredictionClient s_predictionClient = new(PSReadLine, PredictionClientKind.Terminal);
+        private static PropertyInfo s_pCurrentLocation = null;
+
+        /// <summary>
+        /// Initialize the <see cref="PropertyInfo"/> objects for those public settable properties newly added to
+        /// <see cref="PredictionClient"/>.
+        /// </summary>
+        private static void InitializePropertyInfo()
+        {
+            Version ver = typeof(PSObject).Assembly.GetName().Version;
+            if (ver.Major < 7 || ver.Minor < 4)
+            {
+                return;
+            }
+
+            Type pcType = typeof(PredictionClient);
+            s_pCurrentLocation = pcType.GetProperty("CurrentLocation");
+        }
+
+        /// <summary>
+        /// New public settable properties may be added to the <see cref="PredictionClient"/> type as it evolves to
+        /// offer more helpful context information. We dynamically set those properties here to avoid any backward
+        /// compatibility issues.
+        /// </summary>
+        private static void UpdatePredictionClient(Runspace runspace, EngineIntrinsics engineIntrinsics)
+        {
+            // Set the current location if the 'CurrentLocation' property exists.
+            if (s_pCurrentLocation is not null)
+            {
+                // Set the current location if it's a local Runspace. Otherwise, set it to null.
+                object path = runspace.RunspaceIsRemote ? null : engineIntrinsics.SessionState.Path.CurrentLocation;
+                s_pCurrentLocation.SetValue(s_predictionClient, path);
+            }
+        }
 
         // Stub helper methods so prediction can be mocked
         [ExcludeFromCodeCoverage]

--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -18,8 +18,8 @@ namespace Microsoft.PowerShell
 {
     public partial class PSConsoleReadLine
     {
-        private const string PSReadLine = "PSReadLine";
-        private static readonly PredictionClient s_predictionClient = new(PSReadLine, PredictionClientKind.Terminal);
+        private const string DefaultName = "PSReadLine";
+        private static readonly PredictionClient s_predictionClient = new(DefaultName, PredictionClientKind.Terminal);
         private static PropertyInfo s_pCurrentLocation = null;
 
         /// <summary>
@@ -35,6 +35,7 @@ namespace Microsoft.PowerShell
             }
 
             Type pcType = typeof(PredictionClient);
+            // Property added in 7.4
             s_pCurrentLocation = pcType.GetProperty("CurrentLocation");
         }
 

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -685,7 +685,7 @@ namespace Microsoft.PowerShell
             }
 
             bool usingLegacyConsole = _console is PlatformWindows.LegacyWin32Console;
-            _options = new PSConsoleReadLineOptions(hostName ?? PSReadLine, usingLegacyConsole);
+            _options = new PSConsoleReadLineOptions(hostName ?? DefaultName, usingLegacyConsole);
             _prediction = new Prediction(this);
             SetDefaultBindings(_options.EditMode);
         }

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -652,6 +652,7 @@ namespace Microsoft.PowerShell
         {
             _singleton = new PSConsoleReadLine();
             _viRegister = new ViRegister(_singleton);
+            InitializePropertyInfo();
         }
 
         private PSConsoleReadLine()
@@ -682,13 +683,9 @@ namespace Microsoft.PowerShell
                 {
                 }
             }
-            if (hostName == null)
-            {
-                hostName = PSReadLine;
-            }
 
             bool usingLegacyConsole = _console is PlatformWindows.LegacyWin32Console;
-            _options = new PSConsoleReadLineOptions(hostName, usingLegacyConsole);
+            _options = new PSConsoleReadLineOptions(hostName ?? PSReadLine, usingLegacyConsole);
             _prediction = new Prediction(this);
             SetDefaultBindings(_options.EditMode);
         }
@@ -697,6 +694,9 @@ namespace Microsoft.PowerShell
         {
             _engineIntrinsics = engineIntrinsics;
             _runspace = runspace;
+
+            // Update the client instance per every call to PSReadLine.
+            UpdatePredictionClient(runspace, engineIntrinsics);
 
             if (!_delayedOneTimeInitCompleted)
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Set the current location in `PredictionClient` when it's supported.
This is in accordance with https://github.com/PowerShell/PowerShell/pull/19414, which adds the property `CurrentLocation` to `PredictionClient`, so as to make it easy for a predictor implementation to know the current location.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3639)