### PR TITLE
support Emacs-style backward word deletion with Ctrl-Alt-b

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -330,6 +330,7 @@ namespace Microsoft.PowerShell
                 { Keys.AltR,                   MakeKeyHandler(RevertLine,                "RevertLine") },
                 { Keys.AltY,                   MakeKeyHandler(YankPop,                   "YankPop") },
                 { Keys.AltBackspace,           MakeKeyHandler(BackwardKillWord,          "BackwardKillWord") },
+                { Keys.CtrlAltH,               MakeKeyHandler(BackwardKillWord,          "BackwardKillWord") },
                 { Keys.AltEquals,              MakeKeyHandler(PossibleCompletions,       "PossibleCompletions") },
                 { Keys.CtrlAltQuestion,        MakeKeyHandler(ShowKeyBindings,           "ShowKeyBindings") },
                 { Keys.AltQuestion,            MakeKeyHandler(WhatIsKey,                 "WhatIsKey") },

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -605,6 +605,7 @@ namespace Microsoft.PowerShell
         public static PSKeyInfo CtrlShiftLeftArrow  = CtrlShift(ConsoleKey.LeftArrow);
         public static PSKeyInfo CtrlShiftRightArrow = CtrlShift(ConsoleKey.RightArrow);
 
+        public static PSKeyInfo CtrlAltH            = CtrlAlt('h');
         public static PSKeyInfo CtrlAltY            = CtrlAlt('y');
         public static PSKeyInfo CtrlAltRBracket     = CtrlAlt(']');
         public static PSKeyInfo CtrlAltQuestion     = CtrlAlt('?');


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add Ctrl-Alt-b for Emacs style keybinding. This keybinding exists in bash as well and works the same as Alt-Backspace.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3707)