### PR TITLE
Support tooltip rendering in the prediction list view

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -101,6 +101,7 @@ namespace Microsoft.PowerShell
         public const string DefaultInlinePredictionColor       = "\x1b[97;2;3m";
         public const string DefaultListPredictionColor         = "\x1b[33m";
         public const string DefaultListPredictionSelectedColor = "\x1b[48;5;238m";
+        public const string DefaultListPredictionTooltipColor  = "\x1b[97;2;3m";
 
         public static EditMode DefaultEditMode = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? EditMode.Windows
@@ -495,6 +496,12 @@ namespace Microsoft.PowerShell
             set => _listPredictionSelectedColor = VTColorUtils.AsEscapeSequence(value);
         }
 
+        public object ListPredictionTooltipColor
+        {
+            get => _listPredictionTooltipColor;
+            set => _listPredictionTooltipColor = VTColorUtils.AsEscapeSequence(value);
+        }
+
         internal string _defaultTokenColor;
         internal string _commentColor;
         internal string _keywordColor;
@@ -512,6 +519,7 @@ namespace Microsoft.PowerShell
         internal string _inlinePredictionColor;
         internal string _listPredictionColor;
         internal string _listPredictionSelectedColor;
+        internal string _listPredictionTooltipColor;
 
         internal void ResetColors()
         {
@@ -532,6 +540,7 @@ namespace Microsoft.PowerShell
             InlinePredictionColor       = DefaultInlinePredictionColor;
             ListPredictionColor         = DefaultListPredictionColor;
             ListPredictionSelectedColor = DefaultListPredictionSelectedColor;
+            ListPredictionTooltipColor  = DefaultListPredictionTooltipColor;
 
             var bg = Console.BackgroundColor;
             if (fg == VTColorUtils.UnknownColor || bg == VTColorUtils.UnknownColor)
@@ -571,6 +580,7 @@ namespace Microsoft.PowerShell
                         {"InlinePrediction", (o, v) => o.InlinePredictionColor = v},
                         {"ListPrediction", (o, v) => o.ListPredictionColor = v},
                         {"ListPredictionSelected", (o, v) => o.ListPredictionSelectedColor = v},
+                        {"ListPredictionTooltip", (o, v) => o.ListPredictionTooltipColor = v},
                     };
 
                 Interlocked.CompareExchange(ref ColorSetters, setters, null);

--- a/PSReadLine/DynamicHelp.cs
+++ b/PSReadLine/DynamicHelp.cs
@@ -19,6 +19,7 @@ namespace Microsoft.PowerShell
         [ExcludeFromCodeCoverage]
         void IPSConsoleReadLineMockableMethods.RenderFullHelp(string content, string regexPatternToScrollTo)
         {
+            _pager ??= new Pager();
             _pager.Write(content, regexPatternToScrollTo);
         }
 
