### PR TITLE
MenuComplete: Streamline tab completion on open menus in Filesystem providers

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -956,7 +956,9 @@ namespace Microsoft.PowerShell
                     if (unambiguousText.Length > 0 && userComplPos >= 0 &&
                         unambiguousText.Length > (userComplPos + userCompletionText.Length))
                     {
+                        // Obtain all the menu items beginning with unambigousText, so we can count them.
                         var unambiguousMenuItems = menu.MenuItems.Where(item => item.CompletionText.StartsWith(unambiguousText));
+                        // If there is only 1 item, and it is a container, then complete it and append the directory separator.
                         if ( Enumerable.Count(unambiguousMenuItems) == 1 )
                         {
                             processingKeys = false;
@@ -975,6 +977,7 @@ namespace Microsoft.PowerShell
                                 userCompletionText = GetUnquotedText(onlyResult, consistentQuoting: false);
                             }
                             _current -= cursorAdjustment;
+                            // If Tabbing into a container (directory), then repeat tab for a menu on its contents (faster navigation).
                             PrependQueuedKeys(nextKey);
                         }
                         else

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -957,7 +957,7 @@ namespace Microsoft.PowerShell
                         unambiguousText.Length > (userComplPos + userCompletionText.Length))
                     {
                         var unambiguousMenuItems = menu.MenuItems.Where(item => item.CompletionText.StartsWith(unambiguousText));
-                        if ( Enumerator.Count(unambiguousMenuItems) == 1 )
+                        if ( Enumerable.Count(unambiguousMenuItems) == 1 )
                         {
                             bool prependNextKey = false;
                             int cursorAdjustment = 0;

--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -959,15 +959,10 @@ namespace Microsoft.PowerShell
                         var unambiguousMenuItems = menu.MenuItems.Where(item => item.CompletionText.StartsWith(unambiguousText));
                         if ( Enumerable.Count(unambiguousMenuItems) == 1 )
                         {
-                            bool prependNextKey = false;
-                            int cursorAdjustment = 0;
                             processingKeys = false;
-
+                            int cursorAdjustment = 0;
                             var onlyResult = unambiguousMenuItems.First();
-                            userCompletionText = onlyResult.CompletionText;
-                            _current = userCompletionText.Length;
-
-                            ExchangePointAndMark(); // cursor to the end of Completion
+                            _current = onlyResult.CompletionText.Length;
 
                             if (onlyResult.ResultType == CompletionResultType.ProviderContainer)
                             {
@@ -979,16 +974,6 @@ namespace Microsoft.PowerShell
                             {
                                 userCompletionText = GetUnquotedText(onlyResult, consistentQuoting: false);
                             }
-                            
-                            // do not append the same char as last char in CompletionText (works for '(', '\')
-                            prependNextKey = userCompletionText[userCompletionText.Length - 1] != nextKey.KeyChar;
-                            _visualSelectionCommandCount = 0;
-                            // if mark was set after cursor, it restored in uninspected position, because text before mark now longer
-                            // should we correct it ? I think not, beause any other text insertion does not correct it
-                            _mark = savedUserMark;
-                    
-                            // without render all key chords that just move cursor leave selection visible, but it can be wrong
-                            Render();
                             _current -= cursorAdjustment;
                             PrependQueuedKeys(nextKey);
                         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Updated tab completion when using the function MenuComplete on a FilesystemProvider (or similar provider with Containers) to append the directory separator and step into the directory, if and only if it is a container and the only remaining menu option.

This reduces the need for MenuComplete users to constantly alternate between tab and enter (or /) to move through filesystem providers, similar to how quickly non-menu navigation can be.

## Description

Currently, when using MenuComplete in, e.g., a filesystem provider with containers, such as when performing basic navigation with `cd` of the filesystem, a common scenario the user encounters is:

1. Press Tab to open the menu and see which items are available.
2. Type a few characters (and/or further Tab presses) to break any ambiguities
3. Press Tab to complete the remaining unambiguous word
4. Press / (optionally backslash on windows) or enter to access the directory
5. Press tab again to see this next directory's items

With this PR, the above steps become:

1. Press Tab to open the menu.
2. Type a few characters (and/or press Tab) to break any ambiguities
3. Press Tab to complete the remaining unambiguous word, and if it is a container, add the / automatically, and open the menu on the next level of files

## Reproducibility

This can be easily reproduced/tested inside the PSReadLine module folder. There are 2 folders which begin with "p." Pressing "cd P", then tab, then "s", then Tab will only complete to "PSReadLine". With this PR, it will complete to "PSReadLine/" and open the menu of the next level. This greatly accelerates tab navigation of file systems when using MenuComplete.

Tested MenuComplete functionality works for Containers, and doesn't impact, e.g., commands.
Tested on PS 7.4.2 and PS 5.1.19041

<!-- Summarize your PR between here and the checklist. -->

## PR Checklist

- [ ] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [ ] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4036)