### PR TITLE
Replace `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` with `DOTNET_NOLOGO`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,7 @@ image: Visual Studio 2022
 
 environment:
   POWERSHELL_TELEMETRY_OPTOUT: 1
-  # Avoid expensive initialization of dotnet cli, see: http://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: 1
   PSREADLINE_TESTRUN: 1
 
 cache:


### PR DESCRIPTION
`DOTNET_SKIP_FIRST_TIME_EXPERIENCE` was completely removed in .NET Core 3.0 and `DOTNET_NOLOGO` was reintroduced as its replacement in .NET Core 3.1 to only suppress the First Time Use Experience message.

cc: @daxian-dbw

See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_nologo for details.