@@ -142,11 +143,6 @@ namespace Microsoft.PowerShell
 
         private void DynamicHelpImpl(bool isFullHelp)
         {
-            if (isFullHelp)
-            {
-                _pager ??= new Pager();
-            }
-
             int cursor = _singleton._current;
             string commandName = null;
             string parameterName = null;

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -235,6 +235,7 @@ namespace Microsoft.PowerShell
                 { Keys.F2,                     MakeKeyHandler(SwitchPredictionView,      "SwitchPredictionView") },
                 { Keys.F3,                     MakeKeyHandler(CharacterSearch,           "CharacterSearch") },
                 { Keys.ShiftF3,                MakeKeyHandler(CharacterSearchBackward,   "CharacterSearchBackward") },
+                { Keys.F4,                     MakeKeyHandler(ShowFullPredictionTooltip, "ShowFullPredictionTooltip") },
                 { Keys.F8,                     MakeKeyHandler(HistorySearchBackward,     "HistorySearchBackward") },
                 { Keys.ShiftF8,                MakeKeyHandler(HistorySearchForward,      "HistorySearchForward") },
                 // Added for xtermjs-based terminals that send different key combinations.
@@ -339,6 +340,7 @@ namespace Microsoft.PowerShell
                 { Keys.AltH,                   MakeKeyHandler(ShowParameterHelp,         "ShowParameterHelp") },
                 { Keys.F1,                     MakeKeyHandler(ShowCommandHelp,           "ShowCommandHelp") },
                 { Keys.F2,                     MakeKeyHandler(SwitchPredictionView,      "SwitchPredictionView") },
+                { Keys.F4,                     MakeKeyHandler(ShowFullPredictionTooltip, "ShowFullPredictionTooltip") },
                 { Keys.AltU,                   MakeKeyHandler(UpcaseWord,                "UpcaseWord") },
                 { Keys.AltL,                   MakeKeyHandler(DowncaseWord,              "DowncaseWord") },
                 { Keys.AltC,                   MakeKeyHandler(CapitalizeWord,            "CapitalizeWord") },
@@ -566,6 +568,7 @@ namespace Microsoft.PowerShell
             case nameof(NextSuggestion):
             case nameof(PreviousSuggestion):
             case nameof(SwitchPredictionView):
+            case nameof(ShowFullPredictionTooltip):
                 return KeyHandlerGroup.Prediction;
 
             case nameof(CaptureScreen):

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -91,6 +91,8 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlG,           MakeKeyHandler(Abort,                  "Abort") },
                 { Keys.AltH,            MakeKeyHandler(ShowParameterHelp,      "ShowParameterHelp") },
                 { Keys.F1,              MakeKeyHandler(ShowCommandHelp,        "ShowCommandHelp") },
+                { Keys.F2,              MakeKeyHandler(SwitchPredictionView,   "SwitchPredictionView") },
+                { Keys.F4,              MakeKeyHandler(ShowFullPredictionTooltip, "ShowFullPredictionTooltip") },
             };
 
             // Some bindings are not available on certain platforms

--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -205,6 +205,10 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                 <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.ListPredictionSelectedColor)</ScriptBlock>
               </ListItem>
               <ListItem>
