### PR TITLE
Add a consistent handler for accepting suggestions and editing lines word-by-word to `Ctrl+RightArrow` in Windows mode

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -186,7 +186,7 @@ namespace Microsoft.PowerShell
                 { Keys.LeftArrow,              MakeKeyHandler(BackwardChar,              "BackwardChar") },
                 { Keys.RightArrow,             MakeKeyHandler(ForwardChar,               "ForwardChar") },
                 { Keys.CtrlLeftArrow,          MakeKeyHandler(BackwardWord,              "BackwardWord") },
-                { Keys.CtrlRightArrow,         MakeKeyHandler(NextWord,                  "NextWord") },
+                { Keys.CtrlRightArrow,         MakeKeyHandler(ForwardWord,               "ForwardWord") },
                 { Keys.ShiftLeftArrow,         MakeKeyHandler(SelectBackwardChar,        "SelectBackwardChar") },
                 { Keys.ShiftRightArrow,        MakeKeyHandler(SelectForwardChar,         "SelectForwardChar") },
                 { Keys.CtrlShiftLeftArrow,     MakeKeyHandler(SelectBackwardWord,        "SelectBackwardWord") },

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -604,6 +604,19 @@ Set-PSReadLineKeyHandler -Key RightArrow `
     }
 }
 
+# `NextWord` does not operate on the suggestion text when the cursor is at the end of the line.
+# This custom binding is an alternative to the other custom binding `ForwardCharAndAcceptNextSuggestionWord`.
+# Besides moving the cursor forward in the current editing line to the end of the current word, or if between words, to the end of the next word,
+# this custom binding causes `Ctrl+RightArrow` to also accept the next word in the suggestion text.
+Set-PSReadLineKeyHandler -Key "Ctrl+RightArrow" `
+                         -BriefDescription ForwardWordAndAcceptNextSuggestionWord `
+                         -LongDescription "Move the cursor forward to the end of the current word, or if between words, to the end of the next word, and accept the next word in suggestion when it's at the end of the current editing line." `
+                         -ScriptBlock {
+    param($key, $arg)
+
+    [Microsoft.PowerShell.PSConsoleReadLine]::ForwardWord($key, $arg)
+}
+
 # Cycle through arguments on current line and select the text. This makes it easier to quickly change the argument if re-running a previously run command from the history
 # or if using a psreadline predictor. You can also use a digit argument to specify which argument you want to select, i.e. Alt+1, Alt+a selects the first argument
 # on the command line.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

- Set default key binding for consistent use of `Ctrl+RightArrow` in Windows
- Bind handler `ForwardWord` to `Ctrl+RightArrow` key
- Keep consistency between line editing and suggestion acceptance
- `Ctrl+RightArrow` moves the cursor to the end of a word in both the edited line and the suggested text
- Behaviour similar to `Alt+F` key binding in Emacs mode
- Example video : [https://youtu.be/HJKplt3bktY](https://youtu.be/HJKplt3bktY)

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4285)