### PR TITLE
Add suggestion acceptance to the `NextWord` key handler in Windows

### DIFF
--- a/PSReadLine/Movement.cs
+++ b/PSReadLine/Movement.cs
@@ -266,6 +266,12 @@ namespace Microsoft.PowerShell
                 return;
             }
 
+            if (_singleton._current == _singleton._buffer.Length && numericArg > 0)
+            {
+                AcceptNextSuggestionWord(numericArg);
+                return;
+            }
+            
             if (numericArg < 0)
             {
                 BackwardWord(key, -numericArg);

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -604,6 +604,19 @@ Set-PSReadLineKeyHandler -Key RightArrow `
     }
 }
 
+# `NextWord` does not operate on the suggestion text when the cursor is at the end of the line.
+# This custom binding is an alternative to the other custom binding `ForwardCharAndAcceptNextSuggestionWord`.
+# Besides moving the cursor forward in the current editing line to the end of the current word, or if between words, to the end of the next word,
+# this custom binding causes `Ctrl+RightArrow` to also accept the next word in the suggestion text.
+Set-PSReadLineKeyHandler -Key "Ctrl+RightArrow" `
+                         -BriefDescription ForwardWordAndAcceptNextSuggestionWord `
+                         -LongDescription "Move the cursor forward to the end of the current word, or if between words, to the end of the next word, and accept the next word in suggestion when it's at the end of the current editing line." `
+                         -ScriptBlock {
+    param($key, $arg)
+
+    [Microsoft.PowerShell.PSConsoleReadLine]::ForwardWord($key, $arg)
+}
+
 # Cycle through arguments on current line and select the text. This makes it easier to quickly change the argument if re-running a previously run command from the history
 # or if using a psreadline predictor. You can also use a digit argument to specify which argument you want to select, i.e. Alt+1, Alt+a selects the first argument
 # on the command line.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

- `Ctrl+RightArrow` key handled by `NextWord` can now move the cursor word-by-word while the user is both editing the line and accepting suggestions
- Keep `Nextword` the default handler of `Ctrl+RightArrow` with an additional feature
- The `Ctrl+RightArrow` key is consistent and intuitive for the two operations

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4289)