+                <Label>ListPredictionTooltipColor</Label>
+                <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.ListPredictionTooltipColor)</ScriptBlock>
+              </ListItem>
+              <ListItem>
                 <Label>MemberColor</Label>
                 <ScriptBlock>[Microsoft.PowerShell.VTColorUtils]::FormatColor($_.MemberColor)</ScriptBlock>
               </ListItem>

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -2193,6 +2193,17 @@ namespace Microsoft.PowerShell.PSReadLine {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Show the full tooltip of the selected list-view item in the terminal's alternate screen buffer.
+        /// </summary>
+        internal static string ShowFullPredictionTooltipDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("ShowFullPredictionTooltipDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Make visual selection of the command arguments.
         /// </summary>
         internal static string SelectCommandArgumentDescription

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -837,6 +837,9 @@ Or not saving history with:
   <data name="SwitchPredictionViewDescription" xml:space="preserve">
     <value>Switch between the inline and list prediction views.</value>
   </data>
+  <data name="ShowFullPredictionTooltipDescription" xml:space="preserve">
+    <value>Show the full tooltip of the selected list-view item in the terminal's alternate screen buffer.</value>
+  </data>
   <data name="WindowSizeTooSmallForListView" xml:space="preserve">
     <value>The prediction 'ListView' is temporarily disabled because the current window size of the console is too small. To use the 'ListView', please make sure the 'WindowWidth' is not less than '{0}' and the 'WindowHeight' is not less than '{1}'.</value>
   </data>

--- a/PSReadLine/Prediction.Entry.cs
+++ b/PSReadLine/Prediction.Entry.cs
@@ -47,6 +47,7 @@ namespace Microsoft.PowerShell
             internal readonly Guid PredictorId;
             internal readonly uint? PredictorSession;
             internal readonly string Source;
+            internal readonly string ToolTip;
             internal readonly string SuggestionText;
             internal readonly int InputMatchIndex;
 
@@ -54,16 +55,17 @@ namespace Microsoft.PowerShell
             private string _listItemTextSelected;
 
             internal SuggestionEntry(string suggestion, int matchIndex)
-                : this(source: HistorySource, predictorId: Guid.Empty, predictorSession: null, suggestion, matchIndex)
+                : this(source: HistorySource, predictorId: Guid.Empty, predictorSession: null, suggestion, tooltip: null, matchIndex)
             {
             }
 
-            internal SuggestionEntry(string source, Guid predictorId, uint? predictorSession, string suggestion, int matchIndex)
+            internal SuggestionEntry(string source, Guid predictorId, uint? predictorSession, string suggestion, string tooltip, int matchIndex)
             {
                 Source = source;
                 PredictorId = predictorId;
                 PredictorSession = predictorSession;
                 SuggestionText = suggestion;
+                ToolTip = tooltip;
                 InputMatchIndex = matchIndex;
 
                 _listItemTextRegular = _listItemTextSelected = null;

--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -927,7 +927,7 @@ namespace Microsoft.PowerShell
                 const string MsgForViewAll = "(<F4> to view all)";
                 const string MoreTextIndicator1 = " \u2026 ";
                 const string MoreTextIndicator2 = "\u2026 ";
-                const string DimItalicStyle = "\x1b[2;3m";
+                const string BoldDimItalicStyle = "\x1b[1;2;3m";
 
                 bool first = true;
                 int newlineIndex = -1;
@@ -942,7 +942,7 @@ namespace Microsoft.PowerShell
                 string tooltipStyle = _singleton._options._listPredictionTooltipColor;
                 if (tooltipStyle != PSConsoleReadLineOptions.DefaultInlinePredictionColor)
                 {
-                    tooltipStyle += DimItalicStyle;
+                    tooltipStyle += BoldDimItalicStyle;
                 }
 
                 do
@@ -1032,7 +1032,7 @@ namespace Microsoft.PowerShell
                 if (moreToCome)
                 {
                     // Append the "(<F4> to view all)" at the end of the last line
-                    string highlightStyle = _singleton._options._listPredictionColor + DimItalicStyle;
+                    string highlightStyle = _singleton._options._listPredictionColor + BoldDimItalicStyle;
                     int remainingCells = windowWidth - cellCount;
 
                     if (remainingCells >= MsgForViewAll.Length + MoreTextIndicator1.Length)

--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -181,6 +181,21 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
+        /// Show the tooltip of the currently selected list item in the full view.
+        /// </summary>
+        public static void ShowFullPredictionTooltip(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            if (_singleton._prediction.ActiveView is PredictionListView listView && listView.HasActiveSuggestion)
+            {
+                string tooltip = listView.SelectedItemTooltip;
+                if (!string.IsNullOrWhiteSpace(tooltip))
+                {
+                    _singleton._mockableMethods.RenderFullHelp(tooltip, regexPatternToScrollTo: null);
+                }
+            }
+        }
+
+        /// <summary>
         /// Implementation for updating the selected item in list view.
         /// </summary>
         private static bool UpdateListSelection(int numericArg)

--- a/PSReadLine/Render.Helper.cs
+++ b/PSReadLine/Render.Helper.cs
@@ -190,5 +190,30 @@ namespace Microsoft.PowerShell
 
             return charLength;
         }
+
+        private static (int newStart, int newEnd) TrimSubstringInPlace(string text, int start, int end)
+        {
+            int newStart = start;
+            int newEnd = end;
+
+            for (; newStart <= end; newStart++)
+            {
+                if (!char.IsWhiteSpace(text[newStart]))
+                {
+                    break;
+                }
+            }
+
+            for (; newEnd > newStart; newEnd--)
+            {
+                if (!char.IsWhiteSpace(text[newEnd]))
+                {
+                    break;
+                }
+            }
+
+            // Return the new start/end after triming, or (-1, -1) if the substring only consists of whitespaces.
+            return newStart > newEnd ? (-1, -1) : (newStart, newEnd);
+        }
     }
 }

--- a/test/InlinePredictionTest.cs
+++ b/test/InlinePredictionTest.cs
@@ -395,6 +395,7 @@ namespace Test
         }
 
         private const uint MiniSessionId = 56;
