### PR TITLE
Change back to `external_distribution` for .nupkg file signing

### DIFF
--- a/.pipelines/PSReadLine-Official.yml
+++ b/.pipelines/PSReadLine-Official.yml
@@ -225,7 +225,7 @@ extends:
           displayName: Sign nupkg
           inputs:
             command: 'sign'
-            signing_profile: external_default
+            signing_profile: external_distribution
             files_to_sign: '*.nupkg'
             search_root: $(nugetPath)
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Change back to `external_distribution` for .nupkg file signing


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/3977)