### PR TITLE
Fix the input anchor column when the buffer is narrowed and then widened

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -784,6 +784,7 @@ namespace Microsoft.PowerShell
             _parseErrors = null;
             _inputAccepted = false;
             _initialX = _console.CursorLeft;
+            _initialPromptCells = _initialX;
             _initialY = _console.CursorTop;
             _initialForeground = _console.ForegroundColor;
             _initialBackground = _console.BackgroundColor;
@@ -1105,6 +1106,7 @@ namespace Microsoft.PowerShell
 
             console.Write(newPrompt);
             _singleton._initialX = console.CursorLeft;
+            _singleton._initialPromptCells = _singleton._initialX;
             _singleton._initialY = console.CursorTop;
             _singleton._previousRender = _initialPrevRender;
             _singleton._previousRender.UpdateConsoleInfo(console);

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -172,9 +172,11 @@ namespace Microsoft.PowerShell
         /// of the physical line where that logical line starts.
         /// This does not depend on the buffer width, whereas '_initialX' is the column of the same
         /// point at the current buffer width, and hence is only ever this value modulo that width.
-        /// We keep it so that '_initialX' can be recomputed after the buffer width changes: reducing
-        /// '_initialX' in place would discard how many physical lines the prompt spans, and the
-        /// column could then never be recovered when the buffer is made wider again.
+        /// It is what we believe the anchor's column to be after a buffer width change, and it is only
+        /// a belief: it is seeded from '_initialX', so it is itself already reduced whenever 'ReadLine'
+        /// starts on a buffer narrower than the prompt. 'RecomputeInitialCoordsFromCursor' checks it
+        /// against the physical cursor, takes a column the cursor agrees with when it disagrees, and
+        /// falls back to it when the cursor cannot tell the columns apart.
         /// </summary>
         private int _initialPromptCells;
 
@@ -1271,18 +1273,16 @@ namespace Microsoft.PowerShell
                 // The '_buffer' and '_current' still reflects what has been rendered on the screen,
                 // so we can use them to re-calculate the initial coordinates in this case.
 
-                // Recompute X from the prompt's cell width, which doesn't change with the buffer width.
-                // Reducing '_initialX' in place instead gives the same result for the first narrowing,
-                // but loses how many physical lines the prompt spans, so the column could not be
-                // recovered when the buffer is made wider again.
-                _initialX = _initialPromptCells % _console.BufferWidth;
-
-                // Recompute Y from the cursor
-                _initialY = 0;
-                // Calculate the new cursor position when assuming '_initialY' is at line 0.
-                var pt = ConvertOffsetToPoint(_current);
-                // Update '_initialY' based on the difference from the actual current cursor position after the resize.
-                _initialY = _console.CursorTop - pt.Y;
+                // Recompute both coordinates from the cursor. '_buffer' and '_current' say where the
+                // cursor is relative to the initial coordinates, and the console says where the cursor
+                // is on the screen; the difference between the two is the initial coordinates.
+                RecomputeInitialCoordsFromCursor(column =>
+                {
+                    // Put the anchor at 'column' of line 0 and render the input from there.
+                    _initialX = column;
+                    _initialY = 0;
+                    return ConvertOffsetToPoint(_current);
+                });
             }
             else
             {
@@ -1310,24 +1310,98 @@ namespace Microsoft.PowerShell
                     throw new InvalidOperationException(message);
                 }
 
-                // Recompute X from the prompt's cell width, which doesn't change with the buffer width.
-                // Reducing '_initialX' in place instead gives the same result for the first narrowing,
-                // but loses how many physical lines the prompt spans, so the column could not be
-                // recovered when the buffer is made wider again.
-                _initialX = _initialPromptCells % _console.BufferWidth;
-
-                // Recompute Y from the cursor
-                _initialY = 0;
-                // Now, use the new initial coordinates, new buffer width, and the rendering data offset to calculate
-                // the new cursor position when assuming '_initialY' is at line 0.
-                Point pt = ConvertRenderDataOffsetToPoint(_initialX, _initialY, _console.BufferWidth, _previousRender, offset);
-                // Update '_initialY' based on the difference from the actual current cursor position after the resize.
+                // Recompute both coordinates from the cursor, the same way as above, except that the
+                // rendering data offset stands in for '_buffer' and '_current'.
                 // This is based on the assumption that the cursor is still pointing to the same character after resizing,
                 // or at least pointing to the physical line where the same character is located after resizing.
                 // However, that assumption is not always guaranteed in Windows Terminal, see the issue:
                 //    https://github.com/microsoft/terminal/issues/10848, and
                 //    https://github.com/microsoft/terminal/issues/10868
