### PR TITLE
Refactoring Key Chords Handling

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -1094,7 +1094,8 @@ namespace Microsoft.PowerShell
                         prependNextKey = true;
 
                         // without this branch experience doesn't look naturally
-                        if (_dispatchTable.TryGetValue(nextKey, out var handler) &&
+                        if (_dispatchTable.TryGetValue(nextKey, out var handlerOrChordDispatchTable) &&
+                            handlerOrChordDispatchTable.TryGetKeyHandler(out var handler) &&
                             (
                                 handler.Action == CopyOrCancelLine ||
                                 handler.Action == Cut ||

--- a/PSReadLine/ConsoleKeyChordConverter.cs
+++ b/PSReadLine/ConsoleKeyChordConverter.cs
@@ -36,20 +36,22 @@ namespace Microsoft.PowerShell
                 throw new ArgumentNullException(nameof(chord));
             }
 
-            int start = 0;
-            var first = GetOneKey(chord, ref start);
+            var keyChord = new List<ConsoleKeyInfo>(2);
 
-            if (start >= chord.Length)
-                return new [] { first };
+            int index = 0;
 
-            if (chord[start++] != ',')
-                throw CantConvert(PSReadLineResources.InvalidSequence, chord);
+            while (true)
+            {
+                keyChord.Add(GetOneKey(chord, ref index));
 
-            var second = GetOneKey(chord, ref start);
-            if (start < chord.Length)
-                throw CantConvert(PSReadLineResources.InvalidSequence, chord);
+                if (index >= chord.Length)
+                    break;
 
-            return new [] { first, second };
+                if (chord[index++] != ',')
+                    throw CantConvert(PSReadLineResources.InvalidSequence, chord);
+            }
+
+            return keyChord.ToArray();
         }
 
         private static ConsoleKeyInfo GetOneKey(string chord, ref int start)

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -1171,9 +1171,13 @@ namespace Microsoft.PowerShell
             var toMatch = new StringBuilder(64);
             while (true)
             {
+                Action<ConsoleKeyInfo?, object> function = null;
+
                 var key = ReadKey();
-                _dispatchTable.TryGetValue(key, out var handler);
-                var function = handler?.Action;
+                _dispatchTable.TryGetValue(key, out var handlerOrChordDispatchTable);
+                if (handlerOrChordDispatchTable.TryGetKeyHandler(out var handler))
+                    function = handler.Action;
+
                 if (function == ReverseSearchHistory)
                 {
                     UpdateHistoryDuringInteractiveSearch(toMatch.ToString(), -1, ref searchFromPoint);

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -1175,7 +1175,7 @@ namespace Microsoft.PowerShell
 
                 var key = ReadKey();
                 _dispatchTable.TryGetValue(key, out var handlerOrChordDispatchTable);
-                if (handlerOrChordDispatchTable.TryGetKeyHandler(out var handler))
+                if (handlerOrChordDispatchTable?.TryGetKeyHandler(out var handler) == true)
                     function = handler.Action;
 
                 if (function == ReverseSearchHistory)

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -103,6 +103,8 @@ namespace Microsoft.PowerShell
                 return PSReadLineResources.SelectionGrouping;
             case KeyHandlerGroup.Search:
                 return PSReadLineResources.SearchGrouping;
+            case KeyHandlerGroup.TextObjects:
+                return PSReadLineResources.TextObjectsGrouping;
             case KeyHandlerGroup.Custom:
                 return PSReadLineResources.CustomGrouping;
             default: return "";

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -3,7 +3,9 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
@@ -34,6 +36,8 @@ namespace Microsoft.PowerShell
         Selection,
         /// <summary>Search functions</summary>
         Search,
+        /// <summary>Text objects functions</summary>
+        TextObjects,
         /// <summary>User defined functions</summary>
         Custom
     }
@@ -152,8 +156,150 @@ namespace Microsoft.PowerShell
             };
         }
 
-        private Dictionary<PSKeyInfo, KeyHandler> _dispatchTable;
-        private Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>> _chordDispatchTable;
+        static ChordDispatchTable MakeChordDispatchTable(IEnumerable<KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable>> chordDispatchTable)
+            => new(chordDispatchTable);
+        static ChordDispatchTable MakeViChordDispatchTable(IEnumerable<KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable>> chordDispatchTable)
+            => new ViChordDispatchTable(chordDispatchTable);
+
+        private ChordDispatchTable _dispatchTable;
+
+        private class ChordDispatchTable : IDictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>
+        {
+            private readonly IDictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable> _dispatchTable;
+            private readonly bool _viMode;
+
+            public ChordDispatchTable(IEnumerable<KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable>> dispatchTable)
+                : this(dispatchTable, false)
+            { }
+
+            protected ChordDispatchTable(IEnumerable<KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable>> dispatchTable, bool viMode)
+            {
+                _dispatchTable = dispatchTable.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                _viMode = viMode;
+            }
+
+            public bool InViMode
+                => _viMode;
+
+            public KeyHandlerOrChordDispatchTable this[PSKeyInfo key]
+            {
+                get => _dispatchTable[key];
+                set => _dispatchTable[key] = value;
+            }
+
+            public ICollection<PSKeyInfo> Keys
+                => _dispatchTable.Keys;
+
+            public ICollection<KeyHandlerOrChordDispatchTable> Values
+                => _dispatchTable.Values;
+
+            public int Count
+                => _dispatchTable.Count;
+
+            public bool IsReadOnly
+                => _dispatchTable.IsReadOnly;
+
+            public void Add(PSKeyInfo key, KeyHandlerOrChordDispatchTable value)
+                => _dispatchTable.Add(key, value);
+
+            public void Add(KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable> item)
+                => _dispatchTable.Add(item);
+
+            public void Clear()
+                => _dispatchTable.Clear();
+
+            public bool Contains(KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable> item)
+                => _dispatchTable.Contains(item);
+
+            public bool ContainsKey(PSKeyInfo key)
+                => _dispatchTable.ContainsKey(key);
+
+            public void CopyTo(KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable>[] array, int arrayIndex)
+                => _dispatchTable.CopyTo(array, arrayIndex);
+
+            public IEnumerator<KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable>> GetEnumerator()
+                => _dispatchTable.GetEnumerator();
+
+            public bool Remove(PSKeyInfo key)
+                => _dispatchTable.Remove(key);
+
+            public bool Remove(KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable> item)
+                => _dispatchTable.Remove(item);
+
+            public bool TryGetValue(
+                PSKeyInfo key,
+#if NET6_0_OR_GREATER
+                [MaybeNullWhen(false)]
+#endif
+                out KeyHandlerOrChordDispatchTable value
+                )
+                => _dispatchTable.TryGetValue(key, out value);
+
+            IEnumerator IEnumerable.GetEnumerator()
+                => ((IEnumerable)_dispatchTable).GetEnumerator();
+        }
+
+        /// <summary>
+        /// Represents a <cee cref="ChordDispatchTable" /> that
+        /// handles vi-specific key bindings like handling digit
+        /// arguments after the first key.
+        /// </summary>
+        private sealed class ViChordDispatchTable : ChordDispatchTable
+        {
+            public ViChordDispatchTable(IEnumerable<KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable>> dispatchTable)
+                : base(dispatchTable, viMode: true)
+            {
+            }
+        }
+
+        private sealed class KeyHandlerOrChordDispatchTable
+        {
+            private readonly KeyHandler _keyHandler = null;
+            private readonly ChordDispatchTable _chordDispatchTable = null;
+
+            /// <summary>
+            /// Initialize a new instance of the <see cref="KeyHandlerOrChordDispatchTable"/> class
+            /// that acts as a key handler.
+            /// </summary>
+            /// <param name="keyHandler"></param>
+            public KeyHandlerOrChordDispatchTable(KeyHandler keyHandler)
+            {
+                _keyHandler = keyHandler;
+            }
+
+            /// <summary>
+            /// Initialize a new instance of the <see cref="KeyHandlerOrChordDispatchTable"/> class
+            /// that acts as a chord dispatch table.
+            /// </summary>
+            /// <param name="chordDispatchTable"></param>
+            public KeyHandlerOrChordDispatchTable(IEnumerable<KeyValuePair<PSKeyInfo, KeyHandlerOrChordDispatchTable>> chordDispatchTable)
+            {
+                _chordDispatchTable = new ChordDispatchTable(chordDispatchTable);
+            }
+            public KeyHandlerOrChordDispatchTable(ChordDispatchTable chordDispatchTable)
+            {
+                _chordDispatchTable = chordDispatchTable;
+            }
+
+            public static implicit operator KeyHandlerOrChordDispatchTable(KeyHandler handler)
+                => new KeyHandlerOrChordDispatchTable(handler);
+
+            public static implicit operator KeyHandlerOrChordDispatchTable(ChordDispatchTable chordDispatchTable)
+                => new KeyHandlerOrChordDispatchTable(chordDispatchTable);
+
+            public bool TryGetKeyHandler(out KeyHandler keyHandler)
+            {
+                keyHandler = _keyHandler;
+                return (_keyHandler != null);
+            }
+
+            public static explicit operator ChordDispatchTable(KeyHandlerOrChordDispatchTable handlerOrChordDispatchTable)
+            {
+                if (handlerOrChordDispatchTable._chordDispatchTable == null)
+                    throw new InvalidCastException();
+                return handlerOrChordDispatchTable._chordDispatchTable;
+            }
+        }
 
         /// <summary>
         /// Helper to set bindings based on EditMode
@@ -176,7 +322,7 @@ namespace Microsoft.PowerShell
 
         void SetDefaultWindowsBindings()
         {
-            _dispatchTable = new Dictionary<PSKeyInfo, KeyHandler>
+            _dispatchTable = MakeChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>
             {
                 { Keys.Enter,                  MakeKeyHandler(AcceptLine,                "AcceptLine") },
                 { Keys.ShiftEnter,             MakeKeyHandler(AddLine,                   "AddLine") },
@@ -242,7 +388,7 @@ namespace Microsoft.PowerShell
                 { Keys.AltD,                   MakeKeyHandler(KillWord,                  "KillWord") },
                 { Keys.CtrlAt,                 MakeKeyHandler(MenuComplete,              "MenuComplete") },
                 { Keys.CtrlW,                  MakeKeyHandler(BackwardKillWord,          "BackwardKillWord") },
-            };
+            });
 
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -260,13 +406,11 @@ namespace Microsoft.PowerShell
                 _dispatchTable.Add(Keys.CtrlPageUp,   MakeKeyHandler(ScrollDisplayUpLine,   "ScrollDisplayUpLine"));
                 _dispatchTable.Add(Keys.CtrlPageDown, MakeKeyHandler(ScrollDisplayDownLine, "ScrollDisplayDownLine"));
             }
