### PR TITLE
Move the v2.3.6 changelog to GitHub

### DIFF
--- a/PSReadLine/Changes.txt
+++ b/PSReadLine/Changes.txt
@@ -16,6 +16,18 @@
 
 [2.4.0-beta0]: https://github.com/PowerShell/PSReadLine/compare/v2.3.4...v2.4.0-beta0
 
+### [2.3.6] - 2024-10-02
+
+This is a servicing release that excludes SBOM files from the module.
+
+- Update the OneBranch pipeline to keep it compliant and remove SBOM files from module (#4201)
+- Make sure the `CodeQL` result from release pipeline gets uploaded (#4082)
+- Add 'ob_restore_phase' for every task before the signing task to work around the signing issue (#4046)
+- Change the NuGet feed to use the governed PowerShell feed (#4044)
+- Disable SBOM, signing, and codeQL for the publish job (#3986)
+
+[2.3.6]: https://github.com/PowerShell/PSReadLine/compare/v2.3.5...v2.3.6
+
 ### [2.3.5] - 2024-04-02
 
 This is a servicing release that excludes test components from SBOM generation.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Move the v2.3.6 changelog to GitHub
This is a servicing release to exclude SBOM files from the module to avoid false positive security vulnerability report.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4202)