### PR TITLE
Fix a few VI key handlers to close edit group properly

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -205,7 +205,7 @@ namespace Microsoft.PowerShell
             if (InViInsertMode())   // must close out the current edit group before engaging menu completion
             {
                 ViCommandMode();
-                ViInsertWithAppend();
+                ViInsertWithAppendImpl();
             }
 
             // Do not show suggestion text during tab completion.

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -573,6 +573,12 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViInsertWithAppend(ConsoleKeyInfo? key = null, object arg = null)
         {
+            _singleton._groupUndoHelper.StartGroup(ViInsertWithAppend, arg);
+            ViInsertWithAppendImpl(key, arg);
+        }
+
+        private static void ViInsertWithAppendImpl(ConsoleKeyInfo? key = null, object arg = null)
+        {
             ViInsertMode(key, arg);
             ForwardChar(key, arg);
         }
@@ -1304,7 +1310,7 @@ namespace Microsoft.PowerShell
             }
             _singleton.SaveEditItem(EditItemInsertChar.Create('\n', insertPoint));
             _singleton.Render();
-            ViInsertWithAppend();
+            ViInsertWithAppendImpl();
         }
 
         private void MoveToEndOfPhrase()

--- a/PSReadLine/Replace.vi.cs
+++ b/PSReadLine/Replace.vi.cs
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell
                 && !_singleton.IsDelimiter(_singleton._lastWordDelimiter, _singleton.Options.WordDelimiters)
                 && _singleton._shouldAppend)
             {
-                ViInsertWithAppend(key, arg);
+                ViInsertWithAppendImpl(key, arg);
             }
             else
             {
@@ -180,7 +180,7 @@ namespace Microsoft.PowerShell
             }
             if (_singleton._current == _singleton._buffer.Length - 1)
             {
-                ViInsertWithAppend(key, arg);
+                ViInsertWithAppendImpl(key, arg);
             }
             else
             {
@@ -194,7 +194,7 @@ namespace Microsoft.PowerShell
             DeleteEndOfWord(key, arg);
             if (_singleton._current == _singleton._buffer.Length - 1)
             {
-                ViInsertWithAppend(key, arg);
+                ViInsertWithAppendImpl(key, arg);
             }
             else
             {
@@ -208,7 +208,7 @@ namespace Microsoft.PowerShell
             ViDeleteEndOfGlob(key, arg);
             if (_singleton._current == _singleton._buffer.Length - 1)
             {
-                ViInsertWithAppend(key, arg);
+                ViInsertWithAppendImpl(key, arg);
             }
             else
             {
@@ -270,12 +270,16 @@ namespace Microsoft.PowerShell
             {
                 if (_singleton._current < initialCurrent || _singleton._current >= _singleton._buffer.Length)
                 {
-                    ViInsertWithAppend(key, arg);
+                    ViInsertWithAppendImpl(key, arg);
                 }
                 else
                 {
                     ViInsertMode(key, arg);
                 }
+            }
+            else
+            {
+                _singleton._groupUndoHelper.EndGroup();
             }
         }
 
@@ -294,6 +298,10 @@ namespace Microsoft.PowerShell
             if (ViCharacterSearcher.SearchBackwardDelete(keyChar, arg, backoff: false, instigator: (_key, _arg) => ViReplaceToCharBack(keyChar, _key, _arg)))
             {
                 ViInsertMode(key, arg);
+            }
+            else
+            {
+                _singleton._groupUndoHelper.EndGroup();
             }
         }
 
@@ -314,6 +322,10 @@ namespace Microsoft.PowerShell
             {
                 ViInsertMode(key, arg);
             }
+            else
+            {
+                _singleton._groupUndoHelper.EndGroup();
+            }
         }
 
         /// <summary>
@@ -332,8 +344,10 @@ namespace Microsoft.PowerShell
             {
                 ViInsertMode(key, arg);
             }
+            else
+            {
+                _singleton._groupUndoHelper.EndGroup();
+            }
         }
