### PR TITLE
MenuComplete: Improve tab completion in Filesystem providers

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -977,7 +977,7 @@ namespace Microsoft.PowerShell
                         // Autoaccepts the single available option (otherwise need to press rightarrow/tab a second time manually)
                         PrependQueuedKeys(Keys.RightArrow);
                     }
-                    // For multiple items which are shorter length than the unambiguous text, autocomplete through the unambiguous text.
+                    // For multiple items, when your typed length is shorter length than the unambiguous text, autocomplete through the unambiguous text.
                     else if (unambiguousText.Length > 0 && userComplPos >= 0 &&
                         unambiguousText.Length > (userComplPos + userCompletionText.Length))
                     {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR aims to improve the tab completion experience when using the MenuComplete function in filesystem providers (or analogous providers). It targets 2 bugs and streamlines inconsistent behavior in a 3rd QoL issue.

These are:

1. Pressing `Spacebar` on a path containing whitespace will incorrectly autocomplete a single path in spite of multiple ambiguous paths existing.
2. `Tab` fails to complete containers (directories) when their full name is manually typed out (or backspaced into) when a menu is open.
3. Inconsistent / tedious behavior when autcompleting a single, unambiguous container within the menu.

## Description / Reproduction
1.   On Windows, type `cd C:/program` and press `Tab`.  You'll have something like these options: 
 * Program Files
 * Program Files (x86)
 * ProgramData
    If you try to press `SpaceBar` in order to exclude ProgramData, you will instead autocomplete `Program Files` and enter its directory, even though `Program Files (x86)` would have also been viable at that point.
    => Fixed so that pressing `Spacebar` in this context does not autocomplete the entire word.

2. Pressing `Tab` can fail to complete containers (directories) when manually typed out in a menu.
    Type `cd C:/` and press `Tab` to open a menu.
    Type `usr` and press `Tab`.
    You will have `cd C:/usr/` open, but the final `/` is a suggestion, and no further presses of tab will complete this slash.
    => Fixed so that manually typing a directory name and pressing `Tab` will complete it including the directory separator.

3. Inconsistent / tedious behavior when autocompleting a single, unambiguous container within the menu.
    Navigate to the PSReadLine module home directory. There are 2 folders here that begin with "P", Polyfill and PSReadLine.
    First, type `cd PS` and press tab. You will correctly complete to `cd .\PSReadline\`. This is because a menu was avoided.
    Instead, try typing `cd P` and then `Tab`. This will open a menu. Type `s` followed by `Tab`. You will end up stuck before the directory separator character (similar to bug 2 but for a different reason).
    => This has been made consistent, so that an open menu will complete the same as no menu. This is also a QoL fix that streamlines using a menu, making it faster to tab through nested directories when navigating the filesystem. Ideally this would make `MenuComplete` as quick to use as function `Complete` while retaining the benefit of offering a menu.

All of the fixes are localized in one region of the code, except the first fix, which is on line 774.

## Miscellaneous

As this is my first time contributing, please let me know if there's anything I should consider in my PR. I'm also happy to engage in any discussion.

Tested `MenuComplete` functionality works for Containers, and doesn't impact, e.g., commands.
Tested on Windows 10 with PS 7.4.2 and PS 5.1.19041.

## PR Checklist

- [ ] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [ ] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4038)