+        private static readonly Guid predictorId_0 = Guid.Parse("c69fa9fc-6157-4877-8cf4-a9c83a0128af");
         private static readonly Guid predictorId_1 = Guid.Parse("b45b5fbe-90fa-486c-9c87-e7940fdd6273");
         private static readonly Guid predictorId_2 = Guid.Parse("74a86463-033b-44a3-b386-41ee191c94be");
         private static readonly Guid predictorId_3 = Guid.Parse("19e98622-99e0-41f7-9ee0-a8bed92cde51");
@@ -409,9 +410,23 @@ namespace Test
                 new[] { typeof(Guid), typeof(string), typeof(uint), typeof(List<PredictiveSuggestion>) }, null);
 
             var input = ast.Extent.Text;
-            if (input == "netsh")
+            if (input is "netsh")
             {
                 return null;
+            }
+            else if (input is "tooltip")
+            {
+                var suggestions_0 = new List<PredictiveSuggestion>
+                {
+                    new PredictiveSuggestion("tooltip NO1", "Hello\nBinary\nWorld\nPowerShell is a task automation and configuration management program from Microsoft"),
+                    new PredictiveSuggestion("tooltip NO2", "Hello\nWorld"),
+                };
+
+                return new List<PredictionResult>
+                {
+                    (PredictionResult)ctor.Invoke(
+                        new object[] { predictorId_0, "Tooltip", MiniSessionId, suggestions_0 }),
+                };
             }
 
             var suggestions_1 = new List<PredictiveSuggestion>

