### PR TITLE
support fish-shell-style C-e for accepting history suggestion

### DIFF
--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -18,9 +18,19 @@ namespace Microsoft.PowerShell
         /// If the input has multiple lines, move to the end of the current line,
         /// or if already at the end of the line, move to the end of the input.
         /// If the input has a single line, move to the end of the input.
+        /// If already at the end of input, accept edit suggestion.
         /// </summary>
         public static void EndOfLine(ConsoleKeyInfo? key = null, object arg = null)
         {
+            if (TryGetArgAsInt(arg, out var numericArg, 1))
+            {
+                if (_singleton._current == _singleton._buffer.Length && numericArg > 0)
+                {
+                    AcceptSuggestion(key, arg);
+                    return;
+                }
+            }
+
             int i = _singleton._current;
             for (; i < _singleton._buffer.Length; i++)
             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use C-e for accepting history suggestions.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3708)