-
-            _chordDispatchTable = new Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>>();
         }
 
         void SetDefaultEmacsBindings()
         {
-            _dispatchTable = new Dictionary<PSKeyInfo, KeyHandler>
+            _dispatchTable = MakeChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>
             {
                 { Keys.Backspace,              MakeKeyHandler(BackwardDeleteChar,        "BackwardDeleteChar") },
                 { Keys.Enter,                  MakeKeyHandler(AcceptLine,                "AcceptLine") },
@@ -283,7 +427,23 @@ namespace Microsoft.PowerShell
                 { Keys.End,                    MakeKeyHandler(EndOfLine,                 "EndOfLine") },
                 { Keys.ShiftHome,              MakeKeyHandler(SelectBackwardsLine,       "SelectBackwardsLine") },
                 { Keys.ShiftEnd,               MakeKeyHandler(SelectLine,                "SelectLine") },
-                { Keys.Escape,                 MakeKeyHandler(Chord,                     "ChordFirstKey") },
+                { Keys.Escape,                 MakeChordDispatchTable(new Dictionary<PSKeyInfo, PSConsoleReadLine.KeyHandlerOrChordDispatchTable>{
+
+                    // Escape,<key> table (meta key)
+                    { Keys.B,         MakeKeyHandler(BackwardWord,     "BackwardWord") },
+                    { Keys.D,         MakeKeyHandler(KillWord,         "KillWord")},
+                    { Keys.F,         MakeKeyHandler(ForwardWord,      "ForwardWord")},
+                    { Keys.R,         MakeKeyHandler(RevertLine,       "RevertLine")},
+                    { Keys.Y,         MakeKeyHandler(YankPop,          "YankPop")},
+                    { Keys.U,         MakeKeyHandler(UpcaseWord,       "UpcaseWord") },
+                    { Keys.L,         MakeKeyHandler(DowncaseWord,     "DowncaseWord") },
+                    { Keys.C,         MakeKeyHandler(CapitalizeWord,   "CapitalizeWord") },
+                    { Keys.CtrlY,     MakeKeyHandler(YankNthArg,       "YankNthArg")},
+                    { Keys.Backspace, MakeKeyHandler(BackwardKillWord, "BackwardKillWord")},
+                    { Keys.Period,    MakeKeyHandler(YankLastArg,      "YankLastArg")},
+                    { Keys.Underbar,  MakeKeyHandler(YankLastArg,      "YankLastArg")},
+                }) },
+
                 { Keys.Delete,                 MakeKeyHandler(DeleteChar,                "DeleteChar") },
                 { Keys.Tab,                    MakeKeyHandler(Complete,                  "Complete") },
                 { Keys.CtrlA,                  MakeKeyHandler(BeginningOfLine,           "BeginningOfLine") },
@@ -303,7 +463,15 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlS,                  MakeKeyHandler(ForwardSearchHistory,      "ForwardSearchHistory") },
                 { Keys.CtrlT,                  MakeKeyHandler(SwapCharacters,            "SwapCharacters") },
                 { Keys.CtrlU,                  MakeKeyHandler(BackwardKillInput,         "BackwardKillInput") },
-                { Keys.CtrlX,                  MakeKeyHandler(Chord,                     "ChordFirstKey") },
+                { Keys.CtrlX,                  MakeChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>{
+
+                    // Ctrl+X,<key> table (meta key)
+                    { Keys.Backspace, MakeKeyHandler(BackwardKillInput,    "BackwardKillInput") },
+                    { Keys.CtrlE,     MakeKeyHandler(ViEditVisually,       "ViEditVisually") },
+                    { Keys.CtrlU,     MakeKeyHandler(Undo,                 "Undo") },
+                    { Keys.CtrlX,     MakeKeyHandler(ExchangePointAndMark, "ExchangePointAndMark") },
+                }) },
+
                 { Keys.CtrlW,                  MakeKeyHandler(UnixWordRubout,            "UnixWordRubout") },
                 { Keys.CtrlY,                  MakeKeyHandler(Yank,                      "Yank") },
                 { Keys.CtrlAt,                 MakeKeyHandler(SetMark,                   "SetMark") },
@@ -344,7 +512,7 @@ namespace Microsoft.PowerShell
                 { Keys.AltU,                   MakeKeyHandler(UpcaseWord,                "UpcaseWord") },
                 { Keys.AltL,                   MakeKeyHandler(DowncaseWord,              "DowncaseWord") },
                 { Keys.AltC,                   MakeKeyHandler(CapitalizeWord,            "CapitalizeWord") },
-            };
+            });
 
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -365,35 +533,6 @@ namespace Microsoft.PowerShell
             {
                 _dispatchTable.Add(Keys.AltSpace,     MakeKeyHandler(SetMark,               "SetMark"));
             }
-
-            _chordDispatchTable = new Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>>
-            {
-                // Escape,<key> table (meta key)
-                [Keys.Escape] = new Dictionary<PSKeyInfo, KeyHandler>
-                {
-                    { Keys.B,         MakeKeyHandler(BackwardWord,     "BackwardWord") },
-                    { Keys.D,         MakeKeyHandler(KillWord,         "KillWord")},
-                    { Keys.F,         MakeKeyHandler(ForwardWord,      "ForwardWord")},
-                    { Keys.R,         MakeKeyHandler(RevertLine,       "RevertLine")},
-                    { Keys.Y,         MakeKeyHandler(YankPop,          "YankPop")},
-                    { Keys.U,         MakeKeyHandler(UpcaseWord,       "UpcaseWord") },
-                    { Keys.L,         MakeKeyHandler(DowncaseWord,     "DowncaseWord") },
-                    { Keys.C,         MakeKeyHandler(CapitalizeWord,   "CapitalizeWord") },
-                    { Keys.CtrlY,     MakeKeyHandler(YankNthArg,       "YankNthArg")},
-                    { Keys.Backspace, MakeKeyHandler(BackwardKillWord, "BackwardKillWord")},
-                    { Keys.Period,    MakeKeyHandler(YankLastArg,      "YankLastArg")},
-                    { Keys.Underbar,  MakeKeyHandler(YankLastArg,      "YankLastArg")},
-                },
-
-                // Ctrl+X,<key> table
-                [Keys.CtrlX] = new Dictionary<PSKeyInfo, KeyHandler>
-                {
-                    { Keys.Backspace, MakeKeyHandler(BackwardKillInput,    "BackwardKillInput") },
-                    { Keys.CtrlE,     MakeKeyHandler(ViEditVisually,       "ViEditVisually") },
-                    { Keys.CtrlU,     MakeKeyHandler(Undo,                 "Undo") },
-                    { Keys.CtrlX,     MakeKeyHandler(ExchangePointAndMark, "ExchangePointAndMark") },
-                }
-            };
         }
 
         /// <summary>
@@ -429,7 +568,6 @@ namespace Microsoft.PowerShell
             case nameof(DeletePreviousLines):
             case nameof(DeleteRelativeLines):
             case nameof(DeleteToEnd):
-            case nameof(DeleteWord):
             case nameof(DowncaseWord):
             case nameof(ForwardDeleteInput):
             case nameof(ForwardDeleteLine):
@@ -588,7 +726,6 @@ namespace Microsoft.PowerShell
             case nameof(ViEditVisually):
             case nameof(ViExit):
             case nameof(ViInsertMode):
-            case nameof(ViDGChord):
             case nameof(WhatIsKey):
             case nameof(ShowCommandHelp):
             case nameof(ShowParameterHelp):
@@ -622,6 +759,10 @@ namespace Microsoft.PowerShell
             case nameof(SelectShellNextWord):
             case nameof(SelectCommandArgument):
                 return KeyHandlerGroup.Selection;
+
+            case nameof(ViDeleteInnerWord):
+            case nameof(DeleteWord):
+                return KeyHandlerGroup.TextObjects;
 
             default:
                 return KeyHandlerGroup.Custom;
@@ -682,43 +823,8 @@ namespace Microsoft.PowerShell
         {
             _singleton._statusLinePrompt = "what-is-key: ";
             _singleton.Render();
-            var toLookup = ReadKey();
-            var buffer = new StringBuilder();
-            _singleton._dispatchTable.TryGetValue(toLookup, out var keyHandler);
-            buffer.Append(toLookup.KeyStr);
-            if (keyHandler != null)
-            {
-                if (keyHandler.BriefDescription == "ChordFirstKey")
-                {
-                    if (_singleton._chordDispatchTable.TryGetValue(toLookup, out var secondKeyDispatchTable))
-                    {
-                        toLookup = ReadKey();
-                        secondKeyDispatchTable.TryGetValue(toLookup, out keyHandler);
-                        buffer.Append(",");
-                        buffer.Append(toLookup.KeyStr);
-                    }
-                }
-            }
-            buffer.Append(": ");
-            if (keyHandler != null)
-            {
-                buffer.Append(keyHandler.BriefDescription);
-                if (!string.IsNullOrWhiteSpace(keyHandler.LongDescription))
-                {
-                    buffer.Append(" - ");
-                    buffer.Append(keyHandler.LongDescription);
-                }
-            }
-            else if (toLookup.KeyChar != 0)
-            {
-                buffer.Append("SelfInsert");
-                buffer.Append(" - ");
-                buffer.Append(PSReadLineResources.SelfInsertDescription);
-            }
-            else
-            {
-                buffer.Append(PSReadLineResources.KeyIsUnbound);
-            }
+
+            var buffer = ReadKeyChord();
 
             _singleton.ClearStatusMessage(render: false);
 
@@ -730,6 +836,61 @@ namespace Microsoft.PowerShell
 
             console.WriteLine(buffer.ToString());
             InvokePrompt(key: null, arg: console.CursorTop);
+        }
+
+        private static StringBuilder ReadKeyChord()
+        {
+            var buffer = new StringBuilder();
+
+            var toLookup = ReadKey();
+
+            buffer.Append(toLookup.KeyStr);
+
+            if (_singleton._dispatchTable.TryGetValue(toLookup, out var handlerOrChordDispatchTable))
+            {
+                KeyHandler keyHandler = null;
+
+                while (handlerOrChordDispatchTable != null && !handlerOrChordDispatchTable.TryGetKeyHandler(out keyHandler))
+                {
+                    toLookup = ReadKey();
+
+                    buffer.Append(",");
+                    buffer.Append(toLookup.KeyStr);
+
+                    var secondKeyDispatchTable = (ChordDispatchTable)handlerOrChordDispatchTable;
+                    secondKeyDispatchTable.TryGetValue(toLookup, out handlerOrChordDispatchTable);
+                }
+
+                if (keyHandler != null)
+                {
+                    buffer.Append(": ");
+                    buffer.Append(keyHandler.BriefDescription);
+                    if (!string.IsNullOrWhiteSpace(keyHandler.LongDescription))
+                    {
+                        buffer.Append(" - ");
+                        buffer.Append(keyHandler.LongDescription);
+                    }
+                }
+                else
+                {
+                    buffer.Append(": ");
+                    buffer.Append(PSReadLineResources.KeyIsUnbound);
+                }
+            }
+            else if (toLookup.KeyChar != 0)
+            {
+                buffer.Append(": ");
+                buffer.Append("SelfInsert");
+                buffer.Append(" - ");
+                buffer.Append(PSReadLineResources.SelfInsertDescription);
+            }
+            else
+            {
+                buffer.Append(": ");
+                buffer.Append(PSReadLineResources.KeyIsUnbound);
+            }
+
+            return buffer;
         }
     }
 }

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -37,65 +37,55 @@ namespace Microsoft.PowerShell
 
         private int _normalCursorSize = 10;
 