--- a/test/ListViewTooltipTest.cs
+++ b/test/ListViewTooltipTest.cs
@@ -1,0 +1,484 @@
+using System;
+using Microsoft.PowerShell;
+using Xunit;
+
+namespace Test
+{
+    public partial class ReadLine
+    {
+        [SkippableFact]
+        public void List_Item_Tooltip_4_Lines()
+        {
+            // Set the terminal height to 22 and width to 60, so the metadata line will be fully rendered
+            // and maximum 4 lines can be used for tooltip for a selected list item.
+            int listWidth = 60;
+            TestSetup(new TestConsole(keyboardLayout: _, width: listWidth, height: 22), KeyMode.Cmd);
+
+            // The font effect sequences of 'dim' and 'italic' used in list view metadata line
+            // are ignored in the mock console, so only the white color will be left.
+            var dimmedColors = Tuple.Create(ConsoleColor.White, _console.BackgroundColor);
+            var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
+            using var disp = SetPrediction(PredictionSource.HistoryAndPlugin, PredictionViewStyle.ListView);
+            _mockedMethods.ClearPredictionFields();
+
+            SetHistory("tooltip -history");
+            Test("tooltip NO2", Keys(
+                "tooltip", CheckThat(() => AssertScreenIs(6,
+                        TokenClassification.Command, "tooltip",
+                        NextLine,
+                        TokenClassification.ListPrediction, "<-/3>",
+                        TokenClassification.None, new string(' ', listWidth - 28), // 28 is the length of '<-/3>' plus '<History(1) Tooltip(2)>'.
+                        dimmedColors, "<History(1) Tooltip(2)>",
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " -history",
+                        TokenClassification.None, new string(' ', listWidth - 27), // 27 is the length of '> tooltip -history' plus '[History]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "History",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO1",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO1' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO2",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO2' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        // List view is done, no more list item following.
+                        NextLine,
+                        NextLine
+                     )),
+                _.DownArrow,
+                     CheckThat(() => AssertScreenIs(6,
+                        TokenClassification.Command, "tooltip",
+                        TokenClassification.None, ' ',
+                        TokenClassification.Parameter, "-history",
+                        NextLine,
+                        TokenClassification.ListPrediction, "<1/3>",
+                        TokenClassification.None, new string(' ', listWidth - 30), // 30 is the length of '<1/3>' plus '<History(1/1) Tooltip(2)>'.
+                        dimmedColors, '<',
+                        TokenClassification.ListPrediction, "History(1/1) ",
+                        dimmedColors, "Tooltip(2)>",
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.ListPredictionSelected, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.ListPredictionSelected, " -history",
+                        TokenClassification.ListPredictionSelected, new string(' ', listWidth - 27), // 27 is the length of '> tooltip -history' plus '[History]'.
+                        TokenClassification.ListPredictionSelected, '[',
+                        TokenClassification.ListPrediction, "History",
+                        TokenClassification.ListPredictionSelected, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO1",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO1' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO2",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO2' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        // List view is done, no more list item following.
+                        NextLine,
+                        NextLine
+                     )),
+                _.DownArrow,
+                    CheckThat(() => AssertScreenIs(10,
+                        TokenClassification.Command, "tooltip",
+                        TokenClassification.None, " NO1",
+                        NextLine,
+                        TokenClassification.ListPrediction, "<2/3>",
+                        TokenClassification.None, new string(' ', listWidth - 30), // 30 is the length of '<2/3>' plus '<History(1) Tooltip(1/2)>'.
+                        dimmedColors, "<History(1) ",
+                        TokenClassification.ListPrediction, "Tooltip(1/2)",
+                        dimmedColors, '>',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " -history",
+                        TokenClassification.None, new string(' ', listWidth - 27), // 27 is the length of '> tooltip -history' plus '[History]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "History",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.ListPredictionSelected, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.ListPredictionSelected, " NO1",
+                        TokenClassification.ListPredictionSelected, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO1' plus '[Tooltip]'.
+                        TokenClassification.ListPredictionSelected, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.ListPredictionSelected, ']',
+                        NextLine,
+                        dimmedColors, "   >> Hello",  NextLine,
+                        dimmedColors, "      Binary", NextLine,
+                        dimmedColors, "      World",  NextLine,
+                        dimmedColors, "      PowerShell is a task automation an… ",
+                        TokenClassification.ListPrediction, "(<F4> to view all)",
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO2",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO2' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        // List view is done, no more list item following.
+                        NextLine,
+                        NextLine
+                     )),
+                _.DownArrow,
+                    CheckThat(() => AssertScreenIs(8,
+                        TokenClassification.Command, "tooltip",
+                        TokenClassification.None, " NO2",
+                        NextLine,
+                        TokenClassification.ListPrediction, "<3/3>",
+                        TokenClassification.None, new string(' ', listWidth - 30), // 30 is the length of '<3/3>' plus '<History(1) Tooltip(2/2)>'.
+                        dimmedColors, "<History(1) ",
+                        TokenClassification.ListPrediction, "Tooltip(2/2)",
+                        dimmedColors, '>',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " -history",
+                        TokenClassification.None, new string(' ', listWidth - 27), // 27 is the length of '> tooltip -history' plus '[History]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "History",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO1",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO1' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.ListPredictionSelected, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.ListPredictionSelected, " NO2",
+                        TokenClassification.ListPredictionSelected, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO2' plus '[Tooltip]'.
+                        TokenClassification.ListPredictionSelected, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.ListPredictionSelected, ']',
+                        NextLine,
+                        dimmedColors, "   >> Hello", NextLine,
+                        dimmedColors, "      World",
+                        // List view is done, no more list item following.
+                        NextLine,
+                        NextLine
+                     )),
+
+                // Once accepted, the list should be cleared.
+                _.Enter, CheckThat(() => AssertScreenIs(2,
+                        TokenClassification.Command, "tooltip",
+                        TokenClassification.None, " NO2",
+                        NextLine,
+                        NextLine))
+            ));
+        }
+
+        [SkippableFact]
+        public void List_Item_Tooltip_2_Lines()
+        {
+            // Set the terminal height to 15 and width to 60, so the metadata line will be fully rendered
+            // and maximum 2 lines can be used for tooltip for a selected list item.
+            int listWidth = 60;
+            TestSetup(new TestConsole(keyboardLayout: _, width: listWidth, height: 15), KeyMode.Cmd);
+
+            // The font effect sequences of 'dim' and 'italic' used in list view metadata line
+            // are ignored in the mock console, so only the white color will be left.
+            var dimmedColors = Tuple.Create(ConsoleColor.White, _console.BackgroundColor);
+            var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
+            using var disp = SetPrediction(PredictionSource.HistoryAndPlugin, PredictionViewStyle.ListView);
+            _mockedMethods.ClearPredictionFields();
+
+            SetHistory("tooltip -history");
+            Test("tooltip NO2", Keys(
+                "tooltip", CheckThat(() => AssertScreenIs(6,
+                        TokenClassification.Command, "tooltip",
+                        NextLine,
+                        TokenClassification.ListPrediction, "<-/3>",
+                        TokenClassification.None, new string(' ', listWidth - 28), // 28 is the length of '<-/3>' plus '<History(1) Tooltip(2)>'.
+                        dimmedColors, "<History(1) Tooltip(2)>",
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " -history",
+                        TokenClassification.None, new string(' ', listWidth - 27), // 27 is the length of '> tooltip -history' plus '[History]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "History",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO1",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO1' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO2",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO2' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        // List view is done, no more list item following.
+                        NextLine,
+                        NextLine
+                     )),
+                _.DownArrow, _.DownArrow,
+                    CheckThat(() => AssertScreenIs(8,
+                        TokenClassification.Command, "tooltip",
+                        TokenClassification.None, " NO1",
+                        NextLine,
+                        TokenClassification.ListPrediction, "<2/3>",
+                        TokenClassification.None, new string(' ', listWidth - 30), // 30 is the length of '<2/3>' plus '<History(1) Tooltip(1/2)>'.
+                        dimmedColors, "<History(1) ",
+                        TokenClassification.ListPrediction, "Tooltip(1/2)",
+                        dimmedColors, '>',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " -history",
+                        TokenClassification.None, new string(' ', listWidth - 27), // 27 is the length of '> tooltip -history' plus '[History]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "History",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.ListPredictionSelected, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.ListPredictionSelected, " NO1",
+                        TokenClassification.ListPredictionSelected, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO1' plus '[Tooltip]'.
+                        TokenClassification.ListPredictionSelected, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.ListPredictionSelected, ']',
+                        NextLine,
+                        dimmedColors, "   >> Hello", NextLine,
+                        dimmedColors, "      Binary … ",
+                        TokenClassification.ListPrediction, "(<F4> to view all)",
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO2",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO2' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        // List view is done, no more list item following.
+                        NextLine,
+                        NextLine
+                     )),
+                _.F4,
+                    CheckThat(() => Assert.Equal(
+                        "Hello\nBinary\nWorld\nPowerShell is a task automation and configuration management program from Microsoft",
+                        _mockedMethods.helpContentRendered)),
+                _.DownArrow,
+                    CheckThat(() => AssertScreenIs(8,
+                        TokenClassification.Command, "tooltip",
+                        TokenClassification.None, " NO2",
+                        NextLine,
+                        TokenClassification.ListPrediction, "<3/3>",
+                        TokenClassification.None, new string(' ', listWidth - 30), // 30 is the length of '<3/3>' plus '<History(1) Tooltip(2/2)>'.
+                        dimmedColors, "<History(1) ",
+                        TokenClassification.ListPrediction, "Tooltip(2/2)",
+                        dimmedColors, '>',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " -history",
+                        TokenClassification.None, new string(' ', listWidth - 27), // 27 is the length of '> tooltip -history' plus '[History]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "History",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO1",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO1' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.ListPredictionSelected, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.ListPredictionSelected, " NO2",
+                        TokenClassification.ListPredictionSelected, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO2' plus '[Tooltip]'.
+                        TokenClassification.ListPredictionSelected, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.ListPredictionSelected, ']',
+                        NextLine,
+                        dimmedColors, "   >> Hello", NextLine,
+                        dimmedColors, "      World",
+                        // List view is done, no more list item following.
+                        NextLine,
+                        NextLine
+                     )),
+
+                // Once accepted, the list should be cleared.
+                _.Enter, CheckThat(() => AssertScreenIs(2,
+                        TokenClassification.Command, "tooltip",
+                        TokenClassification.None, " NO2",
+                        NextLine,
+                        NextLine))
+            ));
+        }
+
+        [SkippableFact]
+        public void List_Item_Tooltip_1_Line()
+        {
+            // Set the terminal height to 6 and width to 60, so the metadata line will be fully rendered
+            // and maximum 2 lines can be used for tooltip for a selected list item.
+            int listWidth = 60;
+            TestSetup(new TestConsole(keyboardLayout: _, width: listWidth, height: 6), KeyMode.Cmd);
+
+            // The font effect sequences of 'dim' and 'italic' used in list view metadata line
+            // are ignored in the mock console, so only the white color will be left.
+            var dimmedColors = Tuple.Create(ConsoleColor.White, _console.BackgroundColor);
+            var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
+            using var disp = SetPrediction(PredictionSource.HistoryAndPlugin, PredictionViewStyle.ListView);
+            _mockedMethods.ClearPredictionFields();
+
+            SetHistory("tooltip -history");
+            Test("tooltip NO2", Keys(
+                "tooltip",  _.DownArrow, _.DownArrow,
+                    CheckThat(() => AssertScreenIs(6,
+                        TokenClassification.Command, "tooltip",
+                        TokenClassification.None, " NO1",
+                        NextLine,
+                        TokenClassification.ListPrediction, "<2/3>",
+                        TokenClassification.None, new string(' ', listWidth - 30), // 30 is the length of '<2/3>' plus '<History(1) Tooltip(1/2)>'.
+                        dimmedColors, "<History(1) ",
+                        TokenClassification.ListPrediction, "Tooltip(1/2)",
+                        dimmedColors, '>',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " -history",
+                        TokenClassification.None, new string(' ', listWidth - 27), // 27 is the length of '> tooltip -history' plus '[History]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "History",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.ListPredictionSelected, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.ListPredictionSelected, " NO1",
+                        TokenClassification.ListPredictionSelected, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO1' plus '[Tooltip]'.
+                        TokenClassification.ListPredictionSelected, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.ListPredictionSelected, ']',
+                        NextLine,
+                        dimmedColors, "   >> Hello … ",
+                        TokenClassification.ListPrediction, "(<F4> to view all)",
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO2",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO2' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        // List view is done, no more list item following.
+                        NextLine
+                     )),
+                _.F4,
+                    CheckThat(() => Assert.Equal(
+                        "Hello\nBinary\nWorld\nPowerShell is a task automation and configuration management program from Microsoft",
+                        _mockedMethods.helpContentRendered)),
+                _.DownArrow,
+                    CheckThat(() => AssertScreenIs(6,
+                        TokenClassification.Command, "tooltip",
+                        TokenClassification.None, " NO2",
+                        NextLine,
+                        TokenClassification.ListPrediction, "<3/3>",
+                        TokenClassification.None, new string(' ', listWidth - 30), // 30 is the length of '<3/3>' plus '<History(1) Tooltip(2/2)>'.
+                        dimmedColors, "<History(1) ",
+                        TokenClassification.ListPrediction, "Tooltip(2/2)",
+                        dimmedColors, '>',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " -history",
+                        TokenClassification.None, new string(' ', listWidth - 27), // 27 is the length of '> tooltip -history' plus '[History]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "History",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.None, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.None, " NO1",
+                        TokenClassification.None, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO1' plus '[Tooltip]'.
+                        TokenClassification.None, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.None, ']',
+                        NextLine,
+                        TokenClassification.ListPrediction, '>',
+                        TokenClassification.ListPredictionSelected, ' ',
+                        emphasisColors, "tooltip",
+                        TokenClassification.ListPredictionSelected, " NO2",
+                        TokenClassification.ListPredictionSelected, new string(' ', listWidth - 22), // 22 is the length of '> tooltip NO2' plus '[Tooltip]'.
+                        TokenClassification.ListPredictionSelected, '[',
+                        TokenClassification.ListPrediction, "Tooltip",
+                        TokenClassification.ListPredictionSelected, ']',
+                        NextLine,
+                        dimmedColors, "   >> Hello … ",
+                        TokenClassification.ListPrediction, "(<F4> to view all)",
+                        // List view is done, no more list item following.
+                        NextLine
+                     )),
+                _.F4,
+                    CheckThat(() => Assert.Equal(
+                        "Hello\nWorld",
+                        _mockedMethods.helpContentRendered)),
+
+                // Once accepted, the list should be cleared.
+                _.Enter, CheckThat(() => AssertScreenIs(2,
+                        TokenClassification.Command, "tooltip",
+                        TokenClassification.None, " NO2",
+                        NextLine,
+                        NextLine))
+            ));
+        }
+    }
+}

