### PR TITLE
Add a sample for transforming Unicode code point to Unicode char by 'Alt+x'

### DIFF
--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -686,5 +686,6 @@ Set-PSReadLineKeyHandler -Chord 'Alt+x' `
         return
     }
 
-    [Microsoft.PowerShell.PSConsoleReadLine]::Replace($cursor - 4, 4, $unicode)
+    [Microsoft.PowerShell.PSConsoleReadLine]::Delete($cursor - 4, 4)
+    [Microsoft.PowerShell.PSConsoleReadLine]::Insert($unicode)
 }

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -603,7 +603,7 @@ Set-PSReadLineKeyHandler -Key RightArrow `
 
 # Cycle through arguments on current line and select the text. This makes it easier to quickly change the argument if re-running a previously run command from the history
 # or if using a psreadline predictor. You can also use a digit argument to specify which argument you want to select, i.e. Alt+1, Alt+a selects the first argument
-# on the command line. 
+# on the command line.
 Set-PSReadLineKeyHandler -Key Alt+a `
                          -BriefDescription SelectCommandArguments `
                          -LongDescription "Set current selection to next command argument in the command line. Use of digit argument selects argument by position" `
@@ -655,4 +655,36 @@ Set-PSReadLineKeyHandler -Key Alt+a `
     [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition($nextAst.Extent.StartOffset + $startOffsetAdjustment)
     [Microsoft.PowerShell.PSConsoleReadLine]::SetMark($null, $null)
     [Microsoft.PowerShell.PSConsoleReadLine]::SelectForwardChar($null, ($nextAst.Extent.EndOffset - $nextAst.Extent.StartOffset) - $endOffsetAdjustment)
+}
+
+# Allow you to type a Unicode code point, then pressing `Alt+x` to transform it into a Unicode char.
+Set-PSReadLineKeyHandler -Chord 'Alt+x' `
+                         -BriefDescription ToUnicodeChar `
+                         -LongDescription "Transform Unicode code point into a UTF-16 encoded string" `
+                         -ScriptBlock {
+    $buffer = $null
+    $cursor = 0
+    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref] $buffer, [ref] $cursor)
+    if ($cursor -lt 4) {
+        return
+    }
+
+    $number = 0
+    $isNumber = [int]::TryParse(
+        $buffer.Substring($cursor - 4, 4),
+        [System.Globalization.NumberStyles]::AllowHexSpecifier,
+        $null,
+        [ref] $number)
+
+    if (-not $isNumber) {
+        return
+    }
+
+    try {
+        $unicode = [char]::ConvertFromUtf32($number)
+    } catch {
+        return
+    }
+
+    [Microsoft.PowerShell.PSConsoleReadLine]::Replace($cursor - 4, 4, $unicode)
 }


### PR DESCRIPTION
# PR Summary

Fix #3578 

Add a sample for transforming Unicode code point to Unicode char by 'Alt+x'. (Thanks @SeeminglyScience!)

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3652)