-
-
     }
 }

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -1149,16 +1149,17 @@ namespace Test
                 // relative to where the cursor position is – currently set to 0 - the command
                 // fails. Therefore, we are still in normal mode.
                 //
-                // however, even though the command failed, it still started an edit group
-                // which is now pending further edit actions
+                // as the command failed, the current edit group is now correctly closed.
 
                 "c2tb", CheckThat(() => AssertLineIs("bcd")),
 
                 // attempt to [c]hange text un[t]il just before the [2]nd [b] character a third time.
                 // this exercises a code path where starting a edit group while another
                 // pending edit group was previously started crashed PSRL.
-
-                "c2tb" // should not crash
+                //
+                // this should no longer crash as any started pending group is now properly closed if
+                // the command fails
+                "c2tb"
                 ));
         }
 

--- a/test/BasicEditingTest.VI.cs
+++ b/test/BasicEditingTest.VI.cs
@@ -1121,5 +1121,87 @@ namespace Test
                 _.RightArrow, // 'RightArrow' again does nothing, but doesn't crash
                 "c"));
         }
+
+        [SkippableFact]
+        public void ViDefect1281_1()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("bcd", Keys(
+                "abcdabcd", _.Escape,
+
+                // return to the [B]eginning of the word,
+                // then [c]hange text un[t]il just before the [2]nd [b] character
+                // this leaves the cursor at the current position (0) but erases
+                // the "abcda" text portion, / switches to edit mode and
+                // positions the cursor just before the "bcd" text portion.
+
+                "Bc2tb",
+
+                // going back to normal mode again without having modified the buffer further
+                // even though the [c] command started an edit group, going back to normal
+                // mode closes the pending edit group.
+
+                _.Escape, CheckThat(() => AssertCursorLeftIs(0)),
+
+                // attempt to [c]hange text un[t]il just before the [2]nd [b] character again
+                // because the [b] character only appears once further down in the buffer
+                // relative to where the cursor position is – currently set to 0 - the command
+                // fails. Therefore, we are still in normal mode.
+                //
+                // however, even though the command failed, it still started an edit group
+                // which is now pending further edit actions
+
+                "c2tb", CheckThat(() => AssertLineIs("bcd")),
+
+                // attempt to [c]hange text un[t]il just before the [2]nd [b] character a third time.
+                // this exercises a code path where starting a edit group while another
+                // pending edit group was previously started crashed PSRL.
+
+                "c2tb" // should not crash
+                ));
+        }
+
+        [SkippableFact]
+        public void ViDefect1281_2()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("abc", Keys(
+                "abc", _.Escape,
+
+                // 'cff' triggers `ViReplaceToChar` to delete until the character 'f'. But 'abc' doesn't
+                // have the letter 'f', so the started edit group should be ended and cursor is not moved.
+                "cff",
+                CheckThat(() => AssertCursorLeftIs(2)),
+
+                // the subsequent 'cc' calls `ViReplaceLine` to replace the current line with 'i', which
+                // starts a new edit group.
+                "ccip",
+                CheckThat(() => AssertLineIs("ip")),
+
+                // now we undo the 'cci' step, and accept the current command line, which should be 'abc'.
+                _.Escape, "u"
+                ));
+        }
+
+        [SkippableFact]
+        public void ViDefect1281_3()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("bcd", Keys(
+                "bcd", _.Escape, _.LeftArrow, _.LeftArrow,
+
+                // 'a' triggers `ViInsertWithAppend` and we append 'iii' after 'b'.
+                "aiii",
+                CheckThat(() => AssertCursorLeftIs(4)),
+                CheckThat(() => AssertLineIs("biiicd")),
+
+                // now we undo the 'aiii' step, and accept the current command line,
+                // which should be 'bcd'.
+                _.Escape, "u"
+                ));
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #1281

I copied the code in `Repalce.vi.cs` from #2012 (thanks @springcomp!) to fix the instances where edit group was not correctly ended when searching fails. I also copied a test from #2012 and added 2 more tests.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->
