### PR TITLE
[vi-mode] Supports `_` (void) and `+` (system clipboard) named registers for copying and pasting.

### DIFF
--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -313,6 +313,8 @@ namespace Microsoft.PowerShell
 
             _viChordDQuoteTable = new Dictionary<PSKeyInfo, KeyHandler>
             {
+                { Keys.DQuote,          MakeKeyHandler( ViSelectNamedRegister, "ViSelectNamedRegister" ) },
+                { Keys.Plus,            MakeKeyHandler( ViSelectNamedRegister, "ViSelectNamedRegister" ) },
                 { Keys.Underbar,        MakeKeyHandler( ViSelectNamedRegister, "ViSelectNamedRegister" ) },
             };
 

--- a/PSReadLine/KeyBindings.vi.cs
+++ b/PSReadLine/KeyBindings.vi.cs
@@ -44,6 +44,7 @@ namespace Microsoft.PowerShell
         private static Dictionary<PSKeyInfo, KeyHandler> _viChordCTable;
         private static Dictionary<PSKeyInfo, KeyHandler> _viChordYTable;
         private static Dictionary<PSKeyInfo, KeyHandler> _viChordDGTable;
+        private static Dictionary<PSKeyInfo, KeyHandler> _viChordDQuoteTable;
 
         private static Dictionary<PSKeyInfo, KeyHandler> _viChordTextObjectsTable;
 
@@ -218,6 +219,7 @@ namespace Microsoft.PowerShell
                 { Keys.Comma,           MakeKeyHandler(RepeatLastCharSearchBackwards, "RepeatLastCharSearchBackwards") },
                 { Keys.AltH,            MakeKeyHandler(ShowParameterHelp,     "ShowParameterHelp") },
                 { Keys.F1,              MakeKeyHandler(ShowCommandHelp,       "ShowCommandHelp") },
+                { Keys.DQuote,          MakeKeyHandler(ViChord,               "ChordFirstKey") },
             };
 
             // Some bindings are not available on certain platforms
@@ -309,6 +311,11 @@ namespace Microsoft.PowerShell
                 { Keys.G,               MakeKeyHandler( DeleteRelativeLines,   "DeleteRelativeLines") },
             };
 
+            _viChordDQuoteTable = new Dictionary<PSKeyInfo, KeyHandler>
+            {
+                { Keys.Underbar,        MakeKeyHandler( ViSelectNamedRegister, "ViSelectNamedRegister" ) },
+            };
+
             _viCmdChordTable = new Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>>();
             _viInsChordTable = new Dictionary<PSKeyInfo, Dictionary<PSKeyInfo, KeyHandler>>();
 
@@ -318,6 +325,7 @@ namespace Microsoft.PowerShell
             _viCmdChordTable[Keys.D] = _viChordDTable;
             _viCmdChordTable[Keys.C] = _viChordCTable;
             _viCmdChordTable[Keys.Y] = _viChordYTable;
+            _viCmdChordTable[Keys.DQuote] = _viChordDQuoteTable;
 
             _normalCursorSize = _console.CursorSize;
             if ((_normalCursorSize < 1) || (_normalCursorSize > 100))

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -653,7 +653,14 @@ namespace Microsoft.PowerShell
             _registers = new Dictionary<string, ViRegister> {
                 [""] = new ViRegister(_singleton, new InMemoryClipboard()),
                 ["_"] = new ViRegister(_singleton, new NoOpClipboard()),
+                ["\""] = new ViRegister(_singleton, new SystemClipboard()),
             };
+
+            // '+' and '"' are synonyms
+
+            _registers["+"] = _registers["\""];
+
+            // default register is the unnamed local register
 
             _viRegister = _registers[""];
 

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -649,7 +649,14 @@ namespace Microsoft.PowerShell
         static PSConsoleReadLine()
         {
             _singleton = new PSConsoleReadLine();
-            _viRegister = new ViRegister(_singleton);
+
+            _registers = new Dictionary<string, ViRegister> {
+                [""] = new ViRegister(_singleton, new InMemoryClipboard()),
+                ["_"] = new ViRegister(_singleton, new NoOpClipboard()),
+            };
+
+            _viRegister = _registers[""];
+
             InitializePropertyInfo();
         }
 

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -5,7 +5,6 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Security.Cryptography.Pkcs;
 
 namespace Microsoft.PowerShell
 {

--- a/PSReadLine/ReadLine.vi.cs
+++ b/PSReadLine/ReadLine.vi.cs
@@ -5,6 +5,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Security.Cryptography.Pkcs;
 
 namespace Microsoft.PowerShell
 {
@@ -445,6 +446,7 @@ namespace Microsoft.PowerShell
             _singleton._dispatchTable = _viCmdKeyMap;
             _singleton._chordDispatchTable = _viCmdChordTable;
             ViBackwardChar();
+            ViSelectNamedRegister("");
             _singleton.ViIndicateCommandMode();
         }
 
@@ -752,7 +754,7 @@ namespace Microsoft.PowerShell
 
             var deleteText = _singleton._buffer.ToString(range.Offset, range.Count);
 
-            _viRegister.LinewiseRecord(deleteText);
+            _singleton.SaveLinesToClipboard(deleteText);
 
             var deletePosition = range.Offset;
             var anchor = _singleton._current;
@@ -1154,6 +1156,16 @@ namespace Microsoft.PowerShell
             }
 
             ViChordHandler(_viChordDGTable, arg);
