### PR TITLE
Add ctrl+enter key binding for Linux

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -270,6 +270,7 @@ namespace Microsoft.PowerShell
             {
                 { Keys.Backspace,              MakeKeyHandler(BackwardDeleteChar,        "BackwardDeleteChar") },
                 { Keys.Enter,                  MakeKeyHandler(AcceptLine,                "AcceptLine") },
+                { Keys.CtrlEnter,              MakeKeyHandler(AcceptLine,                "AcceptLine") },
                 { Keys.ShiftEnter,             MakeKeyHandler(AddLine,                   "AddLine") },
                 { Keys.LeftArrow,              MakeKeyHandler(BackwardChar,              "BackwardChar") },
                 { Keys.RightArrow,             MakeKeyHandler(ForwardChar,               "ForwardChar") },


### PR DESCRIPTION
# PR Summary
Adds the Ctrl+Enter key binding for Linux that defaults to AcceptLine. This allows PSReadLine to work by default on Linux terminals like Alacritty (in tmux) where a newline in a paste comes across as the Ctrl+Enter key. Not all terminals on Linux will send a newline in a paste as this key but some do. Having this key handler means that pasting a string with newlines is preserved properly rather than as 

You can replicate how a newline was handled in a tty with a .NET application by running the following Python code on Linux

```python
import os
import pty
import subprocess
import sys

parent, child = pty.openpty()
p = subprocess.Popen(
    ['pwsh', '-Command', '[Console]::ReadKey($true) | ConvertTo-Json -EnumsAsString'],
    preexec_fn=os.setsid,
    stdin=child,
    stdout=sys.stdout,
    stderr=sys.stderr,
)
stdin = os.fdopen(parent, 'wb', 0)
os.close(child)

stdin.write(b"\n")
p.communicate()
```

The output on PowerShell 7.4/.NET 8 is

```json
{
  "KeyChar": "\n",
  "Key": "Enter",
  "Modifiers": "Control"
}
```

.NET introduced a rewrite of `Console.ReadKey()` in .NET 7 https://github.com/dotnet/runtime/pull/72193 that changed how a `\n` on a tty was handled. In the past this is what it returned

```json
{
  "KeyChar": "\r",
  "Key": "Enter",
  "Modifiers": 0
}
```

As there were no modifiers the `\r` was treated as a newline and so just worked.

I'm unsure how you wish for me to test this, any guidance there would be appreciated.

For anyone encountering this, you can add this line to your `$profile` to get copy/pasting working without this PR.

```powershell
Set-PSReadLineKeyHandler -Chord "Ctrl+Enter" -Function AcceptLine
```

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/3983)