### PR TITLE
Update PSReadLine build to target `netstandard2.0`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -65,23 +65,7 @@ Additional references:
 
 ### Bootstrap, Build and Test
 
-To build `PSReadLine` on Windows, Linux, or macOS,
-you must have the following installed:
-
-* .NET Core SDK 2.1.802 or [a newer version](https://www.microsoft.com/net/download)
-* The PowerShell modules `InvokeBuild` and `platyPS`
-
-The build script `build.ps1` can be used to bootstrap, build and test the project.
-
-* Bootstrap: `./build.ps1 -Bootstrap`
-* Build:
-    * Targeting .NET 4.6.2 (Windows only): `./build.ps1 -Configuration Debug -Framework net462`
-    * Targeting .NET Core: `./build.ps1 -Configuration Debug -Framework net6.0`
-* Test:
-    * Targeting .NET 4.6.2 (Windows only): `./build.ps1 -Test -Configuration Debug -Framework net462`
-    * Targeting .NET Core: `./build.ps1 -Test -Configuration Debug -Framework net6.0`
-
-After build, the produced artifacts can be found at `<your-local-repo-root>/bin/Debug`.
+See the [Building](../README.md#building) section in README for details.
 
 ### Submitting Pull Request
 

--- a/.pipelines/PSReadLine-Official.yml
+++ b/.pipelines/PSReadLine-Official.yml
@@ -114,7 +114,7 @@ extends:
         - pwsh: |
             Write-Host "PS Version: $($($PSVersionTable.PSVersion))"
             Set-Location -Path '$(repoRoot)'
-            .\build.ps1 -Configuration Release -Framework net462
+            .\build.ps1 -Configuration Release
           displayName: Build
           env:
             # Set ob_restore_phase to run this step before '🔒 Setup Signing' step.
@@ -166,7 +166,7 @@ extends:
             TargetFolder: $(ob_outputDirectory)
 
         - pwsh: |
-            $versionInfo = Get-Item "$(signSrcPath)\Microsoft.PowerShell.PSReadLine2.dll" | ForEach-Object VersionInfo
+            $versionInfo = Get-Item "$(signSrcPath)\Microsoft.PowerShell.PSReadLine.dll" | ForEach-Object VersionInfo
             $moduleVersion = $versionInfo.ProductVersion.Split('+')[0]
             $vstsCommandString = "vso[task.setvariable variable=ob_sdl_sbom_packageversion]${moduleVersion}"
 

--- a/MockPSConsole/MockPSConsole.csproj
+++ b/MockPSConsole/MockPSConsole.csproj
@@ -4,21 +4,18 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MockPSConsole</RootNamespace>
     <AssemblyName>MockPSConsole</AssemblyName>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <ApplicationManifest>Program.manifest</ApplicationManifest>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="System.Xml.XDocument" version="4.3.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" version="4.5.0" />
-    <PackageReference Include="Microsoft.CSharp" version="4.7.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.23" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.4.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MockPSConsole/MockPSConsole.csproj
+++ b/MockPSConsole/MockPSConsole.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.4.7" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" version="7.2.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/OnImportAndRemove.cs
+++ b/PSReadLine/OnImportAndRemove.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.PSReadLine
             }
 
             string root = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location);
-            string subd = (Environment.Version.Major >= 6) ? "net6plus" : "net462";
+            string subd = (Environment.Version.Major >= 6) ? "net6plus" : "netstd";
             string path = Path.Combine(root, subd, "Microsoft.PowerShell.PSReadLine.Polyfiller.dll");
 
             return Assembly.LoadFrom(path);

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -3,30 +3,23 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.PowerShell.PSReadLine</RootNamespace>
-    <AssemblyName>Microsoft.PowerShell.PSReadLine2</AssemblyName>
+    <AssemblyName>Microsoft.PowerShell.PSReadLine</AssemblyName>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
     <AssemblyVersion>2.4.0.0</AssemblyVersion>
     <FileVersion>2.4.0</FileVersion>
     <InformationalVersion>2.4.0-beta0</InformationalVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <ItemGroup>
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0" />
     <PackageReference Include="Microsoft.CSharp" version="4.7.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
