### PR TITLE
Avoid running `AddToHistoryHandler` on command lines loaded from history file

### DIFF
--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PowerShell
             _savedCurrentLine._editGroupStart = -1;
         }
 
-        private AddToHistoryOption GetAddToHistoryOption(string line)
+        private AddToHistoryOption GetAddToHistoryOption(string line, bool fromHistoryFile)
         {
             // Whitespace only is useless, never add.
             if (string.IsNullOrWhiteSpace(line))
@@ -154,7 +154,7 @@ namespace Microsoft.PowerShell
                 return AddToHistoryOption.SkipAdding;
             }
 
-            if (Options.AddToHistoryHandler != null)
+            if (!fromHistoryFile && Options.AddToHistoryHandler != null)
             {
                 if (Options.AddToHistoryHandler == PSConsoleReadLineOptions.DefaultAddToHistoryHandler)
                 {
@@ -203,10 +203,11 @@ namespace Microsoft.PowerShell
             bool fromDifferentSession = false,
             bool fromInitialRead = false)
         {
-            var addToHistoryOption = GetAddToHistoryOption(result);
+            bool fromHistoryFile = fromDifferentSession || fromInitialRead;
+            var addToHistoryOption = GetAddToHistoryOption(result, fromHistoryFile);
+
             if (addToHistoryOption != AddToHistoryOption.SkipAdding)
             {
-                var fromHistoryFile = fromDifferentSession || fromInitialRead;
                 _previousHistoryItem = new HistoryItem
                 {
                     CommandLine = result,


### PR DESCRIPTION
# PR Summary

When using a somewhat non-trivial `AddToHistoryHandler` in profile, a session started with the profile will be unresponsive for a few seconds because when loading history items from the history file, PSReadLine calls `AddToHistoryHandler` on each of the items to get the `AddToHistoryOption` for this item (`SkipAdding`, `MemoryOnly`, `MemoryAndFile`). This is unnecessary because those items are read from history file, meaning they have already been saved to the history file. 

This PR fix the issue by avoiding running `AddToHistoryHandler` on command lines loaded from history file.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3643)