--- a/test/MockConsole.cs
+++ b/test/MockConsole.cs
@@ -235,9 +235,9 @@ namespace Test
                     var escapeSequence = s.Substring(i + 2, len);
                     foreach (var subsequence in escapeSequence.Split(';'))
                     {
-                        if (subsequence is "2" or "3")
+                        if (subsequence is "1" or "2" or "3")
                         {
-                            // Ignore the font effect sequence: 2 - dimmed color; 3 - italics
+                            // Ignore the font effect sequence: 1 - bold; 2 - dimmed color; 3 - italics
                             // They are used in the metadata line of the list view.
                             continue;
                         }
@@ -451,9 +451,9 @@ namespace Test
                     var escapeSequence = s.Substring(i + 2, len);
                     foreach (var subsequence in escapeSequence.Split(';'))
                     {
-                        if (subsequence is "2" or "3")
+                        if (subsequence is "1" or "2" or "3")
                         {
-                            // Ignore the font effect sequence: 2 - dimmed color; 3 - italics
+                            // Ignore the font effect sequence: 1 - bold; 2 - dimmed color; 3 - italics
                             // They are used in the metadata line of the list view.
                             continue;
                         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Support tooltip rendering in the prediction list view. Fix #3638.

- By default, the list view can use up to 4 lines for tooltip rendering:

   ![tooltip1](https://user-images.githubusercontent.com/127450/235556900-37c0fc5f-43c9-4861-b258-3ce71e8a99f2.gif)

- For tooltip that spans more than 4 lines, we allow the user to see the full tooltip in the alternate screen buffer with the keybinding <kbd>F4</kbd>

   ![tooltip2](https://user-images.githubusercontent.com/127450/235557003-f4046641-4502-46e8-bbb7-35bef170c6dd.gif)

- When terminal size shrinks, the maximum lines can be used for tooltip also decreases -- it uses up to 2 lines for tooltip when the max list height is reduced to 5.

   ![tooltip3](https://user-images.githubusercontent.com/127450/235557178-0d7fd996-12f9-4775-9b61-19ea99b23c8e.gif)

- When the terminal size is even smaller and the max list view height becomes 3, it uses up to 1 line for tooltip.

   ![tooltip4](https://user-images.githubusercontent.com/127450/235558214-40f5cb0a-ffe2-4122-93cc-61273502db23.gif)

- You can change the tooltip color by `Set-PsreadLineOption -Colors @{ ListPredictionTooltip = "green" }`, for example.

   ![tooltip5](https://user-images.githubusercontent.com/127450/235558768-f5794be4-e6ea-4ed3-a02d-7d8966228787.gif)


## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [x] Doc Issue filed: 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3667)