### PR TITLE
Ignore keys with no valid KeyChar for vi movements

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -289,6 +289,24 @@ namespace Microsoft.PowerShell
             return key;
         }
 
+        /// <summary>
+        /// Reads a key, discarding the key if the PSKeyInfo returned does not
+        /// have a valid character. Will loop until a valid character is read.
+        /// The purpose of this method is to handle cases such as dead keys on
+        /// Windows on layouts such as US-International.
+        /// </summary>
+        /// <returns> The valid character read. </returns>
+        internal static char ReadKeyChar()
+        {
+            PSKeyInfo key;
+            do
+            {
+                key = ReadKey();
+            }
+            while (key.KeyChar == '\0');
+            return key.KeyChar;
+        }
+
         private void PrependQueuedKeys(PSKeyInfo key)
         {
             if (_queuedKeys.Count > 0)

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -163,7 +163,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void SearchChar(ConsoleKeyInfo? key = null, object arg = null)
         {
-            char keyChar = ReadKey().KeyChar;
+            char keyChar = ReadKeyChar();
             ViCharacterSearcher.Set(keyChar, isBackward: false, isBackoff: false);
             ViCharacterSearcher.Search(keyChar, arg, backoff: false);
         }
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void SearchCharBackward(ConsoleKeyInfo? key = null, object arg = null)
         {
-            char keyChar = ReadKey().KeyChar;
+            char keyChar = ReadKeyChar();
             ViCharacterSearcher.Set(keyChar, isBackward: true, isBackoff: false);
             ViCharacterSearcher.SearchBackward(keyChar, arg, backoff: false);
         }
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void SearchCharWithBackoff(ConsoleKeyInfo? key = null, object arg = null)
         {
-            char keyChar = ReadKey().KeyChar;
+            char keyChar = ReadKeyChar();
             ViCharacterSearcher.Set(keyChar, isBackward: false, isBackoff: true);
             ViCharacterSearcher.Search(keyChar, arg, backoff: true);
         }
@@ -196,7 +196,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void SearchCharBackwardWithBackoff(ConsoleKeyInfo? key = null, object arg = null)
         {
-            char keyChar = ReadKey().KeyChar;
+            char keyChar = ReadKeyChar();
             ViCharacterSearcher.Set(keyChar, isBackward: true, isBackoff: true);
             ViCharacterSearcher.SearchBackward(keyChar, arg, backoff: true);
         }
@@ -362,7 +362,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViDeleteToChar(ConsoleKeyInfo? key = null, object arg = null)
         {
-            var keyChar = ReadKey().KeyChar;
+            var keyChar = ReadKeyChar();
             ViDeleteToChar(keyChar, key, arg);
         }
 
@@ -380,7 +380,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViDeleteToCharBackward(ConsoleKeyInfo? key = null, object arg = null)
         {
-            var keyChar = ReadKey().KeyChar;
+            var keyChar = ReadKeyChar();
             ViDeleteToCharBack(keyChar, key, arg);
         }
 
@@ -397,7 +397,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViDeleteToBeforeChar(ConsoleKeyInfo? key = null, object arg = null)
         {
-            var keyChar = ReadKey().KeyChar;
+            var keyChar = ReadKeyChar();
             ViDeleteToBeforeChar(keyChar, key, arg);
         }
 
@@ -415,7 +415,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViDeleteToBeforeCharBackward(ConsoleKeyInfo? key = null, object arg = null)
         {
-            var keyChar = ReadKey().KeyChar;
+            var keyChar = ReadKeyChar();
             ViDeleteToBeforeCharBack(keyChar, key, arg);
         }
 

--- a/PSReadLine/Replace.vi.cs
+++ b/PSReadLine/Replace.vi.cs
@@ -256,7 +256,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViReplaceToChar(ConsoleKeyInfo? key = null, object arg = null)
         {
-            var keyChar = ReadKey().KeyChar;
+            var keyChar = ReadKeyChar();
             ViReplaceToChar(keyChar, key, arg);
         }
 
@@ -288,7 +288,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViReplaceToCharBackward(ConsoleKeyInfo? key = null, object arg = null)
         {
-            var keyChar = ReadKey().KeyChar;
+            var keyChar = ReadKeyChar();
             ViReplaceToCharBack(keyChar, key, arg);
         }
 
@@ -310,7 +310,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViReplaceToBeforeChar(ConsoleKeyInfo? key = null, object arg = null)
         {
-            var keyChar = ReadKey().KeyChar;
+            var keyChar = ReadKeyChar();
             ViReplaceToBeforeChar(keyChar, key, arg);
         }
 
@@ -333,7 +333,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViReplaceToBeforeCharBackward(ConsoleKeyInfo? key = null, object arg = null)
         {
-            var keyChar = ReadKey().KeyChar;
+            var keyChar = ReadKeyChar();
             ViReplaceToBeforeCharBack(keyChar, key, arg);
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add a new function called ReadKeyChar that loops until a key with valid KeyChar is read. Change the calls for ReadKey().KeyChar on .vi.cs files so that vi movements have this new behaviour.

The idea is to fix issues on Windows like not being able to move to characters that are behind dead keys on layouts such as US-international (single quotes, for example, is input only after hitting single quote and then space). The current behavior on Windows breaks the chain by returning a PSKeyInfo without a valid KeyChar and then trying to move to it (instead of waiting for the next key press to get the actual input).

## PR Checklist

- [ X ] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [ X ] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ X ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

I'm not really sure how to unit test it since it seems dependent on the keyboard layout, but I welcome suggestions.

So far I've manually tested it on Windows running PowerShell 7.4.1 with Windows Terminal, conhost and Visual Studio Code and Linux (WSL2) with Windows Terminal.

The only caveaut I've found so far is that function keys (such as F1~F12) will also be ignored, But since the only code that is being changed to use the new version are the vi movement ones I believe this is not an issue.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/3928)