### PR TITLE
Add a private field to indicate if PSReadLine is initialized and ready

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerShell
         #pragma warning restore CS0649
 
         private bool _delayedOneTimeInitCompleted;
+        // This is used by AIShell to check if PSReadLine has done with initialization and ready to render.
         private bool _readLineReady;
 
         private IPSConsoleReadLineMockableMethods _mockableMethods;

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell
         #pragma warning restore CS0649
 
         private bool _delayedOneTimeInitCompleted;
-        // This is used by AIShell to check if PSReadLine has done with initialization and ready to render.
+        // This is used by AIShell to check if PSReadLine is initialized and ready to render.
         private bool _readLineReady;
 
         private IPSConsoleReadLineMockableMethods _mockableMethods;

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerShell
         #pragma warning restore CS0649
 
         private bool _delayedOneTimeInitCompleted;
+        private bool _readLineReady;
 
         private IPSConsoleReadLineMockableMethods _mockableMethods;
         private IConsole _console;
@@ -400,6 +401,7 @@ namespace Microsoft.PowerShell
                         _singleton.Initialize(runspace, engineIntrinsics);
                     }
 
+                    _singleton._readLineReady = true;
                     _singleton._cancelReadCancellationToken = cancellationToken;
                     return _singleton.InputLoop();
                 }
@@ -472,6 +474,8 @@ namespace Microsoft.PowerShell
                 }
                 finally
                 {
+                    _singleton._readLineReady = false;
+
                     try
                     {
                         // If we are closing, restoring the old console settings isn't needed,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When posting code from `AIShell` to PowerShell, we need to know if PSReadLine has finished the initialization that is required for each call to `PSConsoleReadLine.ReadLine(...)`.

This is especially needed when one is calling `Invoke-AIShell -PostCode` from PowerShell to request the generated code to be posted from the `AIShell` side:
- If `PSReadLine` hasn't finishes the initialization, the posted code may be rendered at the wrong row/position (because the new cursor position hasn't been set to `_initialX` and `_initialY`) or even cause exception due to race condition.

The fix is to add a private field to indicate if the initialization per call is done. This doesn't introduce any behavior changes to PSReadLine. Making it a private field means it's not an officially supported scenario, even though a tool like `AIShell` can utilize it.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4706)