### PR TITLE
Correct the `ViBackwardWord` description and fix a typo

### DIFF
--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -1826,7 +1826,7 @@ namespace Microsoft.PowerShell.PSReadLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Repace the current line with the next set of characters typed..
+        ///   Looks up a localized string similar to Replace the current line with the next set of characters typed..
         /// </summary>
         internal static string ViReplaceLineDescription {
             get {

--- a/PSReadLine/PSReadLineResources.Designer.cs
+++ b/PSReadLine/PSReadLineResources.Designer.cs
@@ -1574,7 +1574,7 @@ namespace Microsoft.PowerShell.PSReadLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete backward to the beginning of the previous word, as delimited by white space and common delimiters, and enter insert mode..
+        ///   Looks up a localized string similar to Move the cursor to the beginning of the current or previous word, as delimited by white space and common delimiters..
         /// </summary>
         internal static string ViBackwardWordDescription {
             get {

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -601,7 +601,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Replace the previous word.</value>
   </data>
   <data name="ViBackwardWordDescription" xml:space="preserve">
-    <value>Delete backward to the beginning of the previous word, as delimited by white space and common delimiters, and enter insert mode.</value>
+    <value>Move the cursor to the beginning of the current or previous word, as delimited by white space and common delimiters.</value>
   </data>
   <data name="ViBackwardCharDescription" xml:space="preserve">
     <value>Move the cursor back one character in the Vi edit mode.</value>

--- a/PSReadLine/PSReadLineResources.resx
+++ b/PSReadLine/PSReadLineResources.resx
@@ -553,7 +553,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Replace the current character with only one character.</value>
   </data>
   <data name="ViReplaceLineDescription" xml:space="preserve">
-    <value>Repace the current line with the next set of characters typed.</value>
+    <value>Replace the current line with the next set of characters typed.</value>
   </data>
   <data name="ViReplaceToEndDescription" xml:space="preserve">
     <value>Replace the characters from the cursor position to the end of the line.</value>


### PR DESCRIPTION
# PR Summary

Fix the incorrect key handler description for `ViBackwardWord` so `Get-PSReadLineKeyHandler` accurately reports that it moves the cursor to the beginning of the current or previous word, and correct a typo in the `ViReplaceLine` description.

The existing embedded resource incorrectly says that `ViBackwardWord` deletes text and enters insert mode. This updates both the resource value and its generated designer comment to match the command's actual behavior.

Additionally, the `ViReplaceLine` description misspells "Replace" as "Repace". This corrects the resource value and its generated designer comment.

Validation:
- Parsed `PSReadLineResources.resx` successfully as XML.
- Verified that the resource values and generated designer comments agree.
- Ran `git diff --check`.
- Built the Debug module successfully with .NET SDK 8.0.415 (3 tasks, 0 errors, 0 warnings).
- Imported the built module in a clean PowerShell process and verified that `<b>` resolves to `ViBackwardWord` with the corrected description.
- Verified that `<S>` and `<c,c>` resolve to `ViReplaceLine` with the corrected description.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed:
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/5199)
