### PR TITLE
Fix to force refreshing suggestion in the inline view when plugin is in use

### DIFF
--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -1082,10 +1082,12 @@ namespace Microsoft.PowerShell
                 {
                     _inputText = userInput;
 
+                    string currentSugText = null;
                     bool needToRefresh = _suggestionText == null
                         || _suggestionText.Length <= userInput.Length
                         || _lastInputText.Length > userInput.Length
                         || !_suggestionText.StartsWith(userInput, _singleton._options.HistoryStringComparison);
+
 
                     // The current suggestion was from history and it still applies to the new input. However, the plugin is in use,
                     // so we may need to force refreshing in case the plugin gives more relevant suggestion for the new input. This
@@ -1097,6 +1099,9 @@ namespace Microsoft.PowerShell
                         // thus we should keep on using.
                         needToRefresh = !_alreadyAccepted;
                         _alreadyAccepted = false;
+
+                        // We can reuse the current suggestion text for history to avoid an unnecessary search.
+                        currentSugText = _suggestionText;
                     }
 
                     if (needToRefresh)
@@ -1112,7 +1117,7 @@ namespace Microsoft.PowerShell
 
                         if (UseHistory)
                         {
-                            _suggestionText = GetOneHistorySuggestion(userInput);
+                            _suggestionText = currentSugText ?? GetOneHistorySuggestion(userInput);
                             _predictorId = Guid.Empty;
                             _predictorSession = null;
                         }

--- a/test/UnitTestReadLine.cs
+++ b/test/UnitTestReadLine.cs
@@ -27,7 +27,7 @@ namespace Test
         internal Guid acceptedPredictorId;
         internal string acceptedSuggestion;
         internal string helpContentRendered;
-        internal Dictionary<Guid, Tuple<uint, int>> displayedSuggestions = new Dictionary<Guid, Tuple<uint, int>>();
+        internal Dictionary<Guid, Tuple<uint, int>> displayedSuggestions = new();
 
         internal void ClearPredictionFields()
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix to force refreshing suggestion in the inline view when plugin is in use, even if the current history suggestion can still apply to the new input.

Scenario:
When the prediction source is `HistoryAndPlugin`, we favor plugin results over history results in the inline view. For an command-line input, if the plugin doesn't return anything, the history result will be used.

Today, when an inline view prediction is displayed, if you keep typing and the existing suggestion can still apply to the resulted new input, PSReadLine will continue to use the existing suggestion text instead of refreshing the suggestion.
So, when the history suggestion is used for inline view, if the new input resulted from your typing can still fit in the existing history suggestion, the plugin won't be triggered, even though it now may return more relevant result.

This PR fixes the above issue:
- when the prediction source is `History` only, the behavior is not changed
- when the prediction source is `HistoryAndPlugin`
   - the existing suggestion is from a plugin, then the current behavior is not changed -- if the existing suggestion can still apply to the new input, PSReadLine continues to use it instead of refreshing suggestion.
   - the existing suggestion is from history, then new input will force refreshing the suggestion, unless the new input is resulted by the user accepting the next word of the existing history suggestion.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3644)