### PR TITLE
Use the correct directory separator based on the platform we are working with

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -693,6 +693,13 @@ namespace Microsoft.PowerShell
             _engineIntrinsics = engineIntrinsics;
             _runspace = runspace;
 
+            // The directory separator to be used for tab completion may change depending on
+            // whether we are working with a remote Runspace.
+            // So, we always set it to null for every call into 'PSConsoleReadLine.ReadLine',
+            // and do the real initialization when tab completion is triggered for the first
+            // time during that call.
+            _directorySeparator = null;
+
             // Update the client instance per every call to PSReadLine.
             UpdatePredictionClient(runspace, engineIntrinsics);
 


### PR DESCRIPTION
### PR Summary

Fix #3923

When working with a remote Runspace, we choose the directory separator based on the platform of the remote server.

_**Before the fix, the trailing directory separator is `\` in a remote session from Windows to Linux**_

![old](https://github.com/PowerShell/PSReadLine/assets/127450/160e7ead-7562-46f4-86a0-3c885f7d1711)

_***After the fix, the trailing directory separator is `/` in a remote session from Windows to Linux*_

![new](https://github.com/PowerShell/PSReadLine/assets/127450/5a82eb6b-b65a-4cdc-9ebb-413c5da1657d)


## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests **tested manually**
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/3935)