### PR TITLE
Update documentation for consistency with the build parameters implementation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -76,10 +76,10 @@ The build script `build.ps1` can be used to bootstrap, build and test the projec
 * Bootstrap: `./build.ps1 -Bootstrap`
 * Build:
     * Targeting .NET 4.6.2 (Windows only): `./build.ps1 -Configuration Debug -Framework net462`
-    * Targeting .NET Core: `./build.ps1 -Configuration Debug -Framework netcoreapp2.1`
+    * Targeting .NET Core: `./build.ps1 -Configuration Debug -Framework net6.0`
 * Test:
     * Targeting .NET 4.6.2 (Windows only): `./build.ps1 -Test -Configuration Debug -Framework net462`
-    * Targeting .NET Core: `./build.ps1 -Test -Configuration Debug -Framework netcoreapp2.1`
+    * Targeting .NET Core: `./build.ps1 -Test -Configuration Debug -Framework net6.0`
 
 After build, the produced artifacts can be found at `<your-local-repo-root>/bin/Debug`.
 

--- a/README.md
+++ b/README.md
@@ -234,10 +234,10 @@ The build script `build.ps1` can be used to bootstrap, build and test the projec
 * Bootstrap: `./build.ps1 -Bootstrap`
 * Build:
     * Targeting .NET 4.6.2 (Windows only): `./build.ps1 -Configuration Debug -Framework net462`
-    * Targeting .NET Core: `./build.ps1 -Configuration Debug -Framework netcoreapp2.1`
+    * Targeting .NET Core: `./build.ps1 -Configuration Debug -Framework net6.0`
 * Test:
     * Targeting .NET 4.6.2 (Windows only): `./build.ps1 -Test -Configuration Debug -Framework net462`
-    * Targeting .NET Core: `./build.ps1 -Test -Configuration Debug -Framework netcoreapp2.1`
+    * Targeting .NET Core: `./build.ps1 -Test -Configuration Debug -Framework net6.0`
 
 After build, the produced artifacts can be found at `<your-local-repo-root>/bin/Debug`.
 In order to isolate your imported module to the one locally built, be sure to run 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

- Remove misleading parameter values from Build and Test command documentation
- The valid set of values of the parameter `-Framework` does not contain `netcoreapp2` or `netcoreapp2.1`
- Replace invalid values with `net6.0`

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4286)