### PR TITLE
Fix the null-reference exception when running `Debug-Job` on a thread job

### DIFF
--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -50,7 +50,9 @@ namespace Microsoft.PowerShell
             if (s_pCurrentLocation is not null)
             {
                 // Set the current location if it's a local Runspace. Otherwise, set it to null.
-                object path = runspace.RunspaceIsRemote ? null : engineIntrinsics.SessionState.Path.CurrentLocation;
+                object path = runspace is null || runspace.RunspaceIsRemote
+                    ? null
+                    : engineIntrinsics?.SessionState.Path.CurrentLocation;
                 s_pCurrentLocation.SetValue(s_predictionClient, path);
             }
         }


### PR DESCRIPTION


<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix #3954 

The `$Host.Runspace` is null when `PSConsoleHostReadLine` is invoked while debugging a thread job.
This is because a thread job uses the default host, which always has value `null` for `$Host.Runspace`.
We set the current path to be `null` when either `runspace` or `engineIntrinsics` is null.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/3957)