-        private static Dictionary<PSKeyInfo, KeyHandler> _viInsKeyMap;
-        private static Dictionary<PSKeyInfo, KeyHandler> _viCmdKeyMap;
-        private static Dictionary<PSKeyInfo, KeyHandler> _viChordDTable;
-        private static Dictionary<PSKeyInfo, KeyHandler> _viChordGTable;
-        private static Dictionary<PSKeyInfo, KeyHandler> _viChordCTable;
-        private static Dictionary<PSKeyInfo, KeyHandler> _viChordYTable;
-        private static Dictionary<PSKeyInfo, KeyHandler> _viChordDGTable;
-
-        private static Dictionary<PSKeyInfo, KeyHandler> _viChordTextObjectsTable;
-
-        private static Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>> _viCmdChordTable;
-        private static Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>> _viInsChordTable;
+        private static ChordDispatchTable _viInsKeyMap;
+        private static ChordDispatchTable _viCmdKeyMap;
 
         /// <summary>
         /// Sets up the key bindings for vi operations.
         /// </summary>
         private void SetDefaultViBindings()
         {
-            _viInsKeyMap = new Dictionary<PSKeyInfo, KeyHandler>
+            _viInsKeyMap = MakeChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>
             {
-                { Keys.Enter,           MakeKeyHandler(AcceptLine,             "AcceptLine" ) },
-                { Keys.CtrlD,           MakeKeyHandler(ViAcceptLineOrExit,     "ViAcceptLineOrExit" ) },
-                { Keys.ShiftEnter,      MakeKeyHandler(AddLine,                "AddLine") },
-                { Keys.Escape,          MakeKeyHandler(ViCommandMode,          "ViCommandMode") },
-                { Keys.LeftArrow,       MakeKeyHandler(ViBackwardChar,         "ViBackwardChar") },
-                { Keys.RightArrow,      MakeKeyHandler(ViForwardChar,          "ViForwardChar") },
-                { Keys.CtrlLeftArrow,   MakeKeyHandler(BackwardWord,           "BackwardWord") },
-                { Keys.CtrlRightArrow,  MakeKeyHandler(NextWord,               "NextWord") },
-                { Keys.UpArrow,         MakeKeyHandler(PreviousHistory,        "PreviousHistory") },
-                { Keys.DownArrow,       MakeKeyHandler(NextHistory,            "NextHistory") },
-                { Keys.Home,            MakeKeyHandler(BeginningOfLine,        "BeginningOfLine") },
-                { Keys.End,             MakeKeyHandler(EndOfLine,              "EndOfLine") },
-                { Keys.Delete,          MakeKeyHandler(DeleteChar,             "DeleteChar") },
-                { Keys.Backspace,       MakeKeyHandler(BackwardDeleteChar,     "BackwardDeleteChar") },
-                { Keys.CtrlSpace,       MakeKeyHandler(PossibleCompletions,    "PossibleCompletions") },
-                { Keys.Tab,             MakeKeyHandler(ViTabCompleteNext,      "ViTabCompleteNext") },
-                { Keys.ShiftTab,        MakeKeyHandler(ViTabCompletePrevious,  "ViTabCompletePrevious") },
-                { Keys.CtrlU,           MakeKeyHandler(BackwardDeleteInput,    "BackwardDeleteInput") },
-                { Keys.CtrlV,           MakeKeyHandler(Paste,                  "Paste") },
-                { Keys.CtrlC,           MakeKeyHandler(CancelLine,             "CancelLine") },
-                { Keys.CtrlL,           MakeKeyHandler(ClearScreen,            "ClearScreen") },
-                { Keys.CtrlT,           MakeKeyHandler(SwapCharacters,         "SwapCharacters") },
-                { Keys.CtrlY,           MakeKeyHandler(Redo,                   "Redo") },
-                { Keys.CtrlZ,           MakeKeyHandler(Undo,                   "Undo") },
-                { Keys.CtrlBackspace,   MakeKeyHandler(BackwardKillWord,       "BackwardKillWord") },
-                { Keys.CtrlEnd,         MakeKeyHandler(ForwardDeleteInput,     "ForwardDeleteInput") },
-                { Keys.CtrlHome,        MakeKeyHandler(BackwardDeleteInput,    "BackwardDeleteInput") },
-                { Keys.CtrlRBracket,    MakeKeyHandler(GotoBrace,              "GotoBrace") },
-                { Keys.F3,              MakeKeyHandler(CharacterSearch,        "CharacterSearch") },
-                { Keys.ShiftF3,         MakeKeyHandler(CharacterSearchBackward,"CharacterSearchBackward") },
-                { Keys.CtrlAltQuestion, MakeKeyHandler(ShowKeyBindings,        "ShowKeyBindings") },
-                { Keys.CtrlR,           MakeKeyHandler(ReverseSearchHistory,   "ReverseSearchHistory") },
-                { Keys.CtrlS,           MakeKeyHandler(ForwardSearchHistory,   "ForwardSearchHistory") },
-                { Keys.CtrlG,           MakeKeyHandler(Abort,                  "Abort") },
-                { Keys.AltH,            MakeKeyHandler(ShowParameterHelp,      "ShowParameterHelp") },
-                { Keys.F1,              MakeKeyHandler(ShowCommandHelp,        "ShowCommandHelp") },
-                { Keys.F2,              MakeKeyHandler(SwitchPredictionView,   "SwitchPredictionView") },
-                { Keys.F4,              MakeKeyHandler(ShowFullPredictionTooltip, "ShowFullPredictionTooltip") },
-            };
+                { Keys.Enter,           MakeKeyHandler(AcceptLine,                  "AcceptLine" ) },
+                { Keys.CtrlD,           MakeKeyHandler(ViAcceptLineOrExit,          "ViAcceptLineOrExit" ) },
+                { Keys.ShiftEnter,      MakeKeyHandler(AddLine,                     "AddLine") },
+                { Keys.Escape,          MakeKeyHandler(ViCommandMode,               "ViCommandMode") },
+                { Keys.LeftArrow,       MakeKeyHandler(ViBackwardChar,              "ViBackwardChar") },
+                { Keys.RightArrow,      MakeKeyHandler(ViForwardChar,               "ViForwardChar") },
+                { Keys.CtrlLeftArrow,   MakeKeyHandler(BackwardWord,                "BackwardWord") },
+                { Keys.CtrlRightArrow,  MakeKeyHandler(NextWord,                    "NextWord") },
+                { Keys.UpArrow,         MakeKeyHandler(PreviousHistory,             "PreviousHistory") },
+                { Keys.DownArrow,       MakeKeyHandler(NextHistory,                 "NextHistory") },
+                { Keys.Home,            MakeKeyHandler(BeginningOfLine,             "BeginningOfLine") },
+                { Keys.End,             MakeKeyHandler(EndOfLine,                   "EndOfLine") },
+                { Keys.Delete,          MakeKeyHandler(DeleteChar,                  "DeleteChar") },
+                { Keys.Backspace,       MakeKeyHandler(BackwardDeleteChar,          "BackwardDeleteChar") },
+                { Keys.CtrlSpace,       MakeKeyHandler(PossibleCompletions,         "PossibleCompletions") },
+                { Keys.Tab,             MakeKeyHandler(ViTabCompleteNext,           "ViTabCompleteNext") },
+                { Keys.ShiftTab,        MakeKeyHandler(ViTabCompletePrevious,       "ViTabCompletePrevious") },
+                { Keys.CtrlU,           MakeKeyHandler(BackwardDeleteInput,         "BackwardDeleteInput") },
+                { Keys.CtrlV,           MakeKeyHandler(Paste,                       "Paste") },
+                { Keys.CtrlC,           MakeKeyHandler(CancelLine,                  "CancelLine") },
+                { Keys.CtrlL,           MakeKeyHandler(ClearScreen,                 "ClearScreen") },
+                { Keys.CtrlT,           MakeKeyHandler(SwapCharacters,              "SwapCharacters") },
+                { Keys.CtrlY,           MakeKeyHandler(Redo,                        "Redo") },
+                { Keys.CtrlZ,           MakeKeyHandler(Undo,                        "Undo") },
+                { Keys.CtrlBackspace,   MakeKeyHandler(BackwardKillWord,            "BackwardKillWord") },
+                { Keys.CtrlEnd,         MakeKeyHandler(ForwardDeleteInput,          "ForwardDeleteInput") },
+                { Keys.CtrlHome,        MakeKeyHandler(BackwardDeleteInput,         "BackwardDeleteInput") },
+                { Keys.CtrlRBracket,    MakeKeyHandler(GotoBrace,                   "GotoBrace") },
+                { Keys.F3,              MakeKeyHandler(CharacterSearch,             "CharacterSearch") },
+                { Keys.ShiftF3,         MakeKeyHandler(CharacterSearchBackward,     "CharacterSearchBackward") },
+                { Keys.CtrlAltQuestion, MakeKeyHandler(ShowKeyBindings,             "ShowKeyBindings") },
+                { Keys.CtrlR,           MakeKeyHandler(ReverseSearchHistory,        "ReverseSearchHistory") },
+                { Keys.CtrlS,           MakeKeyHandler(ForwardSearchHistory,        "ForwardSearchHistory") },
+                { Keys.CtrlG,           MakeKeyHandler(Abort,                       "Abort") },
+                { Keys.AltH,            MakeKeyHandler(ShowParameterHelp,           "ShowParameterHelp") },
+                { Keys.F1,              MakeKeyHandler(ShowCommandHelp,             "ShowCommandHelp") },
+                { Keys.F2,              MakeKeyHandler(SwitchPredictionView,        "SwitchPredictionView") },
+                { Keys.F4,              MakeKeyHandler(ShowFullPredictionTooltip,   "ShowFullPredictionTooltip") },
+            });
 
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -103,122 +93,200 @@ namespace Microsoft.PowerShell
                 _viInsKeyMap.Add(Keys.CtrlDelete, MakeKeyHandler(KillWord, "KillWord"));
             }
 
