### PR TITLE
Update `SelectCommandArgument` to properly handle POSIX style options for CLI commands

### DIFF
--- a/test/KillYankTest.cs
+++ b/test/KillYankTest.cs
@@ -620,6 +620,56 @@ namespace Test
         }
 
         [SkippableFact]
+        public void SelectCommandArgument_CLIArgs()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            Test("", Keys(
+                "az webapp --name MyWebApp --resource-group MyResourceGroup",
+                _.Alt_a, CheckThat(() => AssertScreenIs(1,
+                    TokenClassification.Command, "az",
+                    TokenClassification.None, ' ',
+                    TokenClassification.Selection, "webapp",
+                    TokenClassification.None, ' ',
+                    TokenClassification.Parameter, "--name",
+                    TokenClassification.None, " MyWebApp ",
+                    TokenClassification.Parameter, "--resource-group",
+                    TokenClassification.None, " MyResourceGroup ")),
+
+                _.Alt_a, CheckThat(() => AssertScreenIs(1,
+                    TokenClassification.Command, "az",
+                    TokenClassification.None, " webapp ",
+                    TokenClassification.Parameter, "--name",
+                    TokenClassification.None, ' ',
+                    TokenClassification.Selection, "MyWebApp",
+                    TokenClassification.None, ' ',
+                    TokenClassification.Parameter, "--resource-group",
+                    TokenClassification.None, " MyResourceGroup ")),
+
+                _.Alt_a, CheckThat(() => AssertScreenIs(1,
+                    TokenClassification.Command, "az",
+                    TokenClassification.None, " webapp ",
+                    TokenClassification.Parameter, "--name",
+                    TokenClassification.None, " MyWebApp ",
+                    TokenClassification.Parameter, "--resource-group",
+                    TokenClassification.None, ' ',
+                    TokenClassification.Selection, "MyResourceGroup")),
+
+                // Verify that we can loop through the arguments.
+                _.Alt_a, CheckThat(() => AssertScreenIs(1,
+                    TokenClassification.Command, "az",
+                    TokenClassification.None, ' ',
+                    TokenClassification.Selection, "webapp",
+                    TokenClassification.None, ' ',
+                    TokenClassification.Parameter, "--name",
+                    TokenClassification.None, " MyWebApp ",
+                    TokenClassification.Parameter, "--resource-group",
+                    TokenClassification.None, " MyResourceGroup ")),
+
+                _.Escape));
+        }
+
+        [SkippableFact]
         public void SelectCommandArgument_HereStringArgs()
         {
             TestSetup(KeyMode.Cmd);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3992

Update `SelectCommandArgument` to properly handle POSIX style options for CLI commands.
The CLI options like `--resource-group` will be treated as parameter after this change.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4016)