-                _initialY = _console.CursorTop - pt.Y;
+                RecomputeInitialCoordsFromCursor(
+                    column => ConvertRenderDataOffsetToPoint(column, 0, _console.BufferWidth, _previousRender, offset));
+            }
+        }
+
+        /// <summary>
+        /// Recompute the initial coordinates - the cell the edit line is anchored at - after the
+        /// buffer width changed, from where the console now says the cursor is.
+        /// </summary>
+        /// <param name="cursorPointFrom">
+        /// Where the cursor would be drawn if the anchor were at the given column of line 0. That is
+        /// the rendering of the current input, so its distance from the anchor is the display cell
+        /// offset from the anchor to the cursor.
+        /// </param>
+        /// <remarks>
+        /// The anchor cannot be observed after a resize: the terminal reflowed the screen and said
+        /// nothing about where it moved the prompt to. The cursor can be observed, and the terminal
+        /// moved the two together, so the anchor is at the column that would put the cursor where the
+        /// console says the cursor is, and at the row that many physical lines above the cursor's.
+        ///
+        /// With an empty input this makes the anchor the cursor, which is exactly what capturing the
+        /// initial coordinates at the start of 'ReadLine' would have given had 'ReadLine' been entered
+        /// at the new width - including the case where the prompt is wider than the buffer, which is
+        /// the case no arithmetic on '_initialX' can recover, because '_initialX' is by then already
+        /// the prompt's cell width reduced modulo the width it was captured at.
+        ///
+        /// The cursor does not always tell the columns apart. A newline in the input moves the
+        /// rendering to the continuation prompt's column no matter where the anchor is, so once the
+        /// cursor is past one, every column agrees with it; and a double width character pushed whole
+        /// onto the next physical line leaves a cell of slack, so two neighbouring columns can agree.
+        /// '_initialPromptCells' is the belief we already hold about the column, so it is where the
+        /// search starts and the answer whenever the cursor agrees with it - which makes this a strict
+        /// refinement of deriving the column from the prompt's cell width alone, and leaves the
+        /// behaviour of every input the cursor says nothing about unchanged.
+        /// </remarks>
+        private void RecomputeInitialCoordsFromCursor(Func<int, Point> cursorPointFrom)
+        {
+            int bufferWidth = _console.BufferWidth;
+            int cursorLeft = _console.CursorLeft;
+            int cursorTop = _console.CursorTop;
+
+            int believedX = _initialPromptCells % bufferWidth;
+            Point believed = cursorPointFrom(believedX);
+
+            int newX = believedX;
+            int newY = cursorTop - believed.Y;
+
+            if (believed.X != cursorLeft || newY < 0)
+            {
+                // The belief is not consistent with the cursor, so take the nearest column that is.
+                // A cursor above the anchor is not a state we can be in, so a column that implies one
+                // is no more of an answer than a column that puts the cursor elsewhere entirely.
+                for (int delta = 1; delta < bufferWidth; delta++)
+                {
+                    if (TryColumn(believedX - delta) || TryColumn(believedX + delta))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            _initialX = newX;
+            _initialY = newY;
+
+            // '_initialPromptCells' is deliberately left as it is. What it holds over '_initialX' is
+            // how many physical lines the prompt spans at the width it was captured at, and the cursor
+            // never reveals that, so rewriting it here from a column observed at a different width
+            // would mix two units and lose the cases it does answer correctly today.
+
+            bool TryColumn(int column)
+            {
+                if (column < 0 || column >= bufferWidth)
+                {
+                    return false;
+                }
+
+                Point candidate = cursorPointFrom(column);
+                if (candidate.X != cursorLeft || cursorTop < candidate.Y)
+                {
+                    return false;
+                }
+
+                newX = column;
+                newY = cursorTop - candidate.Y;
+                return true;
             }
         }
 

--- a/PSReadLine/Render.cs
+++ b/PSReadLine/Render.cs
@@ -166,6 +166,18 @@ namespace Microsoft.PowerShell
         };
         private int _initialX;
         private int _initialY;
+
+        /// <summary>
+        /// The width, in buffer cells, of the last logical line of the prompt, measured from column 0
+        /// of the physical line where that logical line starts.
+        /// This does not depend on the buffer width, whereas '_initialX' is the column of the same
+        /// point at the current buffer width, and hence is only ever this value modulo that width.
+        /// We keep it so that '_initialX' can be recomputed after the buffer width changes: reducing
+        /// '_initialX' in place would discard how many physical lines the prompt spans, and the
+        /// column could then never be recovered when the buffer is made wider again.
+        /// </summary>
+        private int _initialPromptCells;
+
         private bool _waitingToRender;
         private bool _handlePotentialResizing;
 
@@ -885,6 +897,7 @@ namespace Microsoft.PowerShell
                     }
 
                     _initialX = _console.CursorLeft;
+                    _initialPromptCells = _initialX;
                     _initialY = _console.CursorTop;
                     _previousRender = _initialPrevRender;
                 }
@@ -1244,6 +1257,7 @@ namespace Microsoft.PowerShell
                     }
 
                     _initialX = _console.CursorLeft;
+                    _initialPromptCells = _initialX;
                     _initialY = _console.CursorTop;
                     _previousRender = _initialPrevRender;
                 }
@@ -1257,8 +1271,11 @@ namespace Microsoft.PowerShell
                 // The '_buffer' and '_current' still reflects what has been rendered on the screen,
                 // so we can use them to re-calculate the initial coordinates in this case.
 
-                // Recompute X from the buffer width:
-                _initialX %= _console.BufferWidth;
+                // Recompute X from the prompt's cell width, which doesn't change with the buffer width.
+                // Reducing '_initialX' in place instead gives the same result for the first narrowing,
+                // but loses how many physical lines the prompt spans, so the column could not be
+                // recovered when the buffer is made wider again.
+                _initialX = _initialPromptCells % _console.BufferWidth;
 
                 // Recompute Y from the cursor
                 _initialY = 0;
@@ -1293,8 +1310,11 @@ namespace Microsoft.PowerShell
                     throw new InvalidOperationException(message);
                 }
 
-                // Recompute X from the buffer width:
-                _initialX %= _console.BufferWidth;
+                // Recompute X from the prompt's cell width, which doesn't change with the buffer width.
+                // Reducing '_initialX' in place instead gives the same result for the first narrowing,
+                // but loses how many physical lines the prompt spans, so the column could not be
+                // recovered when the buffer is made wider again.
+                _initialX = _initialPromptCells % _console.BufferWidth;
 
                 // Recompute Y from the cursor
                 _initialY = 0;

--- a/test/ResizingTest.cs
+++ b/test/ResizingTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using Microsoft.PowerShell;
 using Newtonsoft.Json;
 using Xunit;
@@ -180,6 +181,87 @@ namespace Test
                         context.LastLineLen == lastLinelen,
                         $"{test.Name}-context_{i}: calculated physical line count or length of last physical line is not what's expected [count: {lineCount}, lastLen: {lastLinelen}]");
                 }
