### PR TITLE
Change the NuGet feed to use the governed powershell feed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="PowerShell_PublicPackages" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -339,3 +339,26 @@ function Test-XUnitTestResults
         throw "$($failedTests.failed) tests failed"
     }
 }
+
+<#
+.SYNOPSIS
+    Run 'dotnet restore' for all the target runtime that we are interested in to
+    update packages on the CFS feed.
+    This needs to be run on a MS employee's dev machine whenever there is update
+    to the NuGet packages used in PSReadLine repo, so that the package and all its
+    dependencies can be pull into the CFS feed from upstream feed.
+#>
+function Update-CFSFeed
+{
+    $rids = @('win-x64', 'win-arm64', 'linux-x64', 'linux-arm', 'linux-arm64', 'osx-x64', 'osx-arm64')
+
+    Write-Host "1. clear all NuGet caches on the local machine." -ForegroundColor Green
+    dotnet nuget locals all -c
+
+    Write-Host "2. restore for target runtimes." -ForegroundColor Green
+    foreach ($rid in $rids) {
+        Write-Host "  - $rid" -ForegroundColor Green
+        dotnet restore -r $rid ../test/PSReadLine.Tests.csproj
+        dotnet restore -r $rid ../MockPSConsole/MockPSConsole.csproj
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Change the NuGet feed to use the governed PowerShell feed. This is a security requirement from Microsoft.
The function `Update-CFSFeed` is added to `helper.psm1`. Whenever we update the NuGet package, we need to run this function on an MS employee's dev machine to update the PowerShell feed.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4044)