### PR TITLE
Handle buffer changes made by a handler of the `OnIdle` event

### DIFF
--- a/PSReadLine/PublicAPI.cs
+++ b/PSReadLine/PublicAPI.cs
@@ -92,6 +92,7 @@ namespace Microsoft.PowerShell
         /// <param name="s">String to insert</param>
         public static void Insert(string s)
         {
+            s = s.Replace("\r\n", "\n");
             _singleton.SaveEditItem(EditItemInsertString.Create(s, _singleton._current));
 
             // Use Append if possible because Insert at end makes StringBuilder quite slow.

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -209,9 +209,14 @@ namespace Microsoft.PowerShell
                         bool runPipelineForEventProcessing = false;
                         foreach (var sub in eventSubscribers)
                         {
-                            // If the buffer is not empty, let's not consider we are idle because the user is in the middle of typing something.
-                            if (string.Equals(sub.SourceIdentifier, PSEngineEvent.OnIdle, StringComparison.OrdinalIgnoreCase) && bufferLen is 0)
+                            if (string.Equals(sub.SourceIdentifier, PSEngineEvent.OnIdle, StringComparison.OrdinalIgnoreCase))
                             {
+                                // If the buffer is not empty, let's not consider we are idle because the user is in the middle of typing something.
+                                if (bufferLen > 0)
+                                {
+                                    continue;
+                                }
+
                                 // There is an 'OnIdle' event subscriber and we are idle because we timed out and the buffer is empty.
                                 // Normally PowerShell generates this event, but now PowerShell assumes the engine is not idle because
                                 // it called 'PSConsoleHostReadLine' which isn't returning. So we generate the event instead.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix #3939

Handle buffer changes made by a handler of the `OnIdle` event.
We don't update the initial cursor top when buffer was changed by an event handler.

It requires interaction with PowerShell to test out this change, and thus I cannot add an automation test.

![buffer](https://github.com/user-attachments/assets/d1b87e43-613a-4401-a2d5-5909d370b512)


### PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4442)