### PR TITLE
Allow accepting the current input automatically from within 'OnIdle' event handler

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -294,9 +294,9 @@ namespace Microsoft.PowerShell
                             if (_singleton._inputAccepted && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                             {
                                 // 'AcceptLine' was called by an 'OnIdle' handler.
-                                // In this case, we only want to break out of the loop and accept the current input on Windows,
-                                // because the 'read-key' thread will still be waiting on the 'ReadKey()' call, and that will cause
-                                // all subsequent terminal operations to be blocked on Linux and macOS until a key is pressed.
+                                // In this case, we only want to break out of the loop and accept the current input on Windows, because
+                                // accepting input without a keystroke would leave the 'readkey thread' blocked on the 'ReadKey()' call,
+                                // and that will make all subsequent writes to console blocked on Linux and macOS until a key is pressed.
                                 _singleton._lineAcceptedExceptionThrown = true;
                                 throw new LineAcceptedException();
                             }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

This PR contains changes to allow accepting the current input automatically from within 'OnIdle' event handler. It is used in `AIShell` project to allow an AI agent to run command in the connected PowerShell session with user's permission.

**It's only supported on Windows**, because accepting input without a keystroke would leave the 'readkey thread' blocked on the `_console.ReadKey()` call. On Linux and macOS, that will cause all subsequent writes to console to be blocked until a key is pressed.

With iTerm2 on macOS, a key can be sent to its tab/pane via its Python API server, so `AIShell` can potentially leverage its Python API to make PowerShell accept a command line input. But on Windows, we have to rely on PSReadLine to support this functionality.

### Caveat

On Windows, having the 'readkey thread' blocked on the `_console.ReadKey()` call doesn't affect subsequent writes to console. However, it will cause problem if the accept command involves another `console.Readkey()` call -- the first key pressing will be swallowed by the 'readkey thread' in this case.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4830)