+        }
+
+        private static void ViDQuoteChord(ConsoleKeyInfo? key = null, object arg = null)
+        {
+            if (!key.HasValue)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            ViChordHandler(_viChordDQuoteTable, arg);
         }
 
         private static bool IsNumeric(PSKeyInfo key)

--- a/PSReadLine/ViRegister.cs
+++ b/PSReadLine/ViRegister.cs
@@ -44,6 +44,18 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
+        /// Represents the system clipboard.
+        /// </summary>
+        internal sealed class SystemClipboard : IClipboard
+        {
+            public string GetText()
+                => Internal.Clipboard.GetText();
+
+            public void SetText(string text)
+                => Internal.Clipboard.SetText(text);
+        }
+
+        /// <summary>
         /// Represents a named register.
         /// </summary>
         internal sealed class ViRegister

--- a/test/YankPasteTest.VI.cs
+++ b/test/YankPasteTest.VI.cs
@@ -584,5 +584,18 @@ namespace Test
                 "2dd", 'P', CheckThat(() => AssertCursorLeftTopIs(0, 0))
                 ));
         }
+
+        [SkippableFact]
+        public void ViYankToBlackHoleRegister()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Test("text\n", Keys(
+                "text", _.Escape, "dd",
+                "iline", _.Escape,
+                "\"_dd", CheckThat(() => AssertLineIs("")),
+                "P", CheckThat(() => AssertLineIs("text\n"))
+                ));
+        }
     }
 }

--- a/test/YankPasteTest.VI.cs
+++ b/test/YankPasteTest.VI.cs
@@ -1,4 +1,5 @@
 using Microsoft.PowerShell;
+using Microsoft.PowerShell.Internal;
 using Xunit;
 
 namespace Test
@@ -597,5 +598,45 @@ namespace Test
                 "P", CheckThat(() => AssertLineIs("text\n"))
                 ));
         }
+
+        [SkippableFact]
+        public void ViYankToSystemClipboard()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Clipboard.SetText("some text");
+
+            Test("text\n", Keys(
+                "text", _.Escape, "dd",
+                "iline", _.Escape,
+                "\"+dd", CheckThat(() => AssertLineIs("")),
+                "P", CheckThat(() => AssertLineIs("text\n"))
+                ));
+
+            // ensure text ends up in the system clipboard
+
+            var text = Clipboard.GetText();
+            Assert.Equal("line", text);
+        }
+
+        [SkippableFact]
+        public void ViYankToInternalClipboard()
+        {
+            TestSetup(KeyMode.Vi);
+
+            Clipboard.SetText("some text");
+
+            Test("line\n", Keys(
+                "text", _.Escape, "dd",
+                "iline", _.Escape,
+                "dd", CheckThat(() => AssertLineIs("")),
+                "P", CheckThat(() => AssertLineIs("line\n"))
+                ));
+
+            // ensure the system clipboard was not affected
+            var text = Clipboard.GetText();
+            Assert.Equal("some text", text);
+        }
+
     }
 }


### PR DESCRIPTION
# PR Summary

This PR builds upon the existing support for [Vi Registers](https://github.com/PowerShell/PSReadLine/blob/master/PSReadLine/ViRegister.cs) and now supports two new named registers:

- Vi Register `_` (underscore) supports copying text into the "black hole" register. That text is lost forever and is not copied to the internal builtin clipboard.
- Vi Register `+` (plus sign) or `"` (double-quote) supports copying text to, and pasting text from the operating system host’s system clipboard. Copied text does not end up in the internal builtin clipboard which stays unaffected.

This PR is a follow up on design discussions that happened in #3769.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4220)