-            _viCmdKeyMap = new Dictionary<PSKeyInfo, KeyHandler>
+            _viCmdKeyMap = MakeChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>
             {
-                { Keys.Enter,           MakeKeyHandler(ViAcceptLine,         "ViAcceptLine") },
-                { Keys.CtrlD,           MakeKeyHandler(ViAcceptLineOrExit,   "ViAcceptLineOrExit") },
-                { Keys.ShiftEnter,      MakeKeyHandler(AddLine,              "AddLine") },
-                { Keys.Escape,          MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.LeftArrow,       MakeKeyHandler(ViBackwardChar,       "ViBackwardChar") },
-                { Keys.RightArrow,      MakeKeyHandler(ViForwardChar,        "ViForwardChar") },
-                { Keys.Space,           MakeKeyHandler(ViForwardChar,        "ViForwardChar") },
-                { Keys.CtrlLeftArrow,   MakeKeyHandler(BackwardWord,         "BackwardWord") },
-                { Keys.CtrlRightArrow,  MakeKeyHandler(NextWord,             "NextWord") },
-                { Keys.UpArrow,         MakeKeyHandler(PreviousHistory,      "PreviousHistory") },
-                { Keys.DownArrow,       MakeKeyHandler(NextHistory,          "NextHistory") },
-                { Keys.Home,            MakeKeyHandler(BeginningOfLine,      "BeginningOfLine") },
-                { Keys.End,             MakeKeyHandler(MoveToEndOfLine,      "MoveToEndOfLine") },
-                { Keys.Delete,          MakeKeyHandler(DeleteChar,           "DeleteChar") },
-                { Keys.Backspace,       MakeKeyHandler(ViBackwardChar,       "ViBackwardChar") },
-                { Keys.CtrlSpace,       MakeKeyHandler(PossibleCompletions,  "PossibleCompletions") },
-                { Keys.Tab,             MakeKeyHandler(TabCompleteNext,      "TabCompleteNext") },
-                { Keys.ShiftTab,        MakeKeyHandler(TabCompletePrevious,  "TabCompletePrevious") },
-                { Keys.CtrlV,           MakeKeyHandler(Paste,                "Paste") },
-                { Keys.CtrlC,           MakeKeyHandler(CancelLine,           "CancelLine") },
-                { Keys.CtrlL,           MakeKeyHandler(ClearScreen,          "ClearScreen") },
-                { Keys.CtrlT,           MakeKeyHandler(SwapCharacters,       "SwapCharacters") },
-                { Keys.CtrlU,           MakeKeyHandler(BackwardDeleteInput,  "BackwardDeleteInput") },
-                { Keys.CtrlW,           MakeKeyHandler(BackwardDeleteWord,   "BackwardDeleteWord") },
-                { Keys.CtrlY,           MakeKeyHandler(Redo,                 "Redo") },
-                { Keys.CtrlZ,           MakeKeyHandler(Undo,                 "Undo") },
-                { Keys.CtrlBackspace,   MakeKeyHandler(BackwardKillWord,     "BackwardKillWord") },
-                { Keys.CtrlEnd,         MakeKeyHandler(ForwardDeleteInput,   "ForwardDeleteInput") },
-                { Keys.CtrlHome,        MakeKeyHandler(BackwardDeleteInput,  "BackwardDeleteInput") },
-                { Keys.CtrlRBracket,    MakeKeyHandler(GotoBrace,            "GotoBrace") },
-                { Keys.F3,              MakeKeyHandler(CharacterSearch,      "CharacterSearch") },
-                { Keys.ShiftF3,         MakeKeyHandler(CharacterSearchBackward, "CharacterSearchBackward") },
-                { Keys.A,               MakeKeyHandler(ViInsertWithAppend,   "ViInsertWithAppend") },
-                { Keys.B,               MakeKeyHandler(ViBackwardWord,       "ViBackwardWord") },
-                { Keys.C,               MakeKeyHandler(ViChord,              "ChordFirstKey") },
-                { Keys.D,               MakeKeyHandler(ViChord,              "ChordFirstKey") },
-                { Keys.E,               MakeKeyHandler(NextWordEnd,          "NextWordEnd") },
-                { Keys.F,               MakeKeyHandler(SearchChar,           "SearchChar") },
-                { Keys.G,               MakeKeyHandler(ViChord,              "ChordFirstKey") },
-                { Keys.H,               MakeKeyHandler(ViBackwardChar,       "ViBackwardChar") },
-                { Keys.I,               MakeKeyHandler(ViInsertMode,         "ViInsertMode") },
-                { Keys.J,               MakeKeyHandler(NextHistory,          "NextHistory") },
-                { Keys.K,               MakeKeyHandler(PreviousHistory,      "PreviousHistory") },
-                { Keys.L,               MakeKeyHandler(ViForwardChar,        "ViForwardChar") },
-                { Keys.M,               MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.N,               MakeKeyHandler(RepeatSearch,         "RepeatSearch") },
-                { Keys.O,               MakeKeyHandler(ViAppendLine,         "ViAppendLine") },
-                { Keys.P,               MakeKeyHandler(PasteAfter,           "PasteAfter") },
-                { Keys.Q,               MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.R,               MakeKeyHandler(ReplaceCharInPlace,   "ReplaceCharInPlace") },
-                { Keys.S,               MakeKeyHandler(ViInsertWithDelete,   "ViInsertWithDelete") },
-                { Keys.T,               MakeKeyHandler(SearchCharWithBackoff,"SearchCharWithBackoff") },
-                { Keys.U,               MakeKeyHandler(Undo,                 "Undo") },
-                { Keys.V,               MakeKeyHandler(ViEditVisually,       "ViEditVisually") },
-                { Keys.W,               MakeKeyHandler(ViNextWord,           "ViNextWord") },
-                { Keys.X,               MakeKeyHandler(DeleteChar,           "DeleteChar") },
-                { Keys.Y,               MakeKeyHandler(ViChord,              "ChordFirstKey") },
-                { Keys.Z,               MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.ucA,             MakeKeyHandler(ViInsertAtEnd,        "ViInsertAtEnd") },
-                { Keys.ucB,             MakeKeyHandler(ViBackwardGlob,       "ViBackwardGlob") },
-                { Keys.ucC,             MakeKeyHandler(ViReplaceToEnd,       "ViReplaceToEnd") },
-                { Keys.ucD,             MakeKeyHandler(DeleteToEnd,          "DeleteToEnd") },
-                { Keys.ucE,             MakeKeyHandler(ViEndOfGlob,          "ViEndOfGlob") },
-                { Keys.ucF,             MakeKeyHandler(SearchCharBackward,   "SearchCharBackward") },
-                { Keys.ucG,             MakeKeyHandler(MoveToLastLine,       "MoveToLastLine") },
-                { Keys.ucH,             MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.ucI,             MakeKeyHandler(ViInsertAtBegining,   "ViInsertAtBegining") },
-                { Keys.ucJ,             MakeKeyHandler(ViJoinLines,          "ViJoinLines") },
-                { Keys.ucK,             MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.ucL,             MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.ucM,             MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.ucN,             MakeKeyHandler(RepeatSearchBackward, "RepeatSearchBackward") },
-                { Keys.ucO,             MakeKeyHandler(ViInsertLine,         "ViInsertLine") },
-                { Keys.ucP,             MakeKeyHandler(PasteBefore,          "PasteBefore") },
-                { Keys.ucQ,             MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.ucR,             MakeKeyHandler(ViReplaceUntilEsc,    "ViReplaceUntilEsc") },
-                { Keys.ucS,             MakeKeyHandler(ViReplaceLine,        "ViReplaceLine") },
-                { Keys.ucT,             MakeKeyHandler(SearchCharBackwardWithBackoff, "SearchCharBackwardWithBackoff") },
-                { Keys.ucU,             MakeKeyHandler(UndoAll,              "UndoAll") },
-                { Keys.ucV,             MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.ucW,             MakeKeyHandler(ViNextGlob,           "ViNextGlob") },
-                { Keys.ucX,             MakeKeyHandler(BackwardDeleteChar,   "BackwardDeleteChar") },
-                { Keys.ucY,             MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys.ucZ,             MakeKeyHandler(Ding,                 "Ignore") },
-                { Keys._0,              MakeKeyHandler(DigitArgument,        "DigitArgument") },
-                { Keys._1,              MakeKeyHandler(DigitArgument,        "DigitArgument") },
-                { Keys._2,              MakeKeyHandler(DigitArgument,        "DigitArgument") },
-                { Keys._3,              MakeKeyHandler(DigitArgument,        "DigitArgument") },
-                { Keys._4,              MakeKeyHandler(DigitArgument,        "DigitArgument") },
-                { Keys._5,              MakeKeyHandler(DigitArgument,        "DigitArgument") },
-                { Keys._6,              MakeKeyHandler(DigitArgument,        "DigitArgument") },
-                { Keys._7,              MakeKeyHandler(DigitArgument,        "DigitArgument") },
-                { Keys._8,              MakeKeyHandler(DigitArgument,        "DigitArgument") },
-                { Keys._9,              MakeKeyHandler(DigitArgument,        "DigitArgument") },
-                { Keys.Dollar,          MakeKeyHandler(MoveToEndOfLine,      "MoveToEndOfLine") },
-                { Keys.Percent,         MakeKeyHandler(ViGotoBrace,          "ViGotoBrace") },
-                { Keys.Pound,           MakeKeyHandler(PrependAndAccept,     "PrependAndAccept") },
-                { Keys.Pipe,            MakeKeyHandler(GotoColumn,           "GotoColumn") },
-                { Keys.Uphat,           MakeKeyHandler(GotoFirstNonBlankOfLine, "GotoFirstNonBlankOfLine") },
-                { Keys.Underbar,        MakeKeyHandler(GotoFirstNonBlankOfLine, "GotoFirstNonBlankOfLine") },
-                { Keys.Tilde,           MakeKeyHandler(InvertCase,           "InvertCase") },
-                { Keys.Slash,           MakeKeyHandler(ViSearchHistoryBackward, "ViSearchHistoryBackward") },
-                { Keys.Question,        MakeKeyHandler(SearchForward,        "SearchForward") },
-                { Keys.CtrlR,           MakeKeyHandler(ReverseSearchHistory, "ReverseSearchHistory") },
-                { Keys.CtrlS,           MakeKeyHandler(ForwardSearchHistory, "ForwardSearchHistory") },
-                { Keys.CtrlG,           MakeKeyHandler(Abort,                "Abort") },
-                { Keys.Plus,            MakeKeyHandler(NextHistory,          "NextHistory") },
-                { Keys.Minus,           MakeKeyHandler(PreviousHistory,      "PreviousHistory") },
-                { Keys.Period,          MakeKeyHandler(RepeatLastCommand,    "RepeatLastCommand") },
-                { Keys.Semicolon,       MakeKeyHandler(RepeatLastCharSearch, "RepeatLastCharSearch") },
-                { Keys.Comma,           MakeKeyHandler(RepeatLastCharSearchBackwards, "RepeatLastCharSearchBackwards") },
-                { Keys.AltH,            MakeKeyHandler(ShowParameterHelp,     "ShowParameterHelp") },
-                { Keys.F1,              MakeKeyHandler(ShowCommandHelp,       "ShowCommandHelp") },
-            };
+
+                { Keys.Enter,           MakeKeyHandler(ViAcceptLine,                        "ViAcceptLine") },
+                { Keys.CtrlD,           MakeKeyHandler(ViAcceptLineOrExit,                  "ViAcceptLineOrExit") },
+                { Keys.ShiftEnter,      MakeKeyHandler(AddLine,                             "AddLine") },
+                { Keys.Escape,          MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.LeftArrow,       MakeKeyHandler(ViBackwardChar,                      "ViBackwardChar") },
+                { Keys.RightArrow,      MakeKeyHandler(ViForwardChar,                       "ViForwardChar") },
+                { Keys.Space,           MakeKeyHandler(ViForwardChar,                       "ViForwardChar") },
+                { Keys.CtrlLeftArrow,   MakeKeyHandler(BackwardWord,                        "BackwardWord") },
+                { Keys.CtrlRightArrow,  MakeKeyHandler(NextWord,                            "NextWord") },
+                { Keys.UpArrow,         MakeKeyHandler(PreviousHistory,                     "PreviousHistory") },
+                { Keys.DownArrow,       MakeKeyHandler(NextHistory,                         "NextHistory") },
+                { Keys.Home,            MakeKeyHandler(BeginningOfLine,                     "BeginningOfLine") },
+                { Keys.End,             MakeKeyHandler(MoveToEndOfLine,                     "MoveToEndOfLine") },
+                { Keys.Delete,          MakeKeyHandler(DeleteChar,                          "DeleteChar") },
+                { Keys.Backspace,       MakeKeyHandler(ViBackwardChar,                      "ViBackwardChar") },
+                { Keys.CtrlSpace,       MakeKeyHandler(PossibleCompletions,                 "PossibleCompletions") },
+                { Keys.Tab,             MakeKeyHandler(TabCompleteNext,                     "TabCompleteNext") },
+                { Keys.ShiftTab,        MakeKeyHandler(TabCompletePrevious,                 "TabCompletePrevious") },
+                { Keys.CtrlV,           MakeKeyHandler(Paste,                               "Paste") },
+                { Keys.CtrlC,           MakeKeyHandler(CancelLine,                          "CancelLine") },
+                { Keys.CtrlL,           MakeKeyHandler(ClearScreen,                         "ClearScreen") },
+                { Keys.CtrlT,           MakeKeyHandler(SwapCharacters,                      "SwapCharacters") },
+                { Keys.CtrlU,           MakeKeyHandler(BackwardDeleteInput,                 "BackwardDeleteInput") },
+                { Keys.CtrlW,           MakeKeyHandler(BackwardDeleteWord,                  "BackwardDeleteWord") },
+                { Keys.CtrlY,           MakeKeyHandler(Redo,                                "Redo") },
+                { Keys.CtrlZ,           MakeKeyHandler(Undo,                                "Undo") },
+                { Keys.CtrlBackspace,   MakeKeyHandler(BackwardKillWord,                    "BackwardKillWord") },
+                { Keys.CtrlEnd,         MakeKeyHandler(ForwardDeleteInput,                  "ForwardDeleteInput") },
+                { Keys.CtrlHome,        MakeKeyHandler(BackwardDeleteInput,                 "BackwardDeleteInput") },
+                { Keys.CtrlRBracket,    MakeKeyHandler(GotoBrace,                           "GotoBrace") },
+                { Keys.F3,              MakeKeyHandler(CharacterSearch,                     "CharacterSearch") },
+                { Keys.ShiftF3,         MakeKeyHandler(CharacterSearchBackward,             "CharacterSearchBackward") },
+                { Keys.A,               MakeKeyHandler(ViInsertWithAppend,                  "ViInsertWithAppend") },
+                { Keys.B,               MakeKeyHandler(ViBackwardWord,                      "ViBackwardWord") },
+                { Keys.C,               MakeViChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>{
+
+                    { Keys.C,           MakeKeyHandler( ViReplaceLine,                      "ViReplaceLine") },
+                    { Keys.Dollar,      MakeKeyHandler( ViReplaceToEnd,                     "ViReplaceToEnd") },
+                    { Keys.B,           MakeKeyHandler( ViBackwardReplaceWord,              "ViBackwardReplaceWord") },
+                    { Keys.ucB,         MakeKeyHandler( ViBackwardReplaceGlob,              "ViBackwardReplaceGlob") },
+                    { Keys.W,           MakeKeyHandler( ViReplaceWord,                      "ViReplaceWord") },
+                    { Keys.ucW,         MakeKeyHandler( ViReplaceGlob,                      "ViReplaceGlob") },
+                    { Keys.E,           MakeKeyHandler( ViReplaceEndOfWord,                 "ViReplaceEndOfWord") },
+                    { Keys.ucE,         MakeKeyHandler( ViReplaceEndOfGlob,                 "ViReplaceEndOfGlob") },
+                    { Keys.H,           MakeKeyHandler( BackwardReplaceChar,                "BackwardReplaceChar") },
+                    { Keys.L,           MakeKeyHandler( ReplaceChar,                        "ReplaceChar") },
+                    { Keys.Space,       MakeKeyHandler( ReplaceChar,                        "ReplaceChar") },
+                    { Keys._0,          MakeKeyHandler( ViBackwardReplaceLine,              "ViBackwardReplaceLine") },
+                    { Keys.Uphat,       MakeKeyHandler( ViBackwardReplaceLineToFirstChar,   "ViBackwardReplaceLineToFirstChar") },
+                    { Keys.Percent,     MakeKeyHandler( ViReplaceBrace,                     "ViReplaceBrace") },
+                    { Keys.F,           MakeKeyHandler( ViReplaceToChar,                    "ViReplaceToChar") },
+                    { Keys.ucF,         MakeKeyHandler( ViReplaceToCharBackward,            "ViReplaceToCharBackward") },
+                    { Keys.T,           MakeKeyHandler( ViReplaceToBeforeChar,              "ViReplaceToBeforeChar") },
+                    { Keys.ucT,         MakeKeyHandler( ViReplaceToBeforeCharBackward,      "ViReplaceToBeforeCharBackward") },
+                }) },
+
+                { Keys.D,               MakeViChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>{
+
+                    { Keys.D,           MakeKeyHandler( DeleteLine,                         "DeleteLine") },
+                    { Keys.Underbar,    MakeKeyHandler( DeleteLine,                         "DeleteLine") },
+                    { Keys.Dollar,      MakeKeyHandler( DeleteToEnd,                        "DeleteToEnd") },
+                    { Keys.B,           MakeKeyHandler( BackwardDeleteWord,                 "BackwardDeleteWord") },
+                    { Keys.ucB,         MakeKeyHandler( ViBackwardDeleteGlob,               "ViBackwardDeleteGlob") },
+                    { Keys.W,           MakeKeyHandler( DeleteWord,                         "DeleteWord") },
+                    { Keys.ucW,         MakeKeyHandler( ViDeleteGlob,                       "ViDeleteGlob") },
+                    { Keys.E,           MakeKeyHandler( DeleteEndOfWord,                    "DeleteEndOfWord") },
+                    { Keys.G,           MakeChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>{
+
+                        { Keys.G,       MakeKeyHandler( DeleteRelativeLines,                "DeleteRelativeLines") },
+                    }) },
+
+                    { Keys.ucG,         MakeKeyHandler( DeleteEndOfBuffer,                  "DeleteEndOfBuffer") },
+                    { Keys.ucE,         MakeKeyHandler( ViDeleteEndOfGlob,                  "ViDeleteEndOfGlob") },
+                    { Keys.H,           MakeKeyHandler( BackwardDeleteChar,                 "BackwardDeleteChar") },
+                    { Keys.I,           MakeChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>{
+
+                        { Keys.W,       MakeKeyHandler(ViDeleteInnerWord,                   "ViDeleteInnerWord")},
+                    }) },
+
+                    { Keys.J,           MakeKeyHandler( DeleteNextLines,                    "DeleteNextLines") },
+                    { Keys.K,           MakeKeyHandler( DeletePreviousLines,                "DeletePreviousLines") },
+                    { Keys.L,           MakeKeyHandler( DeleteChar,                         "DeleteChar") },
+                    { Keys.Space,       MakeKeyHandler( DeleteChar,                         "DeleteChar") },
+                    { Keys._0,          MakeKeyHandler( BackwardDeleteLine,                 "BackwardDeleteLine") },
+                    { Keys.Uphat,       MakeKeyHandler( DeleteLineToFirstChar,              "DeleteLineToFirstChar") },
+                    { Keys.Percent,     MakeKeyHandler( ViDeleteBrace,                      "ViDeleteBrace") },
+                    { Keys.F,           MakeKeyHandler( ViDeleteToChar,                     "ViDeleteToChar") },
+                    { Keys.ucF,         MakeKeyHandler( ViDeleteToCharBackward,             "ViDeleteToCharBackward") },
+                    { Keys.T,           MakeKeyHandler( ViDeleteToBeforeChar,               "ViDeleteToBeforeChar") },
+                    { Keys.ucT,         MakeKeyHandler( ViDeleteToBeforeCharBackward,       "ViDeleteToBeforeCharBackward") }
+                })},
+
+                { Keys.E,               MakeKeyHandler(NextWordEnd,                         "NextWordEnd") },
+                { Keys.F,               MakeKeyHandler(SearchChar,                          "SearchChar") },
+                { Keys.G,               MakeChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>{
+
+                    { Keys.G,           MakeKeyHandler( MoveToFirstLine,                    "MoveToFirstLine") },
+                }) },
+
+                { Keys.H,               MakeKeyHandler(ViBackwardChar,                      "ViBackwardChar") },
+                { Keys.I,               MakeKeyHandler(ViInsertMode,                        "ViInsertMode") },
+                { Keys.J,               MakeKeyHandler(NextHistory,                         "NextHistory") },
+                { Keys.K,               MakeKeyHandler(PreviousHistory,                     "PreviousHistory") },
+                { Keys.L,               MakeKeyHandler(ViForwardChar,                       "ViForwardChar") },
+                { Keys.M,               MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.N,               MakeKeyHandler(RepeatSearch,                        "RepeatSearch") },
+                { Keys.O,               MakeKeyHandler(ViAppendLine,                        "ViAppendLine") },
+                { Keys.P,               MakeKeyHandler(PasteAfter,                          "PasteAfter") },
+                { Keys.Q,               MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.R,               MakeKeyHandler(ReplaceCharInPlace,                  "ReplaceCharInPlace") },
+                { Keys.S,               MakeKeyHandler(ViInsertWithDelete,                  "ViInsertWithDelete") },
+                { Keys.T,               MakeKeyHandler(SearchCharWithBackoff,               "SearchCharWithBackoff") },
+                { Keys.U,               MakeKeyHandler(Undo,                                "Undo") },
+                { Keys.V,               MakeKeyHandler(ViEditVisually,                      "ViEditVisually") },
+                { Keys.W,               MakeKeyHandler(ViNextWord,                          "ViNextWord") },
+                { Keys.X,               MakeKeyHandler(DeleteChar,                          "DeleteChar") },
+                { Keys.Y,               MakeViChordDispatchTable(new Dictionary<PSKeyInfo, KeyHandlerOrChordDispatchTable>{
+
+                    { Keys.Y,           MakeKeyHandler( ViYankLine,                         "ViYankLine") },
+                    { Keys.Dollar,      MakeKeyHandler( ViYankToEndOfLine,                  "ViYankToEndOfLine") },
+                    { Keys.B,           MakeKeyHandler( ViYankPreviousWord,                 "ViYankPreviousWord") },
+                    { Keys.ucB,         MakeKeyHandler( ViYankPreviousGlob,                 "ViYankPreviousGlob") },
+                    { Keys.W,           MakeKeyHandler( ViYankNextWord,                     "ViYankNextWord") },
+                    { Keys.ucW,         MakeKeyHandler( ViYankNextGlob,                     "ViYankNextGlob") },
+                    { Keys.E,           MakeKeyHandler( ViYankEndOfWord,                    "ViYankEndOfWord") },
+                    { Keys.ucE,         MakeKeyHandler( ViYankEndOfGlob,                    "ViYankEndOfGlob") },
+                    { Keys.H,           MakeKeyHandler( ViYankLeft,                         "ViYankLeft") },
+                    { Keys.L,           MakeKeyHandler( ViYankRight,                        "ViYankRight") },
+                    { Keys.Space,       MakeKeyHandler( ViYankRight,                        "ViYankRight") },
+                    { Keys._0,          MakeKeyHandler( ViYankBeginningOfLine,              "ViYankBeginningOfLine") },
+                    { Keys.Uphat,       MakeKeyHandler( ViYankToFirstChar,                  "ViYankToFirstChar") },
+                    { Keys.Percent,     MakeKeyHandler( ViYankPercent,                      "ViYankPercent") },
+                }) },
+
+                { Keys.Z,               MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.ucA,             MakeKeyHandler(ViInsertAtEnd,                       "ViInsertAtEnd") },
+                { Keys.ucB,             MakeKeyHandler(ViBackwardGlob,                      "ViBackwardGlob") },
+                { Keys.ucC,             MakeKeyHandler(ViReplaceToEnd,                      "ViReplaceToEnd") },
+                { Keys.ucD,             MakeKeyHandler(DeleteToEnd,                         "DeleteToEnd") },
+                { Keys.ucE,             MakeKeyHandler(ViEndOfGlob,                         "ViEndOfGlob") },
+                { Keys.ucF,             MakeKeyHandler(SearchCharBackward,                  "SearchCharBackward") },
+                { Keys.ucG,             MakeKeyHandler(MoveToLastLine,                      "MoveToLastLine") },
+                { Keys.ucH,             MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.ucI,             MakeKeyHandler(ViInsertAtBegining,                  "ViInsertAtBegining") },
+                { Keys.ucJ,             MakeKeyHandler(ViJoinLines,                         "ViJoinLines") },
+                { Keys.ucK,             MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.ucL,             MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.ucM,             MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.ucN,             MakeKeyHandler(RepeatSearchBackward,                "RepeatSearchBackward") },
+                { Keys.ucO,             MakeKeyHandler(ViInsertLine,                        "ViInsertLine") },
+                { Keys.ucP,             MakeKeyHandler(PasteBefore,                         "PasteBefore") },
+                { Keys.ucQ,             MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.ucR,             MakeKeyHandler(ViReplaceUntilEsc,                   "ViReplaceUntilEsc") },
+                { Keys.ucS,             MakeKeyHandler(ViReplaceLine,                       "ViReplaceLine") },
+                { Keys.ucT,             MakeKeyHandler(SearchCharBackwardWithBackoff,       "SearchCharBackwardWithBackoff") },
+                { Keys.ucU,             MakeKeyHandler(UndoAll,                             "UndoAll") },
+                { Keys.ucV,             MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.ucW,             MakeKeyHandler(ViNextGlob,                          "ViNextGlob") },
+                { Keys.ucX,             MakeKeyHandler(BackwardDeleteChar,                  "BackwardDeleteChar") },
+                { Keys.ucY,             MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys.ucZ,             MakeKeyHandler(Ding,                                "Ignore") },
+                { Keys._0,              MakeKeyHandler(DigitArgument,                       "DigitArgument") },
+                { Keys._1,              MakeKeyHandler(DigitArgument,                       "DigitArgument") },
+                { Keys._2,              MakeKeyHandler(DigitArgument,                       "DigitArgument") },
+                { Keys._3,              MakeKeyHandler(DigitArgument,                       "DigitArgument") },
+                { Keys._4,              MakeKeyHandler(DigitArgument,                       "DigitArgument") },
+                { Keys._5,              MakeKeyHandler(DigitArgument,                       "DigitArgument") },
+                { Keys._6,              MakeKeyHandler(DigitArgument,                       "DigitArgument") },
+                { Keys._7,              MakeKeyHandler(DigitArgument,                       "DigitArgument") },
+                { Keys._8,              MakeKeyHandler(DigitArgument,                       "DigitArgument") },
+                { Keys._9,              MakeKeyHandler(DigitArgument,                       "DigitArgument") },
+                { Keys.Dollar,          MakeKeyHandler(MoveToEndOfLine,                     "MoveToEndOfLine") },
+                { Keys.Percent,         MakeKeyHandler(ViGotoBrace,                         "ViGotoBrace") },
+                { Keys.Pound,           MakeKeyHandler(PrependAndAccept,                    "PrependAndAccept") },
+                { Keys.Pipe,            MakeKeyHandler(GotoColumn,                          "GotoColumn") },
+                { Keys.Uphat,           MakeKeyHandler(GotoFirstNonBlankOfLine,             "GotoFirstNonBlankOfLine") },
+                { Keys.Underbar,        MakeKeyHandler(GotoFirstNonBlankOfLine,             "GotoFirstNonBlankOfLine") },
+                { Keys.Tilde,           MakeKeyHandler(InvertCase,                          "InvertCase") },
+                { Keys.Slash,           MakeKeyHandler(ViSearchHistoryBackward,             "ViSearchHistoryBackward") },
+                { Keys.Question,        MakeKeyHandler(SearchForward,                       "SearchForward") },
+                { Keys.CtrlR,           MakeKeyHandler(ReverseSearchHistory,                "ReverseSearchHistory") },
+                { Keys.CtrlS,           MakeKeyHandler(ForwardSearchHistory,                "ForwardSearchHistory") },
+                { Keys.CtrlG,           MakeKeyHandler(Abort,                               "Abort") },
+                { Keys.Plus,            MakeKeyHandler(NextHistory,                         "NextHistory") },
+                { Keys.Minus,           MakeKeyHandler(PreviousHistory,                     "PreviousHistory") },
+                { Keys.Period,          MakeKeyHandler(RepeatLastCommand,                   "RepeatLastCommand") },
+                { Keys.Semicolon,       MakeKeyHandler(RepeatLastCharSearch,                "RepeatLastCharSearch") },
+                { Keys.Comma,           MakeKeyHandler(RepeatLastCharSearchBackwards,       "RepeatLastCharSearchBackwards") },
+                { Keys.AltH,            MakeKeyHandler(ShowParameterHelp,                   "ShowParameterHelp") },
+                { Keys.F1,              MakeKeyHandler(ShowCommandHelp,                     "ShowCommandHelp") },
+            });
 
             // Some bindings are not available on certain platforms
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -226,98 +294,7 @@ namespace Microsoft.PowerShell
                 _viCmdKeyMap.Add(Keys.CtrlDelete, MakeKeyHandler(KillWord, "KillWord"));
             }
 
