### PR TITLE
[vi-mode] Add ViClipboardMode Option to Support Copying and Pasting to System Clipboard

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -50,6 +50,12 @@ namespace Microsoft.PowerShell
         Command
     }
 
+    public enum ViClipboardMode
+    {
+        ViRegister,
+        SystemClipboard
+    }
+
     public enum HistorySaveStyle
     {
         SaveIncrementally,
@@ -341,6 +347,11 @@ namespace Microsoft.PowerShell
         /// The script block to execute when the indicator mode is set to Script.
         /// </summary>
         public ScriptBlock ViModeChangeHandler { get; set; }
+
+        /// <summary>
+        /// Which source should be used when copying and pasting in vi edit mode?
+        /// </summary>
+        public ViClipboardMode ViClipboardMode { get; set; }
 
         /// <summary>
         /// The path to the saved history.
@@ -788,6 +799,14 @@ namespace Microsoft.PowerShell
 
         [Parameter]
         public ScriptBlock ViModeChangeHandler { get; set; }
+
+        [Parameter]
+        public ViClipboardMode ViClipboardMode
+        {
+            get => _viClipboardMode.GetValueOrDefault();
+            set => _viClipboardMode = value;
+        }
+        internal ViClipboardMode? _viClipboardMode;
 
         [Parameter]
         public PredictionSource PredictionSource

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -120,6 +120,10 @@ namespace Microsoft.PowerShell
                 }
                 Options.ViModeChangeHandler = options.ViModeChangeHandler;
             }
+            if (options._viClipboardMode.HasValue)
+            {
+                Options.ViClipboardMode = options.ViClipboardMode;
+            }
             if (options.HistorySavePath != null)
             {
                 Options.HistorySavePath = options.HistorySavePath;

--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -153,6 +153,9 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                   <PropertyName>ViModeChangeHandler</PropertyName>
               </ListItem>
               <ListItem>
+                  <PropertyName>ViClipboardMode</PropertyName>
+              </ListItem>
+              <ListItem>
                 <PropertyName>WordDelimiters</PropertyName>
               </ListItem>
               <ListItem>

--- a/PSReadLine/ViRegister.cs
+++ b/PSReadLine/ViRegister.cs
@@ -12,28 +12,29 @@ namespace Microsoft.PowerShell
         {
             private readonly PSConsoleReadLine _singleton;
             private string _localText;
+            private PSConsoleReadLineOptions _options;
             private string Text
             {
                 get
                 {
-                    if (_singleton.Options.ViClipboardMode == ViClipboardMode.ViRegister)
+                    if (_options?.ViClipboardMode == ViClipboardMode.SystemClipboard)
                     {
-                        return _localText;
+                        return Internal.Clipboard.GetText();
                     }
                     else
                     {
-                        return Internal.Clipboard.GetText();
+                        return _localText;
                     }
                 }
                 set
                 {
-                    if (_singleton.Options.ViClipboardMode == ViClipboardMode.ViRegister)
+                    if (_options?.ViClipboardMode == ViClipboardMode.SystemClipboard)
                     {
-                        _localText = value;
+                        Internal.Clipboard.SetText(value);
                     }
                     else
                     {
-                        Internal.Clipboard.SetText(value);
+                        _localText = value;
                     }
                 }
             }
@@ -48,6 +49,14 @@ namespace Microsoft.PowerShell
             public ViRegister(PSConsoleReadLine singleton)
             {
                 _singleton = singleton;
+                _options = _singleton?.Options;
+            }
+
+            internal static ViRegister CreateTestRegister(PSConsoleReadLineOptions options)
+            {
+                ViRegister register = new ViRegister(null);
+                register._options = options;
+                return register;
             }
 
             /// <summary>

--- a/test/ViRegisterTests.cs
+++ b/test/ViRegisterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using Microsoft.PowerShell;
+using Microsoft.PowerShell.Internal;
 using Xunit;
 
 namespace Test
@@ -151,6 +152,52 @@ namespace Test
 
             Assert.Equal("line1\nline2\nline3\n", buffer.ToString());
             Assert.Equal(6, newPosition);
+        }
+
+        [Fact]
+        public void ViRegister_ClipboardModeViRegister()
+        {
+            PSConsoleReadLineOptions options = new PSConsoleReadLineOptions(string.Empty, false)
+            {
+                ViClipboardMode = ViClipboardMode.ViRegister
+            };
+            var register = PSConsoleReadLine.ViRegister.CreateTestRegister(options);
+
+            // system under test
+
+            Clipboard.SetText("EmptyClipboard");
+            var copyBuffer = new StringBuilder("CopiedText");
+            register.Record(copyBuffer);
+            var pasteBuffer = new StringBuilder();
+            register.PasteAfter(pasteBuffer, 0);
+
+            // assert expectations
+
+            Assert.Equal("EmptyClipboard", Clipboard.GetText());
+            Assert.Equal("CopiedText", pasteBuffer.ToString());
+        }
+
+        [Fact]
+        public void ViRegister_ClipboardModeSystemClipboard()
+        {
+            PSConsoleReadLineOptions options = new PSConsoleReadLineOptions(string.Empty, false)
+            {
+                ViClipboardMode = ViClipboardMode.SystemClipboard
+            };
+            var register = PSConsoleReadLine.ViRegister.CreateTestRegister(options);
+
+            // system under test
+
+            Clipboard.SetText("EmptyClipboard");
+            var copyBuffer = new StringBuilder("CopiedText");
+            register.Record(copyBuffer);
+            var pasteBuffer = new StringBuilder();
+            register.PasteAfter(pasteBuffer, 0);
+
+            // assert expectations
+
+            Assert.Equal("CopiedText", Clipboard.GetText());
+            Assert.Equal("CopiedText", pasteBuffer.ToString());
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds the ViClipboardMode option. This option has two values: ViRegister and SystemClipboard. 

ViRegister, the default, maintains the original behavior for copying and pasting in Vi edit mode, which was to copy and paste using a buffer that was local to the current instance of PSReadLine. With this original behavior, text cannot be copied to/from other applications using Vi keys and it can't be copied between separate panes or windows of PowerShell.

The other value, SystemClipboard, changes the copy and paste behavior in Vi edit mode. When this value is used, text is copied and pasted from the system's clipboard when the user uses Vi key commands. This allows the user to copy and paste text from external applications using "y" or "p". It also allows the user to copy and paste text between different panes or windows of PowerShell.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [x] Doc Issue filed: [MicrosoftDocs/PowerShell-Docs#10325](https://github.com/MicrosoftDocs/PowerShell-Docs/pull/10325)

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3769&drop=dogfoodAlpha