### PR TITLE
Stop trying to de-duplicate completion results

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -298,31 +298,6 @@ namespace Microsoft.PowerShell
                     var length = _tabCompletions.ReplacementLength;
                     if (start < 0 || start > _singleton._buffer.Length) return null;
                     if (length < 0 || length > (_singleton._buffer.Length - start)) return null;
-
-                    if (_tabCompletions.CompletionMatches.Count > 1)
-                    {
-                        // Filter out apparent duplicates -- the 'ListItemText' is exactly the same.
-                        var hashSet = new HashSet<string>();
-                        var matches = _tabCompletions.CompletionMatches;
-                        List<int> indices = null;
-
-                        for (int i = 0; i < matches.Count; i++)
-                        {
-                            if (!hashSet.Add(matches[i].ListItemText))
-                            {
-                                indices ??= new List<int>();
-                                indices.Add(i);
-                            }
-                        }
-
-                        if (indices is not null)
-                        {
-                            for (int i = indices.Count - 1; i >= 0; i--)
-                            {
-                                matches.RemoveAt(indices[i]);
-                            }
-                        }
-                    }
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3896
Given that both ISE and VSCode editor completion doesn't de-duplicate completion results, we probably should stop trying to de-duplicate completion results in PSReadLine to be consistent.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/3897)