-            _viChordDTable = new Dictionary<PSKeyInfo, KeyHandler>
-            {
-                { Keys.D,               MakeKeyHandler( DeleteLine,                   "DeleteLine") },
-                { Keys.Underbar,        MakeKeyHandler( DeleteLine,                   "DeleteLine") },
-                { Keys.Dollar,          MakeKeyHandler( DeleteToEnd,                  "DeleteToEnd") },
-                { Keys.B,               MakeKeyHandler( BackwardDeleteWord,           "BackwardDeleteWord") },
-                { Keys.ucB,             MakeKeyHandler( ViBackwardDeleteGlob,         "ViBackwardDeleteGlob") },
-                { Keys.W,               MakeKeyHandler( DeleteWord,                   "DeleteWord") },
-                { Keys.ucW,             MakeKeyHandler( ViDeleteGlob,                 "ViDeleteGlob") },
-                { Keys.E,               MakeKeyHandler( DeleteEndOfWord,              "DeleteEndOfWord") },
-                { Keys.G,               MakeKeyHandler( ViDGChord,                    "ViDGChord") },
-                { Keys.ucG,             MakeKeyHandler( DeleteEndOfBuffer,            "DeleteEndOfBuffer") },
-                { Keys.ucE,             MakeKeyHandler( ViDeleteEndOfGlob,            "ViDeleteEndOfGlob") },
-                { Keys.H,               MakeKeyHandler( BackwardDeleteChar,           "BackwardDeleteChar") },
-                { Keys.I,               MakeKeyHandler( ViChordDeleteTextObject,      "ChordViTextObject") },               
-                { Keys.J,               MakeKeyHandler( DeleteNextLines,              "DeleteNextLines") },
-                { Keys.K,               MakeKeyHandler( DeletePreviousLines,          "DeletePreviousLines") },
-                { Keys.L,               MakeKeyHandler( DeleteChar,                   "DeleteChar") },
-                { Keys.Space,           MakeKeyHandler( DeleteChar,                   "DeleteChar") },
-                { Keys._0,              MakeKeyHandler( BackwardDeleteLine,           "BackwardDeleteLine") },
-                { Keys.Uphat,           MakeKeyHandler( DeleteLineToFirstChar,        "DeleteLineToFirstChar") },
-                { Keys.Percent,         MakeKeyHandler( ViDeleteBrace,                "ViDeleteBrace") },
-                { Keys.F,               MakeKeyHandler( ViDeleteToChar,               "ViDeleteToChar") },
-                { Keys.ucF,             MakeKeyHandler( ViDeleteToCharBackward,       "ViDeleteToCharBackward") },
-                { Keys.T,               MakeKeyHandler( ViDeleteToBeforeChar,         "ViDeleteToBeforeChar") },
-                { Keys.ucT,             MakeKeyHandler( ViDeleteToBeforeCharBackward, "ViDeleteToBeforeCharBackward") },
-            };
-
-            _viChordCTable = new Dictionary<PSKeyInfo, KeyHandler>
-            {
-                { Keys.C,               MakeKeyHandler( ViReplaceLine,                    "ViReplaceLine") },
-                { Keys.Dollar,          MakeKeyHandler( ViReplaceToEnd,                   "ViReplaceToEnd") },
-                { Keys.B,               MakeKeyHandler( ViBackwardReplaceWord,            "ViBackwardReplaceWord") },
-                { Keys.ucB,             MakeKeyHandler( ViBackwardReplaceGlob,            "ViBackwardReplaceGlob") },
-                { Keys.W,               MakeKeyHandler( ViReplaceWord,                    "ViReplaceWord") },
-                { Keys.ucW,             MakeKeyHandler( ViReplaceGlob,                    "ViReplaceGlob") },
-                { Keys.E,               MakeKeyHandler( ViReplaceEndOfWord,               "ViReplaceEndOfWord") },
-                { Keys.ucE,             MakeKeyHandler( ViReplaceEndOfGlob,               "ViReplaceEndOfGlob") },
-                { Keys.H,               MakeKeyHandler( BackwardReplaceChar,              "BackwardReplaceChar") },
-                { Keys.L,               MakeKeyHandler( ReplaceChar,                      "ReplaceChar") },
-                { Keys.Space,           MakeKeyHandler( ReplaceChar,                      "ReplaceChar") },
-                { Keys._0,              MakeKeyHandler( ViBackwardReplaceLine,            "ViBackwardReplaceLine") },
-                { Keys.Uphat,           MakeKeyHandler( ViBackwardReplaceLineToFirstChar, "ViBackwardReplaceLineToFirstChar") },
-                { Keys.Percent,         MakeKeyHandler( ViReplaceBrace,                   "ViReplaceBrace") },
-                { Keys.F,               MakeKeyHandler( ViReplaceToChar,                  "ViReplaceToChar") },
-                { Keys.ucF,             MakeKeyHandler( ViReplaceToCharBackward,          "ViReplaceToCharBackward") },
-                { Keys.T,               MakeKeyHandler( ViReplaceToBeforeChar,            "ViReplaceToBeforeChar") },
-                { Keys.ucT,             MakeKeyHandler( ViReplaceToBeforeCharBackward,    "ViReplaceToBeforeCharBackward") },
-            };
-
-            _viChordGTable = new Dictionary<PSKeyInfo, KeyHandler>
-            {
-                { Keys.G,               MakeKeyHandler( MoveToFirstLine,                    "MoveToFirstLine") },
-            };
-
-            _viChordYTable = new Dictionary<PSKeyInfo, KeyHandler>
-            {
-                { Keys.Y,               MakeKeyHandler( ViYankLine,            "ViYankLine") },
-                { Keys.Dollar,          MakeKeyHandler( ViYankToEndOfLine,     "ViYankToEndOfLine") },
-                { Keys.B,               MakeKeyHandler( ViYankPreviousWord,    "ViYankPreviousWord") },
-                { Keys.ucB,             MakeKeyHandler( ViYankPreviousGlob,    "ViYankPreviousGlob") },
-                { Keys.W,               MakeKeyHandler( ViYankNextWord,        "ViYankNextWord") },
-                { Keys.ucW,             MakeKeyHandler( ViYankNextGlob,        "ViYankNextGlob") },
-                { Keys.E,               MakeKeyHandler( ViYankEndOfWord,       "ViYankEndOfWord") },
-                { Keys.ucE,             MakeKeyHandler( ViYankEndOfGlob,       "ViYankEndOfGlob") },
-                { Keys.H,               MakeKeyHandler( ViYankLeft,            "ViYankLeft") },
-                { Keys.L,               MakeKeyHandler( ViYankRight,           "ViYankRight") },
-                { Keys.Space,           MakeKeyHandler( ViYankRight,           "ViYankRight") },
-                { Keys._0,              MakeKeyHandler( ViYankBeginningOfLine, "ViYankBeginningOfLine") },
-                { Keys.Uphat,           MakeKeyHandler( ViYankToFirstChar,     "ViYankToFirstChar") },
-                { Keys.Percent,         MakeKeyHandler( ViYankPercent,         "ViYankPercent") },
-            };
-
-            _viChordTextObjectsTable = new Dictionary<PSKeyInfo, KeyHandler>
-            {
-                { Keys.W,               MakeKeyHandler(ViHandleTextObject,     "WordTextObject")},
-            };
-            
-            _viChordDGTable = new Dictionary<PSKeyInfo, KeyHandler>
-            {
-                { Keys.G,               MakeKeyHandler( DeleteRelativeLines,   "DeleteRelativeLines") },
-            };
-
-            _viCmdChordTable = new Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>>();
-            _viInsChordTable = new Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>>();
-
             _dispatchTable = _viInsKeyMap;
