### PR TITLE
Improve the sensitive history scrubbing to allow retrieving token from `az`, `gcloud`, and `kubectl`

### DIFF
--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -212,6 +212,14 @@ namespace Test
                 "$a.Password.Secret | Set-Value",
                 "Write-Host $a.Password.Secret",
                 "($a.Password, $b) = ('aa', 'bb')", // setting the 'Password' property with string value. Not saved to file.
+                "kubectl get secrets",
+                "kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode",
+                "kubectl describe secret db-user-pass",
+                "(Get-AzAccessToken -ResourceUrl 'https://abc.com').Token",
+                "$token = (Get-AzAccessToken -ResourceUrl 'abc').Token",
+                "az account get-access-token --resource=https://abc.com --query accessToken --output tsv",
+                "curl -X GET --header \"Authorization: Bearer $token\" https://abc.com",
+                "$env:PGPASS = gcloud auth print-access-token",
             };
 
             string[] expectedSavedItems = new[] {
@@ -232,6 +240,14 @@ namespace Test
                 "$a.Secret = $secret",
                 "$a.Password.Secret | Set-Value",
                 "Write-Host $a.Password.Secret",
+                "kubectl get secrets",
+                "kubectl get secret db-user-pass -o jsonpath='{.data.password}' | base64 --decode",
+                "kubectl describe secret db-user-pass",
+                "(Get-AzAccessToken -ResourceUrl 'https://abc.com').Token",
+                "$token = (Get-AzAccessToken -ResourceUrl 'abc').Token",
+                "az account get-access-token --resource=https://abc.com --query accessToken --output tsv",
+                "curl -X GET --header \"Authorization: Bearer $token\" https://abc.com",
+                "$env:PGPASS = gcloud auth print-access-token",
             };
 
             try


### PR DESCRIPTION
# PR Summary

Fix #3633
Improve the sensitive history scrubbing to allow retrieving token from `az`, `gcloud`, and `kubectl`.
The default sensitive history scrubbing was updated to handle retrieving token with [gcloud](https://cloud.google.com/sdk/gcloud/reference/auth/print-access-token), with Azure ([both az cli and Az PowerShell](https://learn.microsoft.com/en-us/azure/healthcare-apis/get-access-token?tabs=azure-cli)), and with `kubectl` (both [`get secret` and `describe secret`](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/)).

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3641)