### PR TITLE
Error solution/Correction - Update SamplePSReadLineProfile.ps1

### DIFF
--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -172,7 +172,7 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
     $token = FindToken $tokens $cursor
 
     # If we're on or inside a **quoted** string token (so not generic), we need to be smarter
-    if ($token -is [StringToken] -and $token.Kind -ne [TokenKind]::Generic) {
+    if ($token -is [System.Management.Automation.Language.StringExpandableToken] -and $token.Kind -ne [System.Management.Automation.Language.TokenKind]::Generic) {
         # If we're at the start of the string, assume we're inserting a new string
         if ($token.Extent.StartOffset -eq $cursor) {
             [Microsoft.PowerShell.PSConsoleReadLine]::Insert("$quote$quote ")
@@ -186,7 +186,7 @@ Set-PSReadLineKeyHandler -Key '"',"'" `
             return
         }
     }
-
+    
     if ($null -eq $token -or
         $token.Kind -eq [TokenKind]::RParen -or $token.Kind -eq [TokenKind]::RCurly -or $token.Kind -eq [TokenKind]::RBracket) {
         if ($line[0..$cursor].Where{$_ -eq $quote}.Count % 2 -eq 1) {


### PR DESCRIPTION
Windows 11 Terminal running:
PowerShell 7.4.0-preview.4
PSReadLine version: 2.3.1 |beta1

Problem: 
Single and double quotes causing new line to render (Skipping current line) or to throw an error.

Error: 
InvalidOperation: D:\SomeExternalDrive\PowerShell\Microsoft.PowerShell_profile.ps1:75 Line |
  75 |      if ($token -is [StringToken] -and $token.Kind -ne [TokenKind]::Ge …
     |                     ~~~~~~~~~~~~~
     | Unable to find type [StringToken].

Solution: 
Line 175 changed from original.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3762&drop=dogfoodAlpha