### PR TITLE
Append reset VT sequence before rendering the inline prediction

### DIFF
--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -1416,6 +1416,7 @@ namespace Microsoft.PowerShell
                 StringBuilder currentLineBuffer = consoleBufferLines[currentLogicalLine];
 
                 currentLineBuffer
+                    .Append(VTColorUtils.AnsiReset)
                     .Append(_singleton._options._inlinePredictionColor)
                     .Append(_suggestionText, inputLength, _renderedLength - inputLength);
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Append reset VT sequence before rendering the inline prediction, so as to reset any VT decorations customized by a user when rendering the inline view.

Before the fix, `gcm -N` shows the following inline prediction -- the VT decoration for the parameter leaks to the inline view.

![image](https://user-images.githubusercontent.com/127450/235816197-4c4e8ce9-b70b-45c7-ae4a-138f80984646.png)

After the fix, `gcm -N` shows the following:

![image](https://user-images.githubusercontent.com/127450/235816286-edecae42-c4ae-4425-8c36-19a220950dab.png)

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3669)