-    <ProjectReference Include="..\Polyfill\Polyfill.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.23" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.PowerShell.Pager" version="1.0.0" />
+    <ProjectReference Include="..\Polyfill\Polyfill.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.psd1
+++ b/PSReadLine/PSReadLine.psd1
@@ -1,6 +1,6 @@
 ﻿@{
 RootModule = 'PSReadLine.psm1'
-NestedModules = @("Microsoft.PowerShell.PSReadLine2.dll")
+NestedModules = @("Microsoft.PowerShell.PSReadLine.dll")
 ModuleVersion = '2.4.0'
 GUID = '5714753b-2afd-4492-a5fd-01d9e2cff8b5'
 Author = 'Microsoft Corporation'

--- a/Polyfill/Polyfill.csproj
+++ b/Polyfill/Polyfill.csproj
@@ -3,19 +3,19 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.PowerShell.PSReadLine.Polyfiller</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.2.23" />
+    <PackageReference Include="System.Management.Automation" Version="7.2.24" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);LEGACY</DefineConstants>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -36,114 +36,33 @@ Some good resources about `PSReadLine`:
 - Ed Wilson (Scripting Guy) wrote a [series](https://devblogs.microsoft.com/scripting/tag/psreadline/) (2014-2015) on `PSReadLine`.
 - John Savill has a [video](https://www.youtube.com/watch?v=Q11sSltuTE0) (2021) covering installation, configuration, and tailoring `PSReadLine` to your liking.
 
-## Installation
+## Installation and Upgrading
 
-There are multiple ways to install `PSReadLine`.
+You will need the `1.6.0` or a higher version of [`PowerShellGet`](https://learn.microsoft.com/en-us/powershell/gallery/powershellget/install-powershellget) to install or upgrade to the latest prerelease version of `PSReadLine`.
 
-### Install from PowerShellGallery (preferred)
-
-You will need the `1.6.0` or a higher version of [`PowerShellGet`](https://learn.microsoft.com/en-us/powershell/gallery/powershellget/install-powershellget) to install the latest prerelease version of `PSReadLine`.
-
-Windows PowerShell 5.1 ships an older version of `PowerShellGet` which doesn't support installing prerelease modules,
-so Windows PowerShell users need to install the latest `PowerShellGet` (if not yet) by running the following commands from an elevated Windows PowerShell session:
+PowerShell 6+ already has a higher version of `PowerShellGet` built-in.
+However, Windows PowerShell 5.1 ships an older version of `PowerShellGet` which doesn't support installing prerelease modules.
+So, Windows PowerShell users need to install the latest `PowerShellGet` (if not yet) by running the following commands from an elevated Windows PowerShell session:
 
 ```powershell
-Install-Module -Name PowerShellGet -Force
-Exit
+Install-Module -Name PowerShellGet -Force; exit
 ```
 
-After installing `PowerShellGet`, you can get the latest prerelease version of `PSReadLine` by running
+After installing `PowerShellGet`, you install or upgrade to the latest prerelease version of `PSReadLine` by running
 
 ```powershell
-Install-Module PSReadLine -AllowPrerelease -Force
+Install-Module PSReadLine -Repository PSGallery -Scope CurrentUser -AllowPrerelease -Force
 ```
 
 If you only want to get the latest stable version, run:
 
 ```powershell
-Install-Module PSReadLine
+Install-Module PSReadLine -Repository PSGallery -Scope CurrentUser -Force
 ```
 
 >[!NOTE] Prerelease versions will have newer features and bug fixes, but may also introduce new issues.
 
-If you are using Windows PowerShell on Windows 10 or using PowerShell 6+, `PSReadLine` is already installed.
-Windows PowerShell on the latest Windows 10 has version `2.0.0-beta2` of `PSReadLine`.
-PowerShell 6+ versions have the newer prerelease versions of `PSReadLine`.
-
-### Install from GitHub (deprecated)
-
-With the preview release of PowerShellGet for PowerShell V3/V4, downloads from GitHub are deprecated.
-We don't intend to update releases on GitHub, and may remove the release entirely from GitHub at some point.
-
-### Post Installation
-
-If you are using Windows PowerShell V5 or V5.1 versions, or using PowerShell 6+ versions, you are good to go and can skip this section.
-
-Otherwise, you need to edit your profile to import the module.
-There are two profile files commonly used and the instructions are slightly different for each.
-The file `C:\Users\[User]\Documents\WindowsPowerShell\profile.ps1` is used for all hosts (e.g. the `ISE` and `powershell.exe`).
-If you already have this file, then you should add the following:
-
-```powershell
-if ($host.Name -eq 'ConsoleHost')
-{
-    Import-Module PSReadLine
-}
-```
-
-Alternatively, the file `C:\Users\[User]\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1` is for `powershell.exe` only.  Using this file, you can simply add:
-
-```powershell
-Import-Module PSReadLine
-```
-
-In either case, you can create the appropriate file if you don't already have one.
-
-## Upgrading
-
-When running one of the suggested commands below, be sure to exit all instances of `powershell.exe`, `pwsh.exe` or `pwsh`,
-including those opened in `VSCode` terminals.
-
-Then, to make sure `PSReadLine` isn't loaded:
-- _if you are on Windows_, run the suggested command below from `cmd.exe`, `powershell_ise.exe`, or via the `Win+R` shortcut;
-- _if you are on Linux/macOS_, run the suggested command below from the default terminal (like `bash` or `zsh`).
-
-
-If you are using the version of `PSReadLine` that ships with Windows PowerShell,
-you need to run: `powershell -noprofile -command "Install-Module PSReadLine -Force -SkipPublisherCheck -AllowPrerelease"`.
-Note: you will need to make sure [PowershellGet is updated](https://github.com/PowerShell/PSReadLine#install-from-powershellgallery-preferred) before running this command.
-
-If you are using the version of `PSReadLine` that ships with PowerShell 6+ versions,
-you need to run: `<path-to-pwsh-executable> -noprofile -command "Install-Module PSReadLine -Force -SkipPublisherCheck -AllowPrerelease"`.
-
-If you've installed `PSReadLine` yourself from the PowerShell Gallery,
-you can simply run: `powershell -noprofile -command "Update-Module PSReadLine -AllowPrerelease"` or
-`<path-to-pwsh-executable> -noprofile -command "Update-Module PSReadLine -AllowPrerelease"`,
-depending on the version of PowerShell you are using.
-
-If you get an error like:
-
-```none
-Remove-Item : Cannot remove item
-C:\Users\{yourName}\Documents\WindowsPowerShell\Modules\PSReadLine\Microsoft.PowerShell.PSReadLine.dll: Access to the path
-'C:\Users\{yourName}\Documents\WindowsPowerShell\Modules\PSReadLine\Microsoft.PowerShell.PSReadLine.dll' is denied.
-```
-
-or a warning like:
-
-```none
-WARNING: The version '2.0.0' of module 'PSReadLine' is currently in use. Retry the operation after closing the applications.
-```
-
-Then you didn't kill all the processes that loaded `PSReadLine`.
-
 ## Usage
-
-To start using, just import the module:
-
-```powershell
-Import-Module PSReadLine
-```
 
 To use Emacs key bindings, you can use:
 
@@ -157,16 +76,19 @@ To view the current key bindings:
 Get-PSReadLineKeyHandler
 ```
 
-There are many configuration options, see the options to `Set-PSReadLineOption`.  `PSReadLine` has help for it's cmdlets as well as an `about_PSReadLine` topic - see those topics for more detailed help.
+There are many configuration options, see the options to `Set-PSReadLineOption`.
+`PSReadLine` has help for its cmdlets as well as an `about_PSReadLine` topic - see those topics for more detailed help.
 
-To set your own custom keybindings, use the cmdlet `Set-PSReadLineKeyHandler`. For example, for a better history experience, try:
+To set your own custom keybindings, use the cmdlet `Set-PSReadLineKeyHandler`.
+For example, for a better history experience, try:
 
 ```powershell
 Set-PSReadLineKeyHandler -Key UpArrow -Function HistorySearchBackward
 Set-PSReadLineKeyHandler -Key DownArrow -Function HistorySearchForward
 ```
 
-With these bindings, up arrow/down arrow will work like PowerShell/cmd if the current command line is blank.  If you've entered some text though, it will search the history for commands that start with the currently entered text.
+With these bindings, up arrow/down arrow will work like PowerShell/cmd if the current command line is blank.
+If you've entered some text though, it will search the history for commands that start with the currently entered text.
 
 To enable bash style completion without using Emacs mode, you can use:
 
@@ -200,7 +122,10 @@ Set-PSReadLineKeyHandler -Chord '"',"'" `
 }
 ```
 
-In this example, when you type a single quote or double quote, there are two things that can happen.  If the character following the cursor is not the quote typed, then a matched pair of quotes is inserted and the cursor is placed inside the the matched quotes.  If the character following the cursor is the quote typed, the cursor is simply moved past the quote without inserting anything.  If you use Resharper or another smart editor, this experience will be familiar.
+In this example, when you type a single quote or double quote, there are two things that can happen.
+If the character following the cursor is not the quote typed, then a matched pair of quotes is inserted and the cursor is placed inside the the matched quotes.
+If the character following the cursor is the quote typed, the cursor is simply moved past the quote without inserting anything.
+If you use `VSCode`, `Resharper`, or another smart editor, this experience will be familiar.
 
 Note that with the handler written this way, it correctly handles Undo - both quotes will be undone with one undo.
 
@@ -211,10 +136,10 @@ See the public methods of `[Microsoft.PowerShell.PSConsoleReadLine]` to see what
 If you want to change the command line in some unimplmented way in your custom key binding, you can use the methods:
 
 ```powershell
-    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState
-    [Microsoft.PowerShell.PSConsoleReadLine]::Insert
-    [Microsoft.PowerShell.PSConsoleReadLine]::Replace
-    [Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition
+[Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState
+[Microsoft.PowerShell.PSConsoleReadLine]::Insert
+[Microsoft.PowerShell.PSConsoleReadLine]::Replace
+[Microsoft.PowerShell.PSConsoleReadLine]::SetCursorPosition
 ```
 
 ## Developing and Contributing
@@ -226,25 +151,22 @@ Please see the [Contribution Guide][] for how to develop and contribute.
 To build `PSReadLine` on Windows, Linux, or macOS,
 you must have the following installed:
 
-* .NET Core SDK 2.1.802 or [a newer version](https://www.microsoft.com/net/download)
+* .NET 6.0 or [a newer version](https://www.microsoft.com/net/download)
 * The PowerShell modules `InvokeBuild` and `platyPS`
 
 The build script `build.ps1` can be used to bootstrap, build and test the project.
 
 * Bootstrap: `./build.ps1 -Bootstrap`
-* Build:
-    * Targeting .NET 4.6.2 (Windows only): `./build.ps1 -Configuration Debug -Framework net462`
-    * Targeting .NET Core: `./build.ps1 -Configuration Debug -Framework net6.0`
+* Build: `./build.ps1 -Configuration Debug`
 * Test:
-    * Targeting .NET 4.6.2 (Windows only): `./build.ps1 -Test -Configuration Debug -Framework net462`
-    * Targeting .NET Core: `./build.ps1 -Test -Configuration Debug -Framework net6.0`
+    * Targeting .NET 4.7.2 (Windows only): `./build.ps1 -Test -Configuration Debug -Framework net472`
+    * Targeting .NET 6.0: `./build.ps1 -Test -Configuration Debug -Framework net6.0`
 
 After build, the produced artifacts can be found at `<your-local-repo-root>/bin/Debug`.
+
 In order to isolate your imported module to the one locally built, be sure to run 
 `pwsh -NonInteractive -NoProfile` to not automatically load the default PSReadLine module installed.
 Then, load the locally built PSReadLine module by `Import-Module <your-local-repo-root>/bin/Debug/PSReadLine/PSReadLine.psd1`.
-
-[Contribution Guide]: https://github.com/PowerShell/PSReadLine/blob/master/.github/CONTRIBUTING.md
 
 ## Change Log
 
@@ -254,8 +176,6 @@ The change log is available [here](https://github.com/PowerShell/PSReadLine/blob
 
 PSReadLine is licensed under the [2-Clause BSD License][].
 
-[2-Clause BSD License]: https://github.com/PowerShell/PSReadLine/blob/master/License.txt
-
 ## Code of Conduct
 
 Please see our [Code of Conduct](.github/CODE_OF_CONDUCT.md) before participating in this project.
@@ -263,3 +183,6 @@ Please see our [Code of Conduct](.github/CODE_OF_CONDUCT.md) before participatin
 ## Security Policy
 
 For any security issues, please see our [Security Policy](.github/SECURITY.md).
+
+[Contribution Guide]: https://github.com/PowerShell/PSReadLine/blob/master/.github/CONTRIBUTING.md
+[2-Clause BSD License]: https://github.com/PowerShell/PSReadLine/blob/master/License.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,10 +17,10 @@ install:
 
 build_script:
   - pwsh: |
-      ./build.ps1 -Configuration Release -Framework net462
+      ./build.ps1 -Configuration Release
 
 test_script:
-  - pwsh: ./build.ps1 -Test -Configuration Release -Framework net462
+  - pwsh: ./build.ps1 -Test -Configuration Release -Framework net472
 
 artifacts:
   - path: .\bin\Release\PSReadLine.zip

--- a/test/PSReadLine.Tests.csproj
+++ b/test/PSReadLine.Tests.csproj
@@ -5,7 +5,7 @@
     <OutputType>library</OutputType>
     <RootNamespace>UnitTestPSReadLine</RootNamespace>
     <AssemblyName>PSReadLine.Tests</AssemblyName>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <IsCodedUITest>False</IsCodedUITest>
@@ -14,28 +14,24 @@
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="System.Xml.XDocument" version="4.3.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" version="4.5.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
-    <PackageReference Include="Microsoft.CSharp" version="4.7.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PowerShellStandard.Library" version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.23" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.24" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="XunitXml.TestLogger" Version="2.1.45" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

By retargeting PSReadLine to `netstandard2.0`, we can simplify the build a lot and produce the same assembly no matter building on Windows or non-Windows.

- Update PSReadLine build to target `netstandard2.0`, including the CI and release pipeline YAML files.
- Update the test to target `net472` and `net6.0`, so that we can run tests with both .NET Framework and .NET
- Rename `Microsoft.PowerShell.PSReadLine2.dll` to `Microsoft.PowerShell.PSReadLine.dll`
- Update and clean up the `README.md` with the up-to-date information

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests **Build changes only**
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4584)