### PR TITLE
Update HelpInfoUri for 7.5

### DIFF
--- a/PSReadLine/PSReadLine.psd1
+++ b/PSReadLine/PSReadLine.psd1
@@ -15,5 +15,5 @@ AliasesToExport = @()
 FunctionsToExport = 'PSConsoleHostReadLine'
 CmdletsToExport = 'Get-PSReadLineKeyHandler','Set-PSReadLineKeyHandler','Remove-PSReadLineKeyHandler',
                   'Get-PSReadLineOption','Set-PSReadLineOption'
-HelpInfoURI = 'https://aka.ms/powershell72-help'
+HelpInfoURI = 'https://aka.ms/powershell75-help'
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR changes the AKA.MS links used for HelpInfoUri to point to the 7.5 version of the documentation.

This change needs to be backported to the v2.3.x version that will ship in PowerShell 7.5 GA. 

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4284)