### PR TITLE
Prepare for the v2.4.0-beta0 release of PSReadLine

### DIFF
--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -42,7 +42,7 @@ stages:
         Write-Host "PS Version: $($($PSVersionTable.PSVersion))"
         Set-Location -Path '$(Build.SourcesDirectory)\PSReadLine'
         .\build.ps1 -Bootstrap
-        .\build.ps1 -Configuration Release -Framework net462 -CheckHelpContent
+        .\build.ps1 -Configuration Release -Framework net462
 
         # Set target folder paths
         New-Item -Path .\bin\Release\NuGetPackage -ItemType Directory > $null

--- a/MockPSConsole/MockPSConsole.csproj
+++ b/MockPSConsole/MockPSConsole.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.13" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine.build.ps1
+++ b/PSReadLine.build.ps1
@@ -160,7 +160,8 @@ task LayoutModule BuildPolyfiller, BuildMainModule, {
     $version = $versionInfo.FileVersion
     $semVer = $versionInfo.ProductVersion
 
-    if ($semVer -match "(.*)-(.*)") {
+    # dotnet build may add the Git commit hash to the 'ProductVersion' attribute with this format: +<commit-hash>.
+    if ($semVer -match "(.*)-([^\+]*)(?:\+.*)?") {
         # Make sure versions match
         if ($matches[1] -ne $version) { throw "AssemblyFileVersion mismatch with AssemblyInformationalVersion" }
         $prerelease = $matches[2]

--- a/PSReadLine/Changes.txt
+++ b/PSReadLine/Changes.txt
@@ -1,3 +1,21 @@
+### [2.4.0-beta0] - 2024-03-01
+
+- Fix the null-reference exception when running `Debug-Job` on a thread job (#3957)
+- Add needed permission to the workflow (#3944, #3945, #3946)
+- Fix copying text to system clipboard on Linux using xclip (#3937)
+- Use the correct directory separator for tab completion based on the platform we are working with (#3935)
+- Update the minimal PS version required to be 5.1 (#3936)
+- Little code style cleanup for the `GetCompletions()` method (#3898)
+- Stop trying to de-duplicate completion results (#3897)
+- Windows keyboard layout handling: get the current layout from the parent terminal process (#3786) (Thanks @ForNeVeR!)
+- Add "resolution no activity" label to the bot-close list (#3852)
+- Fix a few VI key handlers to close edit group properly (#3845)
+- Update the documentation issue template to point to the PowerShell-Doc repo (#3839, #3840, #3841)
+- Handle large history file properly by reading lines in the streaming way (#3810)
+- Update build script to always include the `ProjectUri` info (#3821)
+
+[2.4.0-beta0]: https://github.com/PowerShell/PSReadLine/compare/v2.3.4...v2.4.0-beta0
+
 ### [2.3.4] - 2023-10-02
 
 - Choose the inline prediction color based on the environment (#3808)

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -5,9 +5,9 @@
     <RootNamespace>Microsoft.PowerShell.PSReadLine</RootNamespace>
     <AssemblyName>Microsoft.PowerShell.PSReadLine2</AssemblyName>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
-    <AssemblyVersion>2.3.4.0</AssemblyVersion>
-    <FileVersion>2.3.4</FileVersion>
-    <InformationalVersion>2.3.4</InformationalVersion>
+    <AssemblyVersion>2.4.0.0</AssemblyVersion>
+    <FileVersion>2.4.0</FileVersion>
+    <InformationalVersion>2.4.0-beta0</InformationalVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.13" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.psd1
+++ b/PSReadLine/PSReadLine.psd1
@@ -1,7 +1,7 @@
 ﻿@{
 RootModule = 'PSReadLine.psm1'
 NestedModules = @("Microsoft.PowerShell.PSReadLine2.dll")
-ModuleVersion = '2.3.4'
+ModuleVersion = '2.4.0'
 GUID = '5714753b-2afd-4492-a5fd-01d9e2cff8b5'
 Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'

--- a/Polyfill/Polyfill.csproj
+++ b/Polyfill/Polyfill.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.13" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.18" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.13" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.18" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Prepare for the v2.4.0-beta0 release of PSReadLine
- Update the versions
- Skip help content check, as it does not really work due to the in-box PSReadLine would cause error during help updating in the CI Windows machine.
- Update the build script to handle the pre-release version properly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/3962)