### PR TITLE
Update the OneBranch pipeline to keep it compliant and remove SBOM files from module

### DIFF
--- a/.pipelines/PSReadLine-Official.yml
+++ b/.pipelines/PSReadLine-Official.yml
@@ -15,21 +15,22 @@ pr: none
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   POWERSHELL_TELEMETRY_OPTOUT: 1
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: 1
   WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
 
 resources:
   repositories:
-  - repository: onebranchTemplates
-    type: git
-    name: OneBranch.Pipelines/GovernedTemplates
-    ref: refs/heads/main
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
 
 extends:
-  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
+  template: v2/OneBranch.Official.CrossPlat.yml@templates
   parameters:
     featureFlags:
-      WindowsHostVersion: '1ESWindows2022'
+      WindowsHostVersion:
+        Version: 2022
     globalSdl:
       disableLegacyManifest: true
       cg: # Component Governance parameters. Ignore test components.
@@ -43,7 +44,7 @@ extends:
           enabled: true
       asyncSdl: # https://aka.ms/obpipelines/asyncsdl
         enabled: true
-        forStages: [Build]
+        forStages: [buildstage]
         credscan:
           enabled: true
           scanFolder: $(Build.SourcesDirectory)\PSReadLine\PSReadLine
@@ -154,7 +155,7 @@ extends:
             }
 
             Write-Host "Display files in the folder ..." -ForegroundColor Yellow
-            Get-ChildItem -Path $(signSrcPath) -Recurse | Out-String -Width 120
+            Get-ChildItem -Path $(signSrcPath) -Recurse | Out-String -Width 120 -Stream
           displayName: 'Verify the signed files'
 
         - task: CopyFiles@2
@@ -212,7 +213,11 @@ extends:
             artifact: drop_buildstage_buildjob
 
         - pwsh: |
-            Get-ChildItem $(signOutPath) -Recurse
+            if (Test-Path '$(signOutPath)\_manifest') {
+              Write-Verbose -Verbose "Delete SBOM files ..."
+              Remove-Item -Path '$(signOutPath)\_manifest' -Recurse -Force
+            }
+            Get-ChildItem $(signOutPath) -Recurse | Out-String -Width 120 -Stream
             New-Item -Path $(nugetPath) -ItemType Directory > $null
           displayName: Capture artifacts structure
           env:
@@ -226,7 +231,7 @@ extends:
             } finally {
               Unregister-PSRepository -Name $RepoName -ErrorAction SilentlyContinue
             }
-            Get-ChildItem -Path $(nugetPath)
+            Get-ChildItem -Path $(nugetPath) | Out-String -Width 120 -Stream
           displayName: 'Create the NuGet package'
           env:
             ob_restore_phase: true # This ensures this done in restore phase to workaround signing issue
@@ -290,7 +295,7 @@ extends:
             artifact: drop_buildstage_nupkg
 
         - pwsh: |
-            Get-ChildItem $(nugetPath) -Recurse
+            Get-ChildItem $(nugetPath) -Recurse | Out-String -Width 120 -Stream
           displayName: Find signed Nupkg
 
         - task: NuGetCommand@2

--- a/.pipelines/PSReadLine-Official.yml
+++ b/.pipelines/PSReadLine-Official.yml
@@ -299,14 +299,6 @@ extends:
           displayName: Find signed Nupkg
 
         - task: NuGetCommand@2
-          displayName: Push PSReadLine module to Azure feed
-          inputs:
-            command: push
-            packagesToPush: $(nugetPath)\PSReadLine.*.nupkg
-            nuGetFeedType: external
-            publishFeedCredentials: AzArtifactsFeed
-
-        - task: NuGetCommand@2
           displayName: Push PSReadLine module to PSGallery feed
           inputs:
             command: push

--- a/MockPSConsole/MockPSConsole.csproj
+++ b/MockPSConsole/MockPSConsole.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.18" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.18" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Polyfill/Polyfill.csproj
+++ b/Polyfill/Polyfill.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.18" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.23" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.18" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/helper.psm1
+++ b/tools/helper.psm1
@@ -1,5 +1,5 @@
 
-$MinimalSDKVersion = '6.0.100'
+$MinimalSDKVersion = '6.0.425'
 $IsWindowsEnv = [System.Environment]::OSVersion.Platform -eq "Win32NT"
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $LocalDotnetDirPath = if ($IsWindowsEnv) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

1. Update to the latest 7.2.23 version of PowerShell SDK packages
2. Remove SBOM files from the module folder
3. Update the minimum .NET SDK version used for the build
4. Stop releasing module to the Azure feed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4201)