### PR TITLE
Fix a bug in tooltip rendering related to calculation of the tooltip height

### DIFF
--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -1054,7 +1054,7 @@ namespace Microsoft.PowerShell
                 }
 
                 buff.Append(VTColorUtils.AnsiReset);
-                return _maxTooltipHeight - linesLeft > 0 ? linesLeft : 0;
+                return _maxTooltipHeight - (linesLeft > 0 ? linesLeft : 0);
             }
 
             /// <summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix a bug in tooltip rendering related to calculation of the tooltip height.
The tooltip height calculation is wrong due to my mistake on the precedence order of the ternary operator, which resulted in the clearance of list view not work as expected.

Before:

![image](https://user-images.githubusercontent.com/127450/236052569-9e418484-fe68-4966-87f4-135e74fd2b48.png)

After:

![image](https://user-images.githubusercontent.com/127450/236052620-b589a1f4-25f8-4c09-8684-df76a46601ba.png)


## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3671)