-            _chordDispatchTable = _viInsChordTable;
-            _viCmdChordTable[Keys.G] = _viChordGTable;
-            _viCmdChordTable[Keys.D] = _viChordDTable;
-            _viCmdChordTable[Keys.C] = _viChordCTable;
-            _viCmdChordTable[Keys.Y] = _viChordYTable;
 
             _normalCursorSize = _console.CursorSize;
             if ((_normalCursorSize < 1) || (_normalCursorSize > 100))

--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -370,7 +370,7 @@ namespace Microsoft.PowerShell
         {
             foreach (var entry in _singleton._dispatchTable)
             {
-                if (entry.Value.Action == action)
+                if (entry.Value.TryGetKeyHandler(out var handler) && handler.Action == action)
                     return true;
             }
             return false;

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -369,6 +369,15 @@ namespace Microsoft.PowerShell.PSReadLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Text objects functions.
+        /// </summary>
+        internal static string TextObjectsGrouping {
+            get {
+                return ResourceManager.GetString("TextObjectsGrouping", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to User defined functions.
         /// </summary>
         internal static string CustomGrouping {
@@ -1615,6 +1624,15 @@ namespace Microsoft.PowerShell.PSReadLine {
         internal static string ViDeleteGlobDescription {
             get {
                 return ResourceManager.GetString("ViDeleteGlobDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete the content inside the current word..
+        /// </summary>
+        internal static string ViDeleteInnerWordDescription {
+            get {
+                return ResourceManager.GetString("ViDeleteInnerWordDescription", resourceCulture);
             }
         }
         

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -648,6 +648,9 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
   <data name="ViReplaceGlobDescription" xml:space="preserve">
     <value>Delete to the beginning of the next word, as delimited by white space, and enter insert mode.</value>
   </data>
+  <data name="ViDeleteInnerWordDescription" xml:space="preserve">
+    <value>Delete the content inside and including the current word</value>
+  </data>
   <data name="ViReplaceEndOfWordDescription" xml:space="preserve">
     <value>Delete to the end of the word, as delimited by white space and common delimiters, and enter insert mode.</value>
   </data>
@@ -800,6 +803,9 @@ Or not saving history with:
   </data>
   <data name="SearchGrouping" xml:space="preserve">
     <value>Search functions</value>
+  </data>
+  <data name="TextObjectsGrouping" xml:space="preserve">
+    <value>Text objects functions</value>
   </data>
   <data name="CustomGrouping" xml:space="preserve">
     <value>User defined functions</value>

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -486,12 +486,10 @@ namespace Microsoft.PowerShell
                                 return color >= ConsoleColor.Black && color <= ConsoleColor.White;
                             }
 
-                            if (IsValid(_singleton._initialForeground))
-                            {
+                            if (IsValid(_singleton._initialForeground)) {
                                 console.ForegroundColor = _singleton._initialForeground;
                             }
-                            if (IsValid(_singleton._initialBackground))
-                            {
+                            if (IsValid(_singleton._initialBackground)) {
                                 console.BackgroundColor = _singleton._initialBackground;
                             }
                             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -448,7 +448,8 @@ namespace Microsoft.PowerShell
                         sb.Append(' ');
                         sb.Append(_lastNKeys[i].KeyStr);
 
-                        if (_singleton._dispatchTable.TryGetValue(_lastNKeys[i], out var handler) &&
+                        if (_singleton._dispatchTable.TryGetValue(_lastNKeys[i], out var handlerOrChordDispatchTable) &&
+                            handlerOrChordDispatchTable.TryGetKeyHandler(out var handler) &&
                             "AcceptLine".Equals(handler.BriefDescription, StringComparison.OrdinalIgnoreCase))
                         {
                             // Make it a little easier to see the keys
@@ -485,10 +486,12 @@ namespace Microsoft.PowerShell
                                 return color >= ConsoleColor.Black && color <= ConsoleColor.White;
                             }
 
-                            if (IsValid(_singleton._initialForeground)) {
+                            if (IsValid(_singleton._initialForeground))
+                            {
                                 console.ForegroundColor = _singleton._initialForeground;
                             }
-                            if (IsValid(_singleton._initialBackground)) {
+                            if (IsValid(_singleton._initialBackground))
+                            {
                                 console.BackgroundColor = _singleton._initialBackground;
                             }
                             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -629,47 +632,114 @@ namespace Microsoft.PowerShell
             CallPossibleExternalApplication<object>(() => { action(); return null; });
         }
 
-        void ProcessOneKey(PSKeyInfo key, Dictionary<PSKeyInfo, KeyHandler> dispatchTable, bool ignoreIfNoAction, object arg)
+        void ProcessOneKey(PSKeyInfo key, ChordDispatchTable dispatchTable, bool ignoreIfNoAction, object arg)
+            => ProcessKeyChord(key, dispatchTable, ignoreIfNoAction, arg);
+        void ProcessKeyChord(PSKeyInfo key, ChordDispatchTable dispatchTable, bool ignoreIfNoAction, object arg)
         {
-            var consoleKey = key.AsConsoleKeyInfo();
+            KeyHandlerOrChordDispatchTable handlerOrChordDispatchTable = null;
 
-            // Our dispatch tables are built as much as possible in a portable way, so for example,
-            // we avoid depending on scan codes like ConsoleKey.Oem6 and instead look at the
-            // PSKeyInfo.Key. We also want to ignore the shift state as that may differ on
-            // different keyboard layouts.
-            //
-            // That said, we first look up exactly what we get from Console.ReadKey - that will fail
-            // most of the time, and when it does, we normalize the key.
-            if (!dispatchTable.TryGetValue(key, out var handler))
+            do
             {
-                // If we see a control character where Ctrl wasn't used but shift was, treat that like
-                // shift hadn't be pressed.  This cleanly allows Shift+Backspace without adding a key binding.
-                if (key.Shift && !key.Control && !key.Alt)
+                var consoleKey = key.AsConsoleKeyInfo();
+
+                // Our dispatch tables are built as much as possible in a portable way, so for example,
+                // we avoid depending on scan codes like ConsoleKey.Oem6 and instead look at the
+                // PSKeyInfo.Key. We also want to ignore the shift state as that may differ on
+                // different keyboard layouts.
+                //
+                // That said, we first look up exactly what we get from Console.ReadKey - that will fail
+                // most of the time, and when it does, we normalize the key.
+                if (!dispatchTable.TryGetValue(key, out handlerOrChordDispatchTable))
                 {
-                    var c = consoleKey.KeyChar;
-                    if (c != '\0' && char.IsControl(c))
+                    // If we see a control character where Ctrl wasn't used but shift was, treat that like
+                    // shift hadn't been pressed. This cleanly allows Shift+Backspace without adding a key binding.
+                    if (key.Shift && !key.Control && !key.Alt)
                     {
-                        key = PSKeyInfo.From(consoleKey.Key);
-                        dispatchTable.TryGetValue(key, out handler);
+                        var c = consoleKey.KeyChar;
+                        if (c != '\0' && char.IsControl(c))
+                        {
+                            key = PSKeyInfo.From(consoleKey.Key);
+                            dispatchTable.TryGetValue(key, out handlerOrChordDispatchTable);
+                        }
                     }
                 }
-            }
 
-            if (handler != null)
-            {
-                if (handler.ScriptBlock != null)
+                if (handlerOrChordDispatchTable != null && handlerOrChordDispatchTable.TryGetKeyHandler(out var handler))
                 {
-                    CallPossibleExternalApplication(() => handler.Action(consoleKey, arg));
+                    // invoke key handler
+
+                    if (handler.ScriptBlock != null)
+                    {
+                        CallPossibleExternalApplication(() => handler.Action(consoleKey, arg));
+                    }
+                    else
+                    {
+                        handler.Action(consoleKey, arg);
+                    }
+
+                    // key chords are processed mostly by looping over each key
+                    // in a loop and identifying their dispatch tables until
+                    // the dispatch table is null.
+                    //
+                    // nullify dispatch table to prevent infinite looping
+
+                    handlerOrChordDispatchTable = null;
                 }
+
+                // the current key is part of a key chord
+                // read the next key and select the dispatch
+                // table for the next iteration of the loop
+
+                else if (handlerOrChordDispatchTable != null)
+                {
+                    key = ReadKey();
+
+                    dispatchTable = (ChordDispatchTable)handlerOrChordDispatchTable;
+                    ignoreIfNoAction = true;
+                }
+
+                else if (handlerOrChordDispatchTable == null && dispatchTable.InViMode && IsNumeric(key) && arg == null)
+                {
+                    var argBuffer = _singleton._statusBuffer;
+                    argBuffer.Clear();
+                    _singleton._statusLinePrompt = "digit-argument: ";
+
+                    while (IsNumeric(key))
+                    {
+                        argBuffer.Append(key.KeyChar);
+                        _singleton.Render();
+                        key = ReadKey();
+                    }
+                    var numericArg = int.Parse(argBuffer.ToString());
+                    if (dispatchTable.TryGetValue(key, out var keyHhandler))
+                    {
+                        ProcessOneKey(key, dispatchTable, ignoreIfNoAction: true, arg: numericArg);
+                    }
+                    else
+                    {
+                        Ding();
+                    }
+                    argBuffer.Clear();
+                    _singleton.ClearStatusMessage(render: true);
+
+                    // MUST exit from recursive call
+
+                    return;
+                }
+
+                // insert unmapped keys
+
+                else if (!ignoreIfNoAction)
+                {
+                    SelfInsert(consoleKey, arg);
+                }
+
                 else
                 {
-                    handler.Action(consoleKey, arg);
+                    Ding(key.AsConsoleKeyInfo(), arg);
                 }
-            }
-            else if (!ignoreIfNoAction)
-            {
-                SelfInsert(consoleKey, arg);
-            }
+
+            } while (handlerOrChordDispatchTable != null);
         }
 
         static PSConsoleReadLine()
@@ -910,20 +980,6 @@ namespace Microsoft.PowerShell
             _readKeyThread.Start();
         }
 
-        private static void Chord(ConsoleKeyInfo? key = null, object arg = null)
-        {
-            if (!key.HasValue)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            if (_singleton._chordDispatchTable.TryGetValue(PSKeyInfo.FromConsoleKeyInfo(key.Value), out var secondKeyDispatchTable))
-            {
-                var secondKey = ReadKey();
-                _singleton.ProcessOneKey(secondKey, secondKeyDispatchTable, ignoreIfNoAction: true, arg: arg);
-            }
-        }
-
         /// <summary>
         /// Abort current action, e.g. incremental history search.
         /// </summary>
@@ -965,7 +1021,9 @@ namespace Microsoft.PowerShell
             while (true)
             {
                 var nextKey = ReadKey();
-                if (_singleton._dispatchTable.TryGetValue(nextKey, out var handler))
+                if (_singleton._dispatchTable.TryGetValue(nextKey, out var handlerOrChordDispatchTable) &&
+                    handlerOrChordDispatchTable.TryGetKeyHandler(out var handler)
+                )
                 {
                     if (handler.Action == DigitArgument)
                     {

--- a/PSReadLine/TextObjects.Vi.cs
+++ b/PSReadLine/TextObjects.Vi.cs
@@ -1,98 +1,10 @@
 using System;
-using System.Collections.Generic;
 
 namespace Microsoft.PowerShell
 {
     public partial class PSConsoleReadLine
     {
-        internal enum TextObjectOperation
-        {
-            None,
-            Change,
-            Delete,
-        }
-
-        internal enum TextObjectSpan
-        {
-            None,
-            Around,
-            Inner,
-        }
-
-        private TextObjectOperation _textObjectOperation = TextObjectOperation.None;
-        private TextObjectSpan _textObjectSpan = TextObjectSpan.None;
-
-        private readonly Dictionary<TextObjectOperation, Dictionary<TextObjectSpan, KeyHandler>> _textObjectHandlers = new()
-        {
-            [TextObjectOperation.Delete] = new() { [TextObjectSpan.Inner] = MakeKeyHandler(ViDeleteInnerWord, "ViDeleteInnerWord") },
-        };
-
-        private void ViChordDeleteTextObject(ConsoleKeyInfo? key = null, object arg = null)
-        {
-            _textObjectOperation = TextObjectOperation.Delete;
-            ViChordTextObject(key, arg);
-        }
-
-        private void ViChordTextObject(ConsoleKeyInfo? key = null, object arg = null)
-        {
-            if (!key.HasValue)
-            {
-                ResetTextObjectState();
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            _textObjectSpan = GetRequestedTextObjectSpan(key.Value);
-
-            // Handle text object
-            var textObjectKey = ReadKey();
-            if (_viChordTextObjectsTable.TryGetValue(textObjectKey, out _))
-            {
-                _singleton.ProcessOneKey(textObjectKey, _viChordTextObjectsTable, ignoreIfNoAction: true, arg: arg);
-            }
-            else
-            {
-                ResetTextObjectState();
-                Ding();
-            }
-        }
-
-        private TextObjectSpan GetRequestedTextObjectSpan(ConsoleKeyInfo key)
-        {
-            if (key.KeyChar == 'i')
-            {
-                return TextObjectSpan.Inner;
-            }
-            else if (key.KeyChar == 'a')
-            {
-                return TextObjectSpan.Around;
-            }
-            else
-            {
-                System.Diagnostics.Debug.Assert(false);
-                throw new NotSupportedException();
-            }
-        }
-
-        private static void ViHandleTextObject(ConsoleKeyInfo? key = null, object arg = null)
-        {
-            if (!_singleton._textObjectHandlers.TryGetValue(_singleton._textObjectOperation, out var textObjectHandler) ||
-                !textObjectHandler.TryGetValue(_singleton._textObjectSpan, out var handler))
-            {
-                ResetTextObjectState();
-                Ding();
-                return;
-            }
-
-            handler.Action(key, arg);
-        }
-
-        private static void ResetTextObjectState()
-        {
-            _singleton._textObjectOperation = TextObjectOperation.None;
-            _singleton._textObjectSpan = TextObjectSpan.None;
-        }
-
-        private static void ViDeleteInnerWord(ConsoleKeyInfo? key = null, object arg = null)
+        public static void ViDeleteInnerWord(ConsoleKeyInfo? key = null, object arg = null)
         {
             var delimiters = _singleton.Options.WordDelimiters;
 

--- a/PSReadLine/TextObjects.Vi.cs
+++ b/PSReadLine/TextObjects.Vi.cs
@@ -4,6 +4,9 @@ namespace Microsoft.PowerShell
 {
     public partial class PSConsoleReadLine
     {
+        /// <summary>
+        /// Delete the content inside and including the current word
+        /// </summary>
         public static void ViDeleteInnerWord(ConsoleKeyInfo? key = null, object arg = null)
         {
             var delimiters = _singleton.Options.WordDelimiters;

--- a/test/KeyInfoTest.cs
+++ b/test/KeyInfoTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.PowerShell;
 using Xunit;
 
@@ -7,6 +8,7 @@ namespace Test
     public class KeyInfo
     {
         private const ConsoleModifiers NoModifiers = 0;
+        private const ConsoleModifiers CtrlShift = ConsoleModifiers.Control | ConsoleModifiers.Shift;
 
         [Fact]
         public void KeyInfoConverterSimpleCharLiteral()
@@ -107,6 +109,22 @@ namespace Test
             {
                 TestOne(c);
             }
+        }
+
+        [Fact]
+        public void KeyInfoConverter_ThreeKeyChords()
+        {
+            var chord = ConsoleKeyChordConverter.Convert("Ctrl+K,Ctrl+P,x");
+            Assert.Equal(3, chord.Length);
+
+            Assert.Equal(CtrlShift, chord[0].Modifiers);
+            Assert.Equal(Enum.Parse(typeof(ConsoleKey), "K"), chord[0].Key);
+
+            Assert.Equal(CtrlShift, chord[1].Modifiers);
+            Assert.Equal(Enum.Parse(typeof(ConsoleKey), "P"), chord[1].Key);
+
+            Assert.Equal(NoModifiers, chord[2].Modifiers);
+            Assert.Equal(Enum.Parse(typeof(ConsoleKey), "X"), chord[2].Key);
         }
 
         [Fact]

--- a/test/OptionsTest.VI.cs
+++ b/test/OptionsTest.VI.cs
@@ -37,6 +37,31 @@ namespace Test
             {
                 Assert.Equal("<d,0>", handler.Key);
             }
+
+            handlers = PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "d,i,w" });
+            Assert.NotEmpty(handlers);
+            foreach (var handler in handlers)
+            {
+                Assert.Equal("<d,i,w>", handler.Key);
+            }
+        }
+
+        [SkippableFact]
+        public void ViRemoveKeyHandler()
+        {
+            TestSetup(KeyMode.Vi);
+
+            using var disposable = PSConsoleReadLine.UseViCommandModeTables();
+
+            PSConsoleReadLine.RemoveKeyHandler(new string[] { "d,0" });
+
+            var handlers = PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "d,0" });
+            Assert.Empty(handlers);
+
+            PSConsoleReadLine.RemoveKeyHandler(new string[] { "d,i,w" });
+
+            handlers = PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "d,i,w" });
+            Assert.Empty(handlers);
         }
     }
 }

--- a/test/OptionsTest.cs
+++ b/test/OptionsTest.cs
@@ -56,11 +56,11 @@ namespace Test
         }
 
         [SkippableFact]
-        public void GetKeyHandlers()
+        public void GetKeyHandlers_Unbound()
         {
             System.Collections.Generic.IEnumerable<Microsoft.PowerShell.KeyHandler> handlers;
 
-            foreach (var keymode in new[] {KeyMode.Cmd, KeyMode.Emacs})
+            foreach (var keymode in new[] { KeyMode.Cmd, KeyMode.Emacs })
             {
                 TestSetup(keymode);
 
@@ -85,15 +85,17 @@ namespace Test
                     Assert.Equal("Home", handler.Key);
                 }
             }
+        }
+
+        [SkippableFact]
+        public void GetKeyHandlers_Emacs()
+        {
+            System.Collections.Generic.IEnumerable<Microsoft.PowerShell.KeyHandler> handlers;
 
             TestSetup(KeyMode.Emacs);
             
             handlers = PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "ctrl+x" });
-            Assert.NotEmpty(handlers);
-            foreach (var handler in handlers)
-            {
-                Assert.Equal("Ctrl+x", handler.Key);
-            }
+            Assert.Empty(handlers);
 
             handlers = PSConsoleReadLine.GetKeyHandlers(Chord: new string[] { "ctrl+x,ctrl+e" });
             Assert.NotEmpty(handlers);


### PR DESCRIPTION
# PR Summary

This PR refactors the handling of key chords and consolidates the behaviour from Emacs and VI modes into a single consistent function.

This PR addresses freedback made on #3791 following #2059 which has been merged a bit too optimistically.

# PR Content

In order to achieve a consistent behaviour, the _Chord Dispatch Table_ structures are refactored using a `KeyHandlerOrChordDispatchTable` class that can hold either a regular `KeyHandler` or a nested `ChordDispatchTable`. This means that chord dispatch tables are organized in a tree structure and looking up a key handler is a simple matter of walking down the tree structure.

This allows to greatly simplify the handling of VI-mode three key-chord commands, such as <kbd>d</kbd>, <kbd>g</kbd>, <kbd>g</kbd> (`<d,g,g>` _delete relative lines_) or <kbd>d</kbd>, <kbd>i</kbd>, <kbd>w</kbd> (`<d,i,w>` _delete inner word_)

This allows to remove all the references to a _secondary_ dispatch table when handling key chords in favor of a more consistent algorithm that walks through the chord dispatch table tree structure and identifies whether the next node is a leaf (_i.e_ a `KeyHandler`) or another nested node (_i.e_ an inner-level chord dispatch table).

**Note** in #3791 was discussed the fact that we may want to limit key chords to a maximum of three keys. This PR does not enforce any limit. Maybe such a limit could be hardcoded in the `PSConsoleReadLine.SetKeyHandler()` CmdLet implementation.

This PR consolidates handling of key chords in the `ProcessOneKey` function – which could be renamed `ProcessKeyChord`. Most of the current implementations were using recursive code – albeit, indirectly by calling either the `Chord` or the `ViChord` method. In contrast, this PR _almost_ eliminates recursive code in favor of walking the tree structure. However, handling of VI-mode digit-arguments is a bit complex and I was not able to solve this without resorting to recursive code. This make the `ProcessOneKey` function a bit hard to understand. I have tried adding as much comments as I could think of.

The unit-tests sometimes randomly fail on my machine, but that was already the case with the current code in the `master` branch before this PR. Sometimes, unit-tests fail as part of running the whole test suite. When running one failing test again it then succeeds. Finally, most tests around history fail on my machine but – again – that is already the case with the current code in the `master` branch 🤔. This has mostly been addressed in [a separate pull request](/PowerShell/PSReadLine/pull/4686).

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/3853)