### PR TITLE
Avoid querying for cursor position when it's not necessary

### DIFF
--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -220,9 +220,9 @@ namespace Microsoft.PowerShell
 
         private void Render()
         {
-            // If there are a bunch of keys queued up, skip rendering if we've rendered
-            // recently.
-            if (_queuedKeys.Count > 10 && (_lastRenderTime.ElapsedMilliseconds < 50))
+            // If there are a bunch of keys queued up, skip rendering if we've rendered very recently.
+            long elapsedMs = _lastRenderTime.ElapsedMilliseconds;
+            if (_queuedKeys.Count > 10 && elapsedMs < 50)
             {
                 // We won't render, but most likely the tokens will be different, so make
                 // sure we don't use old tokens, also allow garbage to get collected.
@@ -231,6 +231,20 @@ namespace Microsoft.PowerShell
                 _parseErrors = null;
                 _waitingToRender = true;
                 return;
+            }
+
+            // If we've rendered very recently, skip the terminal window resizing check as it's unlikely
+            // to happen in such a short time interval.
+            // We try to avoid unnecessary resizing check because it requires getting the cursor position
+            // which would force a network round trip in an environment where front-end xtermjs talking to
+            // a server-side PTY via websocket. Without querying for cursor position, content written on
+            // the server side could be buffered, which is much more performant.
+            // See the following 2 GitHub issues for more context:
+            //  - https://github.com/PowerShell/PSReadLine/issues/3879#issuecomment-2573996070
+            //  - https://github.com/PowerShell/PowerShell/issues/24696
+            if (elapsedMs < 50)
+            {
+                _handlePotentialResizing = false;
             }
 
             ForceRender();

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -122,6 +122,14 @@ namespace Microsoft.PowerShell
             cursorLeft = console.CursorLeft;
             cursorTop = console.CursorTop;
         }
+
+        public void UpdateConsoleInfo(int bWidth, int bHeight, int cLeft, int cTop)
+        {
+            bufferWidth = bWidth;
+            bufferHeight = bHeight;
+            cursorLeft = cLeft;
+            cursorTop = cTop;
+        }
     }
 
     internal readonly struct RenderDataOffset
@@ -928,7 +936,7 @@ namespace Microsoft.PowerShell
             _console.SetCursorPosition(point.X, point.Y);
             _console.CursorVisible = true;
 
-            _previousRender.UpdateConsoleInfo(_console);
+            _previousRender.UpdateConsoleInfo(bufferWidth, bufferHeight, point.X, point.Y);
             _previousRender.initialY = _initialY;
 
             // TODO: set WindowTop if necessary


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

## PR Summary

Fix #3879

The lagging is due to PSReadLine queries for cursor position for every key stroke even when it's unnecessary.
 
This change avoids querying for cursor position when it's not necessary. Also skip terminal window resizing check when we've rendered very recently (< 50ms), because a window resizing is unlikely to happen in such a short time interval.

The change has been verified by the user: https://github.com/PowerShell/PSReadLine/issues/3879#issuecomment-2596388696

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests. **Cannot add automation test for this change, but it's verified by the user**, see https://github.com/PowerShell/PSReadLine/issues/3879#issuecomment-2596388696
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4448)