### PR TITLE
Add `ob_restore_phase` for every task before the signing task to work around signing issue

### DIFF
--- a/.pipelines/PSReadLine-Official.yml
+++ b/.pipelines/PSReadLine-Official.yml
@@ -201,9 +201,13 @@ extends:
           type: windows
         steps:
         - checkout: self
+          env:
+            ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
 
         - task: DownloadPipelineArtifact@2
           displayName: 'Download build files'
+          env:
+            ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
           inputs:
             targetPath: $(signOutPath)
             artifact: drop_buildstage_buildjob
@@ -212,6 +216,8 @@ extends:
             Get-ChildItem $(signOutPath) -Recurse
             New-Item -Path $(nugetPath) -ItemType Directory > $null
           displayName: Capture artifacts structure
+          env:
+            ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
 
         - pwsh: |
             try {
@@ -223,6 +229,8 @@ extends:
             }
             Get-ChildItem -Path $(nugetPath)
           displayName: 'Create the NuGet package'
+          env:
+            ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
 
         - task: onebranch.pipeline.signing@1
           displayName: Sign nupkg


### PR DESCRIPTION
## PR Summary

Add `ob_restore_phase` for every task before the signing task to work around signing issue.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4046)