### PR TITLE
Handle large history file properly by reading lines in the streaming way

### DIFF
--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -497,7 +497,7 @@ namespace Microsoft.PowerShell
                     string line;
                     while ((line = sr.ReadLine()) is not null)
                     {
-                        if (!line.EndsWith('`'))
+                        if (!line.EndsWith("`", StringComparison.Ordinal))
                         {
                             // A complete history record is guaranteed to start from the next line.
                             break;

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -457,11 +457,60 @@ namespace Microsoft.PowerShell
             {
                 WithHistoryFileMutexDo(1000, () =>
                 {
-                    var historyLines = File.ReadAllLines(Options.HistorySavePath);
+                    var historyLines = ReadHistoryLinesImpl(Options.HistorySavePath, Options.MaximumHistoryCount);
                     UpdateHistoryFromFile(historyLines, fromDifferentSession: false, fromInitialRead: true);
                     var fileInfo = new FileInfo(Options.HistorySavePath);
                     _historyFileLastSavedSize = fileInfo.Length;
                 });
+            }
+
+            static IEnumerable<string> ReadHistoryLinesImpl(string path, int historyCount)
+            {
+                const long offset_1mb = 1048576;
+                const long offset_05mb = 524288;
+
+                // 1mb content contains more than 34,000 history lines for a typical usage, which should be
+                // more than enough to cover 25,000 history records (a history record could be a multi-line
+                // command). Similarly, 0.5mb content should be enough to cover 10,000 history records.
+                // We optimize the file reading when the history count falls in those ranges. If the history
+                // count is even larger, which should be very rare, we just read all lines.
+                long offset = historyCount switch
+                {
+                    <= 10000 => offset_05mb,
+                    <= 25000 => offset_1mb,
+                    _ => 0,
+                };
+
+                using var fs = new FileStream(path, FileMode.Open);
+                using var sr = new StreamReader(fs);
+
+                if (offset > 0 && fs.Length > offset)
+                {
+                    // When the file size is larger than 1mb, we only read the last 1mb content from the end.
+                    int? b1 = null, b2 = null;
+                    fs.Seek(-offset, SeekOrigin.End);
+
+                    // After seeking, the current position may point at the middle of a history record, or even
+                    // a byte within a unicode char. So, we need to find the start of the next history record.
+                    while ((b2 = fs.ReadByte()) is not -1)
+                    {
+                        // Read bytes until we find the first newline ('\n' == 0xA) that is not right after a backtick ('`' == 0x60).
+                        // It means a separate full history record will start from the next byte.
+                        if (b2 is 0xA && b1.HasValue && b1 is not 0x60)
+                        {
+                            break;
+                        }
+
+                        b1 = b2;
+                    }
+                }
+
+                // Read lines in the streaming way, so it won't consume to much memory even if we have to
+                // read all lines from a large history file.
+                while (!sr.EndOfStream)
+                {
+                    yield return sr.ReadLine();
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3771, Fix #1360, Fix #537

Handle large history file properly by reading lines in the streaming way.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/3810)