+            }
+        }
+
+        private static FieldInfo GetInstanceField(string name)
+        {
+            return typeof(PSConsoleReadLine).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        }
+
+        [Fact]
+        public void RecomputeInitialCoords_ShouldRecoverInitialXWhenBufferGetsWider()
+        {
+            // The column of the initial coordinates is the width of the prompt reduced modulo the
+            // buffer width, so a prompt of 36 cells walked through the buffer widths below has to
+            // give 36, 1, 36, 11 and 36 in turn. Reducing the column in place on each change gives
+            // the right answer only for the first one, because it discards how many physical lines
+            // the prompt spans and the column can then no longer be recovered.
+            //
+            // Only the column is checked here. Recovering the row relies on the terminal having
+            // reflowed the screen buffer, which the test console does not do.
+            const int promptCells = 36;
+            const int bufferHeight = 100;
+            int[] bufferWidths = { 100, 35, 60, 25, 100 };
+
+            PSConsoleReadLine instance = GetPSConsoleReadLineSingleton();
+            FieldInfo consoleField = GetInstanceField("_console");
+            FieldInfo bufferField = GetInstanceField("_buffer");
+            FieldInfo currentField = GetInstanceField("_current");
+            FieldInfo initialXField = GetInstanceField("_initialX");
+            FieldInfo initialYField = GetInstanceField("_initialY");
+            FieldInfo initialPromptCellsField = GetInstanceField("_initialPromptCells");
+            FieldInfo previousRenderField = GetInstanceField("_previousRender");
+            FieldInfo handlePotentialResizingField = GetInstanceField("_handlePotentialResizing");
+            MethodInfo recomputeInitialCoords = typeof(PSConsoleReadLine)
+                .GetMethod("RecomputeInitialCoords", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            object savedConsole = consoleField.GetValue(instance);
+            object savedBuffer = bufferField.GetValue(instance);
+            object savedCurrent = currentField.GetValue(instance);
+            object savedPreviousRender = previousRenderField.GetValue(instance);
+
+            try
+            {
+                // An empty input keeps the initial row at 0 throughout, so a plain test console is
+                // all that is needed to report each new buffer width.
+                bufferField.SetValue(instance, new StringBuilder());
+                currentField.SetValue(instance, 0);
+                initialPromptCellsField.SetValue(instance, promptCells);
+                initialXField.SetValue(instance, promptCells % bufferWidths[0]);
+                initialYField.SetValue(instance, 0);
+
+                RenderData previousRender = new()
+                {
+                    lines = new[] { new RenderedLineData(line: "", isFirstLogicalLine: true) }
+                };
+
+                foreach (int bufferWidth in bufferWidths)
+                {
+                    TestConsole console = new(_, bufferWidth, bufferHeight);
+                    consoleField.SetValue(instance, console);
+
+                    previousRender.initialY = (int)initialYField.GetValue(instance);
+                    previousRenderField.SetValue(instance, previousRender);
+                    handlePotentialResizingField.SetValue(instance, true);
+
+                    recomputeInitialCoords.Invoke(instance, new object[] { true });
+
+                    int initialX = (int)initialXField.GetValue(instance);
+                    Assert.True(
+                        promptCells % bufferWidth == initialX,
+                        $"buffer width {bufferWidth}: initial column is {initialX} but should be {promptCells % bufferWidth}");
+
+                    // The render data now describes the buffer as it was before the next change.
+                    previousRender.UpdateConsoleInfo(console);
+                }
+            }
+            finally
+            {
+                consoleField.SetValue(instance, savedConsole);
+                bufferField.SetValue(instance, savedBuffer);
+                currentField.SetValue(instance, savedCurrent);
+                previousRenderField.SetValue(instance, savedPreviousRender);
             }
         }
     }

--- a/test/ResizingTest.cs
+++ b/test/ResizingTest.cs
@@ -189,20 +189,34 @@ namespace Test
             return typeof(PSConsoleReadLine).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
         }
 
