### PR TITLE
Choose the inline prediction color based on the environment

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -179,11 +179,17 @@ namespace Microsoft.PowerShell
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 DefaultEditMode = EditMode.Windows;
-                DefaultInlinePredictionColor =
-                    Environment.OSVersion.Version.Build >= 22621 // on Windows 11 22H2 or newer versions
-                    || Environment.GetEnvironmentVariable("WT_SESSION") is not null // in Windows Terminal
-                        ? newInlinePredictionColor
-                        : oldInlinePredictionColor;
+
+                // Our tests expect that the default inline-view color is set to the new color, so we configure
+                // the color based on system environment only if we are not in test runs.
+                if (AppDomain.CurrentDomain.FriendlyName is not "PSReadLine.Tests")
+                {
+                    DefaultInlinePredictionColor =
+                        Environment.OSVersion.Version.Build >= 22621 // on Windows 11 22H2 or newer versions
+                        || Environment.GetEnvironmentVariable("WT_SESSION") is not null // in Windows Terminal
+                            ? newInlinePredictionColor
+                            : oldInlinePredictionColor;
+                }
             }
 
             // Use the same color for the list prediction tooltips.

--- a/PSReadLine/PlatformWindows.cs
+++ b/PSReadLine/PlatformWindows.cs
@@ -637,10 +637,7 @@ static class PlatformWindows
     internal static int GetParentPid(Process process)
     {
         // (This is how ProcessCodeMethods in pwsh does it.)
-        PROCESS_BASIC_INFORMATION pbi;
-        int size;
-        var res = NtQueryInformationProcess(process.Handle, 0, out pbi, Marshal.SizeOf<PROCESS_BASIC_INFORMATION>(), out size);
-
+        var res = NtQueryInformationProcess(process.Handle, 0, out PROCESS_BASIC_INFORMATION pbi, Marshal.SizeOf<PROCESS_BASIC_INFORMATION>(), out _);
         return res != 0 ? InvalidProcessId : pbi.InheritedFromUniqueProcessId.ToInt32();
     }
 

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -25,8 +25,6 @@ using Microsoft.PowerShell.PSReadLine;
 
 namespace Microsoft.PowerShell
 {
-    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors")]
-    [SuppressMessage("Microsoft.Usage", "CA2237:MarkISerializableTypesWithSerializable")]
     class ExitException : Exception { }
 
     public partial class PSConsoleReadLine : IPSConsoleReadLineMockableMethods


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3805

Choose the inline prediction color based on the environment. On Windows OS prior to Win11, if it's not running in Windows Terminal, then we use the old inline color that was used in v2.2.6. Otherwise, we use the new color, which provide sufficient contrast in terminals that don't use a pure black background (like VSCode terminal). See #3493 for the color change.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/3808)