-        [Fact]
-        public void RecomputeInitialCoords_ShouldRecoverInitialXWhenBufferGetsWider()
+        /// <summary>
+        /// Drive 'RecomputeInitialCoords' through a chain of buffer widths and check that the anchor
+        /// it recovers at each width is the one the terminal's reflow put on the screen.
+        /// </summary>
+        /// <param name="promptCells">
+        /// The cell width of the prompt's last logical line. The prompt is taken to start at column 0
+        /// of a physical line, so at every buffer width the anchor is at row 'promptCells / width' and
+        /// column 'promptCells % width'. That is the only property of the prompt that matters here.
+        /// </param>
+        /// <param name="input">The input as it stands on the screen when the buffer width changes.</param>
+        /// <param name="cursorOffset">Where '_current' points into that input.</param>
+        /// <param name="bufferWidths">
+        /// The width 'ReadLine' was entered at, followed by the widths the buffer is changed to.
+        /// </param>
+        /// <remarks>
+        /// The cursor the test console reports at each width is the one a terminal that reflowed the
+        /// screen would report: the anchor plus the rendering of the input up to '_current'. The
+        /// rendering is the forward direction of the very calculation under test, which is what makes
+        /// this a test of the inverse - given a rendering and where it ended up on the screen, where
+        /// does the anchor have to be - and not a restatement of it.
+        /// </remarks>
+        private void AssertAnchorIsRecoveredAcrossWidths(
+            int promptCells,
+            string input,
+            int cursorOffset,
+            int[] bufferWidths)
         {
-            // The column of the initial coordinates is the width of the prompt reduced modulo the
-            // buffer width, so a prompt of 36 cells walked through the buffer widths below has to
-            // give 36, 1, 36, 11 and 36 in turn. Reducing the column in place on each change gives
-            // the right answer only for the first one, because it discards how many physical lines
-            // the prompt spans and the column can then no longer be recovered.
-            //
-            // Only the column is checked here. Recovering the row relies on the terminal having
-            // reflowed the screen buffer, which the test console does not do.
-            const int promptCells = 36;
-            const int bufferHeight = 100;
-            int[] bufferWidths = { 100, 35, 60, 25, 100 };
+            const int bufferHeight = 200;
 
             PSConsoleReadLine instance = GetPSConsoleReadLineSingleton();
             FieldInfo consoleField = GetInstanceField("_console");
@@ -219,38 +233,62 @@ namespace Test
             object savedConsole = consoleField.GetValue(instance);
             object savedBuffer = bufferField.GetValue(instance);
             object savedCurrent = currentField.GetValue(instance);
+            object savedInitialX = initialXField.GetValue(instance);
+            object savedInitialY = initialYField.GetValue(instance);
+            object savedInitialPromptCells = initialPromptCellsField.GetValue(instance);
             object savedPreviousRender = previousRenderField.GetValue(instance);
 
             try
             {
-                // An empty input keeps the initial row at 0 throughout, so a plain test console is
-                // all that is needed to report each new buffer width.
-                bufferField.SetValue(instance, new StringBuilder());
-                currentField.SetValue(instance, 0);
-                initialPromptCellsField.SetValue(instance, promptCells);
-                initialXField.SetValue(instance, promptCells % bufferWidths[0]);
-                initialYField.SetValue(instance, 0);
+                bufferField.SetValue(instance, new StringBuilder(input));
+                currentField.SetValue(instance, cursorOffset);
+
+                // What 'ReadLine' captured at the width it was entered at. '_initialX' is the column
+                // the console reported, which is the prompt's cell width reduced modulo that width,
+                // and '_initialPromptCells' is seeded from it - so the seed is the prompt's true cell
+                // width only when the prompt fitted the buffer it started on.
+                int entryWidth = bufferWidths[0];
+                int heldX = promptCells % entryWidth;
+                int heldY = promptCells / entryWidth;
+                initialXField.SetValue(instance, heldX);
+                initialYField.SetValue(instance, heldY);
+                initialPromptCellsField.SetValue(instance, heldX);
 
                 RenderData previousRender = new()
                 {
-                    lines = new[] { new RenderedLineData(line: "", isFirstLogicalLine: true) }
+                    lines = new[] { new RenderedLineData(line: input, isFirstLogicalLine: true) }
                 };
 
-                foreach (int bufferWidth in bufferWidths)
+                for (int i = 1; i < bufferWidths.Length; i++)
                 {
+                    int bufferWidth = bufferWidths[i];
                     TestConsole console = new(_, bufferWidth, bufferHeight);
                     consoleField.SetValue(instance, console);
 
-                    previousRender.initialY = (int)initialYField.GetValue(instance);
+                    // Where the reflow left the anchor, and hence where it left the cursor.
+                    int expectedX = promptCells % bufferWidth;
+                    int expectedY = promptCells / bufferWidth;
+                    initialXField.SetValue(instance, expectedX);
+                    initialYField.SetValue(instance, expectedY);
+                    Point cursor = instance.ConvertOffsetToPoint(cursorOffset);
+                    console.CursorLeft = cursor.X;
+                    console.CursorTop = cursor.Y;
+
+                    // The coordinates PSReadLine actually holds are the ones from the previous width.
+                    initialXField.SetValue(instance, heldX);
+                    initialYField.SetValue(instance, heldY);
+                    previousRender.initialY = heldY;
                     previousRenderField.SetValue(instance, previousRender);
                     handlePotentialResizingField.SetValue(instance, true);
 
                     recomputeInitialCoords.Invoke(instance, new object[] { true });
 
-                    int initialX = (int)initialXField.GetValue(instance);
+                    heldX = (int)initialXField.GetValue(instance);
+                    heldY = (int)initialYField.GetValue(instance);
                     Assert.True(
-                        promptCells % bufferWidth == initialX,
-                        $"buffer width {bufferWidth}: initial column is {initialX} but should be {promptCells % bufferWidth}");
+                        expectedX == heldX && expectedY == heldY,
+                        $"prompt of {promptCells} cells, buffer width {bufferWidth}: the anchor was " +
+                        $"recovered at ({heldX}, {heldY}) but the reflow left it at ({expectedX}, {expectedY})");
 
                     // The render data now describes the buffer as it was before the next change.
                     previousRender.UpdateConsoleInfo(console);
@@ -261,6 +299,207 @@ namespace Test
                 consoleField.SetValue(instance, savedConsole);
                 bufferField.SetValue(instance, savedBuffer);
                 currentField.SetValue(instance, savedCurrent);
+                initialXField.SetValue(instance, savedInitialX);
+                initialYField.SetValue(instance, savedInitialY);
+                initialPromptCellsField.SetValue(instance, savedInitialPromptCells);
+                previousRenderField.SetValue(instance, savedPreviousRender);
+            }
+        }
+
+        [Fact]
+        public void RecomputeInitialCoords_ShouldRecoverInitialXWhenBufferGetsWider()
+        {
+            // The column of the anchor is the width of the prompt reduced modulo the buffer width, so
+            // a prompt of 36 cells walked through the buffer widths below has to give 36, 1, 36, 11
+            // and 36 in turn. Reducing the column in place on each change gives the right answer only
+            // for the first one, because it discards how many physical lines the prompt spans and the
+            // column can then no longer be recovered.
+            AssertAnchorIsRecoveredAcrossWidths(
+                promptCells: 36,
+                input: "",
+                cursorOffset: 0,
+                bufferWidths: new[] { 100, 35, 60, 25, 100 });
+        }
+
+        [Fact]
+        public void RecomputeInitialCoords_ShouldRecoverInitialXWhenThePromptDidNotFitTheInitialBuffer()
+        {
+            // 'ReadLine' is entered on a buffer narrower than the prompt, so the column the console
+            // reports - and therefore everything derived from it - is already reduced: 82 % 62 == 20.
+            // No arithmetic on that 20 can produce 82 again. The cursor can, because the terminal
+            // reflowed the prompt and the cursor together and the input is empty, which puts the
+            // cursor on the anchor itself.
+            AssertAnchorIsRecoveredAcrossWidths(
+                promptCells: 82,
+                input: "",
+                cursorOffset: 0,
+                bufferWidths: new[] { 62, 82 });
+
+            // The same, then on to widths the prompt does and does not fit, in both directions.
+            AssertAnchorIsRecoveredAcrossWidths(
+                promptCells: 82,
+                input: "",
+                cursorOffset: 0,
+                bufferWidths: new[] { 62, 100, 70, 120, 62 });
+        }
+
+        [Fact]
+        public void RecomputeInitialCoords_ShouldRecoverInitialXWithTextOnTheInputLine()
+        {
+            // The cursor is no longer on the anchor, so recovering the anchor means subtracting the
+            // rendering of the input from it.
+            AssertAnchorIsRecoveredAcrossWidths(
+                promptCells: 82,
+                input: "Get-ChildItem",
+                cursorOffset: 13,
+                bufferWidths: new[] { 62, 82 });
+
+            // Narrow to wide, with an input long enough to wrap at every width in the chain.
+            AssertAnchorIsRecoveredAcrossWidths(
+                promptCells: 82,
+                input: "Get-ChildItem -Path . -Recurse | Where-Object { $_.Length -gt 1024 }",
+                cursorOffset: 67,
+                bufferWidths: new[] { 62, 100, 130 });
+
+            // Wide to narrow, and with the cursor inside the input rather than at its end.
+            AssertAnchorIsRecoveredAcrossWidths(
+                promptCells: 36,
+                input: "Get-ChildItem -Path . -Recurse | Where-Object { $_.Length -gt 1024 }",
+                cursorOffset: 30,
+                bufferWidths: new[] { 120, 60, 40 });
+        }
+
+        [Fact]
+        public void RecomputeInitialCoords_ShouldKeepWorkingWhenThePromptFitsTheBuffer()
+        {
+            // The prompt fitted the buffer 'ReadLine' was entered on, so the belief about its cell
+            // width was never damaged and the cursor has to agree with it at every width.
+            AssertAnchorIsRecoveredAcrossWidths(
+                promptCells: 12,
+                input: "",
+                cursorOffset: 0,
+                bufferWidths: new[] { 80, 40, 120, 20, 80 });
+
+            AssertAnchorIsRecoveredAcrossWidths(
+                promptCells: 12,
+                input: "Get-ChildItem -Path .",
+                cursorOffset: 21,
+                bufferWidths: new[] { 80, 40, 120, 20, 80 });
+        }
+
+        [Fact]
+        public void RecomputeInitialCoords_ShouldRecoverInitialXWithAMultiLineInput()
+        {
+            // A newline moves the rendering to the continuation prompt's column no matter where the
+            // anchor is, so past one the cursor says nothing about the anchor's column: taking the
+            // cursor's own column as the offset to subtract would put the anchor at column 0 and draw
+            // the first logical line over the prompt. The belief about the prompt's cell width is the
+            // answer here, and the cursor must be read as agreeing with it rather than replacing it.
+            AssertAnchorIsRecoveredAcrossWidths(
+                promptCells: 30,
+                input: "Get-ChildItem |\nForEach-Object { $_.Name }",
+                cursorOffset: 41,
+                bufferWidths: new[] { 80, 60, 25, 100 });
+
+            // With the cursor still on the first logical line, where the column is observable again.
+            AssertAnchorIsRecoveredAcrossWidths(
+                promptCells: 30,
+                input: "Get-ChildItem |\nForEach-Object { $_.Name }",
+                cursorOffset: 10,
+                bufferWidths: new[] { 80, 60, 25, 100 });
+        }
+
+        [Fact]
+        public void RecomputeInitialCoords_ShouldRecoverInitialXFromRenderDataWhenTheInputChanged()
+        {
+            // The other half of 'RecomputeInitialCoords': the input has changed since it was last
+            // rendered - 'Escape' cleared it after the resize, say - so the anchor has to be recovered
+            // from the previous rendering rather than from '_buffer' and '_current'.
+            const int promptCells = 82;
+            const int entryWidth = 62;
+            const int newWidth = 82;
+            const int bufferHeight = 200;
+            const string rendered = "Get-ChildItem -Path . -Recurse";
+
+            PSConsoleReadLine instance = GetPSConsoleReadLineSingleton();
+            FieldInfo consoleField = GetInstanceField("_console");
+            FieldInfo bufferField = GetInstanceField("_buffer");
+            FieldInfo currentField = GetInstanceField("_current");
+            FieldInfo initialXField = GetInstanceField("_initialX");
+            FieldInfo initialYField = GetInstanceField("_initialY");
+            FieldInfo initialPromptCellsField = GetInstanceField("_initialPromptCells");
+            FieldInfo previousRenderField = GetInstanceField("_previousRender");
+            FieldInfo handlePotentialResizingField = GetInstanceField("_handlePotentialResizing");
+            MethodInfo recomputeInitialCoords = typeof(PSConsoleReadLine)
+                .GetMethod("RecomputeInitialCoords", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            object savedConsole = consoleField.GetValue(instance);
+            object savedBuffer = bufferField.GetValue(instance);
+            object savedCurrent = currentField.GetValue(instance);
+            object savedInitialX = initialXField.GetValue(instance);
+            object savedInitialY = initialYField.GetValue(instance);
+            object savedInitialPromptCells = initialPromptCellsField.GetValue(instance);
+            object savedPreviousRender = previousRenderField.GetValue(instance);
+
+            try
+            {
+                int heldX = promptCells % entryWidth;
+                int heldY = promptCells / entryWidth;
+
+                // The input was cleared after the resize, which is what makes this the other branch.
+                bufferField.SetValue(instance, new StringBuilder());
+                currentField.SetValue(instance, 0);
+                initialXField.SetValue(instance, heldX);
+                initialYField.SetValue(instance, heldY);
+                initialPromptCellsField.SetValue(instance, heldX);
+
+                // The rendering as it stood at the entry width, with the cursor at the end of it.
+                RenderData previousRender = new()
+                {
+                    lines = new[] { new RenderedLineData(rendered, isFirstLogicalLine: true) },
+                    bufferWidth = entryWidth,
+                    bufferHeight = bufferHeight,
+                    initialY = heldY,
+                };
+                Point oldCursor = instance.ConvertRenderDataOffsetToPoint(
+                    heldX, heldY, entryWidth, previousRender, new RenderDataOffset(0, int.MaxValue));
+                previousRender.cursorLeft = oldCursor.X;
+                previousRender.cursorTop = oldCursor.Y;
+                previousRenderField.SetValue(instance, previousRender);
+
+                // Where the reflow left the anchor, and the cursor that follows from it.
+                int expectedX = promptCells % newWidth;
+                int expectedY = promptCells / newWidth;
+                RenderDataOffset offset = instance.ConvertPointToRenderDataOffset(heldX, heldY, previousRender);
+                Assert.NotEqual(-1, offset.LogicalLineIndex);
+                Point newCursor = instance.ConvertRenderDataOffsetToPoint(
+                    expectedX, expectedY, newWidth, previousRender, offset);
+
+                TestConsole console = new(_, newWidth, bufferHeight)
+                {
+                    CursorLeft = newCursor.X,
+                    CursorTop = newCursor.Y,
+                };
+                consoleField.SetValue(instance, console);
+                handlePotentialResizingField.SetValue(instance, true);
+
+                recomputeInitialCoords.Invoke(instance, new object[] { false });
+
+                int initialX = (int)initialXField.GetValue(instance);
+                int initialY = (int)initialYField.GetValue(instance);
+                Assert.True(
+                    expectedX == initialX && expectedY == initialY,
+                    $"buffer width {newWidth}: the anchor was recovered at ({initialX}, {initialY}) " +
+                    $"but the reflow left it at ({expectedX}, {expectedY})");
+            }
+            finally
+            {
+                consoleField.SetValue(instance, savedConsole);
+                bufferField.SetValue(instance, savedBuffer);
+                currentField.SetValue(instance, savedCurrent);
+                initialXField.SetValue(instance, savedInitialX);
+                initialYField.SetValue(instance, savedInitialY);
+                initialPromptCellsField.SetValue(instance, savedInitialPromptCells);
                 previousRenderField.SetValue(instance, savedPreviousRender);
             }
         }


### PR DESCRIPTION
# PR Summary

When the terminal is made narrower than the prompt and then wider again, PSReadLine
draws the input on top of the prompt and leaves the text it drew at the narrow width
behind on the screen. The edit anchor is never restored for the rest of that
`ReadLine` call, so every subsequent keystroke re-renders in the wrong column.

This changes `RecomputeInitialCoords` to stop reducing the anchor's column in place
and to recover it from the physical cursor instead.

Two commits:

1. **Fix the input anchor column when the buffer is narrowed and then widened.**
   Derive the column from `_initialPromptCells`, a width-independent quantity, rather
   than reducing `_initialX` modulo the new width.
2. **Recover the edit anchor from the cursor when the buffer width changes.**
   `_initialPromptCells` is itself seeded from a column the console reported, so it is
   already reduced whenever `ReadLine` starts on a buffer narrower than the prompt.
   The cursor is the only observation that survives a reflow, so the anchor is taken
   to be the column that would put the cursor where the console says it is, with the
   derived column demoted to a starting point and a fallback.

The second commit supersedes the modulo arithmetic introduced by the first for the
cases the cursor can speak to, and keeps it for the cases it cannot.

## Repro

```powershell
# 36 cells wide
function prompt { 'PSRL-ANCHOR-PROBE-0123456789012345> ' }
```

1. Size the window to 100 columns and press <kbd>Enter</kbd> to get a fresh prompt.
2. Type something -- for example `Get-ChildItem -Recurse -Filter *.rs | Select-Object FullName` -- and do *not* press <kbd>Enter</kbd>.
3. Narrow the window to 35 columns, which is narrower than the prompt, and type one character.
   The input wraps onto the following rows and is rendered correctly.
4. Widen the window back to 100 columns and type one more character.

Expected: the input is rendered starting at column 36, right after the prompt.

Actual: the input is rendered starting at column 1, over the prompt:

Screen after step 4, on 2.4.5:

```
PGet-ChildItem -Recurse -Filter *.rs | Select-Object FullNameXY
 Get-ChildItem -Recurse -Filter *.r
s | Select-Object FullNameX
```

and with this change:

```
PSRL-ANCHOR-PROBE-0123456789012345> Get-ChildItem -Recurse -Filter *.rs | Select-Object FullNameXY
 Get-ChildItem -Recurse -Filter *.r
s | Select-Object FullNameX
```

Rows 2 and 3 are what was drawn while the window was narrow. They are not cleaned up
in either case -- the prompt on row 1 is what this change is about.

## Root cause

`RecomputeInitialCoords` recovers the anchor column after a buffer width change with
a single statement, in both of its branches:

- [`Render.cs#L1261`](https://github.com/PowerShell/PSReadLine/blob/2984546f62da9f63c31aba965ec3008fcb107024/PSReadLine/Render.cs#L1261) (`isTextBufferUnchanged: true`)
- [`Render.cs#L1297`](https://github.com/PowerShell/PSReadLine/blob/2984546f62da9f63c31aba965ec3008fcb107024/PSReadLine/Render.cs#L1297) (`isTextBufferUnchanged: false`)

```csharp
// Recompute X from the buffer width:
_initialX %= _console.BufferWidth;
```

`_initialX` is the anchor's column *at the width that was in effect before the
resize*, so it already is the prompt's cell width reduced modulo that width.
Reducing it a second time is correct the first time the buffer is narrowed past the
prompt, but it discards the quotient, and the quotient is the only record of how many
physical lines the prompt spans. Once it is gone the prompt's true width cannot be
reconstructed:

| step | buffer width | prompt cells | `_initialX` before | `_initialX` after | correct |
| --- | --- | --- | --- | --- | --- |
| start | 100 | 36 | -- | 36 | 36 |
| narrow | 35 | 36 | 36 | `36 % 35` = 1 | 1 |
| widen | 100 | 36 | 1 | `1 % 100` = 1 | 36 |

The statement dates back to b2979d1 ("Fix rendering after buffer resize", 2017) and is
present unchanged in every release from 2.0.0 through 2.4.5.

## The first fix: keep the width-independent quantity

`_initialPromptCells` is the cell width of the prompt's last logical line, measured
from column 0 of the physical line where that logical line starts. It is captured
wherever the anchor is captured -- input initialization in `ReadLine.cs`,
`InvokePrompt`, and the two prompt-reprint recovery paths in `Render.cs` -- and is
never modified afterwards. `_initialX` is then derived from it on every buffer width
change:

```csharp
_initialX = _initialPromptCells % _console.BufferWidth;
```

While the prompt fits in the buffer, `_initialPromptCells == _initialX` and the new
expression is the identity, so nothing changes for the common case.

## A second defect the first fix missed

`_initialPromptCells` is seeded from `_initialX`, which is the column the console
reported when `ReadLine` started. That column is the prompt's cell width *already
reduced* modulo the width in effect at the time. So when `ReadLine` starts on a buffer
narrower than the prompt, the seed is not the prompt's width but the reduced column,
and the derivation above reproduces the reduced column forever:

| | prompt cells | buffer width | `_initialPromptCells` | derived column | correct |
| --- | --- | --- | --- | --- | --- |
| `ReadLine` starts | 82 | 62 | `82 % 62` = 20 | -- | 20 |
| widen | 82 | 82 | 20 | `20 % 82` = 20 | 82 |

This is the case listed as not covered in the first version of this PR. It turns out to
be reachable without the terminal ever being resized by hand -- opening a split pane, a
preview pane, or any window that starts narrow puts `ReadLine` on a buffer narrower
than the prompt -- and its symptom does not look like a resize bug, because nothing
renders while the input is empty.

### Recipe

A prompt of 82 cells, `ReadLine` entered at a buffer width of 62, widened to 82, then
one history entry of 36 characters recalled with <kbd>Up</kbd> and blanked with
<kbd>Down</kbd>. No further resize and no typing.

The first render of the recalled entry starts at column 20 instead of column 82, and
<kbd>Down</kbd> then blanks exactly that span, carving a hole out of the middle of the
prompt with its head and tail intact:

```
first commit only  PPPPPPPPPPPPPPPPPPPP                                    PPPPPPPPPPPPPPPPPPPPPPPPPP
both commits       PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP
```

and the emitted sequences say the same thing -- `CUP` to row 3 column 21 versus `CUP`
to row 3 column 82:

```
first commit only  ESC[A  ESC[6n ESC[3;82H ESC[?25l ESC[3;21H ESC[93m SSSS...(36) ESC[3;57H ESC[?25h
both commits       ESC[A  ESC[6n ESC[3;82H ESC[?25l ESC[3;82H ESC[93m SSSS...(36) ESC[4;36H ESC[?25h
```

### The second fix: recover the anchor from the cursor

The anchor is not observable after a resize -- the terminal reflowed the screen and
reported nothing about where it moved the prompt to -- but the cursor is, and the
terminal moved the two together. So the anchor is taken to be at the column that would
put the cursor where the console says the cursor is, and at the row that many physical
lines above the cursor's.

```csharp
private void RecomputeInitialCoordsFromCursor(Func<int, Point> cursorPointFrom)
```

`cursorPointFrom` is where the cursor would be drawn if the anchor were at the given
column of line 0, which is what the two branches of `RecomputeInitialCoords` already
computed: `ConvertOffsetToPoint(_current)` when the text buffer still describes what is
on the screen, and `ConvertRenderDataOffsetToPoint(...)` when it does not.

With an empty input this makes the anchor the cursor itself, which is exactly what
capturing the initial coordinates would have given had `ReadLine` been entered at the
new width -- including the case above, which no arithmetic on `_initialX` can recover.
The assumption that the cursor still points at the same character of the input after a
reflow is the one `_initialY` is already recovered from today.

### The multi-line pitfall that shaped it

The cursor does not always tell the columns apart, and reading it as an unconditional
answer is worse than the defect it fixes.

A newline in the input moves the rendering to the continuation prompt's column no
matter where the anchor is: `ConvertOffsetToPoint` resets the column at every logical
line break, so once the cursor is past one, *every* candidate column produces the same
cursor point. Measuring the offset from column 0 and subtracting it from the cursor
therefore yields column 0 for any multi-line input, on every resize -- the same
overwritten prompt this PR is about, newly inflicted on prompts that always fitted the
buffer. Separately, a double width character pushed whole onto the next physical line
leaves a cell of slack, so two neighbouring columns can agree with the cursor.

So the column derived from `_initialPromptCells` is where the search starts and is the
answer whenever the cursor agrees with it; only when the cursor disagrees does the
search step outward for the nearest column that agrees, and if none does, the derived
column stands. A candidate that would place the cursor above the anchor is rejected,
since that is not a state `ReadLine` can be in. This makes the second commit a
refinement of the first rather than a replacement for it, and leaves every input the
cursor says nothing about rendering exactly as it does today.

`_initialPromptCells` is deliberately left as it is once the anchor is known. What it
holds over `_initialX` is how many physical lines the prompt spans at the width it was
captured at, which the cursor never reveals, so rewriting it from a column observed at
a different width would mix two units.

## Behavior boundaries

- **Narrowing is unchanged.** For the first width change the old and new expressions
  are equal by definition, and for later ones the new expression is what the old one
  was trying to compute.
- **Widening now restores the anchor**, including across several successive resizes
  (100 -> 35 -> 60 -> 25 -> 100 was measured).
- **A prompt already wider than the buffer when `ReadLine` was entered is now covered**
  as long as the cursor can distinguish the column, which it can whenever the cursor is
  on the first logical line of the input. It is not covered for a cursor past a
  newline, where every column agrees with the cursor and the derived column, still
  reduced, is the best available answer.
- **A prompt that exactly fills a physical line** leaves one cell of residual error:
  the console reports a wrap-pending cursor at the last column rather than at column 0
  of the next line, and the Console API does not expose the wrap-pending bit. That is
  the same reading `ReadLine` makes when it captures the initial coordinates in the
  first place, so the recovered anchor has exactly the fidelity a fresh `ReadLine` at
  the new width would have had.

## Verification

### Unit tests

Six tests in `test/ResizingTest.cs`, five of them added by the second commit. They
drive `RecomputeInitialCoords` directly across a chain of buffer widths, setting the
test console's cursor at each width to where a terminal that reflowed the screen would
report it, and assert the recovered anchor against where the reflow left it:

| test | covers |
| --- | --- |
| `..._ShouldRecoverInitialXWhenBufferGetsWider` | 36-cell prompt over 100, 35, 60, 25, 100 |
| `..._ShouldRecoverInitialXWhenThePromptDidNotFitTheInitialBuffer` | 82-cell prompt entered at 62, then widened |
| `..._ShouldRecoverInitialXWithTextOnTheInputLine` | the same with the cursor off the anchor, both directions |
| `..._ShouldKeepWorkingWhenThePromptFitsTheBuffer` | a prompt that always fitted, empty and non-empty |
| `..._ShouldRecoverInitialXWithAMultiLineInput` | the column-0 overshoot described above |
| `..._ShouldRecoverInitialXFromRenderDataWhenTheInputChanged` | the `isTextBufferUnchanged: false` branch |

The rendering the tests place the cursor from is the forward direction of the
calculation under test, which makes them a test of the inverse -- given a rendering and
where it ended up on the screen, where does the anchor have to be -- rather than a
restatement of it.

Three of the six fail on the first commit alone. The multi-line one fails on a version
of the second commit that reads the cursor without checking it against the derived
column, which is what put the check there.

Full suite on this branch (`./build.ps1 -Test -Configuration Release`, net8.0):

```
xUnitTestResults.en-US.xml          total=298 passed=296 failed=0 skipped=2
xUnitTestResults.screen-reader.xml  total=298 passed=16  failed=0 skipped=282
```

Only the en-US layout is installed on my machine, so the rest of the layout-gated
`SkippableFact`s are skipped here; CI covers those.

### Against a real terminal

The unit tests cannot show that PSReadLine then renders where it says it will, so both
commits were also measured end to end through a ConPTY pseudoconsole, on Windows 11
26200.

For the first commit, a probe writes keys, resizes the pseudoconsole, and parses the
emitted `CUP` sequences to read back the column PSReadLine actually renders at. Prompt
= 36 cells, input = 60 characters. The last column is the first commit applied on top of
the v2.4.5 tag, so that it could be loaded next to the shipped module for a like-for-like
comparison. Each case starts at the first width listed, resizes as listed, and types one
character at each width.

| case | widths | 5.1 + 2.0.0 | 7.6.4 + 2.4.5 | 7.6.4 + first commit |
| --- | --- | --- | --- | --- |
| prompt wider than the narrowed buffer, then restored | 100, 35, 100 | FAIL | FAIL | PASS |
| prompt spans 2 rows while narrow | 100, 20, 100 | FAIL | FAIL | PASS |
| prompt spans 4 rows while narrow | 100, 10, 100 | FAIL | FAIL | PASS |
| prompt still fits after narrowing (sanity) | 100, 50, 100 | PASS | PASS | PASS |
| several successive resizes | 100, 35, 60, 25, 100 | FAIL | FAIL | PASS |
| short prompt, never wraps (sanity) | 100, 35, 100 | PASS | PASS | PASS |
| prompt already wrapped when `ReadLine` started | 30, 100 | FAIL | FAIL | FAIL |
| | | **2 / 7** | **2 / 7** | **6 / 7** |

Windows PowerShell 5.1 with 2.4.5 side-loaded measures the same as the two baseline
columns. The last row is the second defect above, and is what the second commit
addresses.

For the second commit, the recipe under "A second defect the first fix missed" was run
against a real `pwsh.exe` over ConPTY, five runs per arm, comparing the child's own
console text buffer read back through the console API rather than the emitted sequences:

```
first commit only     the prompt is carved  5 / 5
both commits          the prompt is carved  0 / 5
```

The instrumented recovery, one line per call:

```
enter unchanged=False handle=True initial=(20,4) promptCells=20 cursor=(81,2) buf=82x20 prev=62x20 bufferLen=36 current=36
  fromCursor width=82 cursor=(81,2) believedX=20 believedPt=(20,0) -> (81,2)
```

One cell of the prompt's trailing space is still blanked, which is the wrap-pending
reading described under "Behavior boundaries" -- one cell, against 36 carved cells
before.

### Editing regression matrix

Fourteen resize-then-edit scenarios (type, repeated type, `Escape`, `Backspace`,
`Home`, `Home` then type, `LeftArrow` then type, `UpArrow`, multi-line input; each
narrowing and widening; short and medium prompts) were run against official 2.4.5 and
against the patched build. The two transcripts -- render columns, cursor moves, and
final screen contents -- are **identical byte for byte**, including the three
scenarios that already drifted before this change (`LeftArrow` then type, and the two
multi-line cases). Those three are separate pre-existing problems and are untouched
here.

## Relationship to #3074

[#3074](https://github.com/PowerShell/PSReadLine/pull/3074) (f46f15d, first released in
v2.2.0-beta5) rewrote `RecomputeInitialCoords` around the render data, and fixed the
cases where the *text buffer* had changed across the resize. It carried this statement
forward unchanged -- it only reformatted `_initialX = _initialX % ...` to `_initialX
%= ...` and duplicated it into the new `else` branch -- so the anchor column has had
the same defect before and after that work. That is consistent with 2.0.0 and 2.4.5
measuring identically in the table above.

## Remaining work

The prompt string itself is available in `InvokePrompt` and in the prompt-reprint
recovery paths, so `_initialPromptCells` could be measured there directly instead of
being seeded from `_initialX`. That would make the derived column correct on those two
entry paths even where the cursor cannot distinguish it, and would leave only the normal
entry path relying on the cursor. It is not folded in here because it would make the
field mean one thing on some paths and another on the rest; happy to add it if you would
like it handled in this PR.

## Notes

Found while building a terminal on Windows, where this was reproducible against the
inbox PSReadLine 2.0.0 as well as current 2.4.5. The second defect surfaced there as a
history recall carving a hole in the prompt with no resize in sight, which is why the
recipe above is written in terms of <kbd>Up</kbd> and <kbd>Down</kbd> rather than a
window drag.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
    - Measured through a ConPTY pseudoconsole, which is the path Windows Terminal and
      the VS Code integrated terminal take, on both Windows PowerShell 5.1 and pwsh
      7.6.4. I have not measured on macOS or Linux; the change reads `CursorLeft`,
      `CursorTop` and `BufferWidth` and has no platform-specific part.
- **User-facing changes**
    - [x] Not Applicable

Related to #3637
