### PR TITLE
Don't warn about the list view window size from `Get-PSReadLineOption`

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -634,9 +634,7 @@ namespace Microsoft.PowerShell
         [ExcludeFromCodeCoverage]
         protected override void EndProcessing()
         {
-            var options = PSConsoleReadLine.GetOptions();
-            WriteObject(options);
-            PSConsoleReadLine.WarnWhenWindowSizeTooSmallForView(options.PredictionViewStyle, this);
+            WriteObject(PSConsoleReadLine.GetOptions());
         }
     }
 

--- a/test/ListPredictionTest.cs
+++ b/test/ListPredictionTest.cs
@@ -9,7 +9,7 @@ namespace Test
         // The source of truth is defined in 'Microsoft.PowerShell.PSConsoleReadLine+PredictionListView'.
         // Make sure the values are in sync.
         private const int MinWindowWidth = 50;
-        private const int MinWindowHeight = 15;
+        private const int MinWindowHeight = 5;
         private const int ListMaxWidth = 100;
         private const int SourceMaxWidth = 15;
 

--- a/test/ListScrollableViewTest.cs
+++ b/test/ListScrollableViewTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Management.Automation.Runspaces;
 using Microsoft.PowerShell;
 using Xunit;
 
@@ -909,6 +910,32 @@ namespace Test
                         NextLine,
                         NextLine))
             ));
+        }
+
+        [SkippableFact]
+        public void ListView_TermSize_WarningOnlyFromSetOption()
+        {
+            Skip.If(ScreenReaderModeEnabled, "List view is not supported in screen reader mode.");
+
+            // The console is under the list view minimum. 'F2' switches the view without
+            // 'Set-PSReadLineOption', so the two cmdlets can be measured separately.
+            TestSetup(new TestConsole(keyboardLayout: _, width: 40, height: 4), KeyMode.Cmd);
+            using var disp = SetPrediction(PredictionSource.History, PredictionViewStyle.InlineView);
+            Test("", Keys(_.F2, _.Enter));
+
+            var iss = InitialSessionState.CreateDefault();
+            iss.Commands.Add(new SessionStateCmdletEntry("Get-PSReadLineOption", typeof(GetPSReadLineOption), helpFileName: null));
+            iss.Commands.Add(new SessionStateCmdletEntry("Set-PSReadLineOption", typeof(SetPSReadLineOption), helpFileName: null));
+            using var ps = System.Management.Automation.PowerShell.Create(iss);
+
+            var result = ps.AddCommand("Get-PSReadLineOption").Invoke();
+            var options = Assert.IsType<PSConsoleReadLineOptions>(Assert.Single(result).BaseObject);
+            Assert.Equal(PredictionViewStyle.ListView, options.PredictionViewStyle);
+            Assert.Empty(ps.Streams.Warning);
+
+            ps.Commands.Clear();
+            ps.AddCommand("Set-PSReadLineOption").AddParameter("PredictionViewStyle", PredictionViewStyle.ListView).Invoke();
+            Assert.Single(ps.Streams.Warning);
         }
     }
 }


### PR DESCRIPTION
# PR Summary

Fixes #5205.

`Get-PSReadLineOption` writes the "prediction 'ListView' is temporarily disabled" warning on every call, as long as `ListView` is the active view style and the window is under 50x5. Two things follow from that:

- Any caller triggers it, not only the person who chose `ListView`. In practice that caller is a prompt module - oh-my-posh reads the options once when its module loads - so the warning turns up on shell start in an editor terminal that is still below the threshold at that moment, and the user who configured `ListView` has no way to suppress a warning raised from someone else's code.
- The same information is already delivered where it is actionable. `Set-PSReadLineOption -PredictionViewStyle ListView` warns at the point the user opts in, and the view itself renders `! terminal size too small to show the list view` inline while typing.

The call has been in `GetPSReadLineOption.EndProcessing` since `ListView` was added in #1909, so this changes long-standing behaviour on purpose. `Set-PSReadLineOption` is untouched, and the new test pins both halves so neither can drift.

#5205 offered warning once per session as an alternative - happy to switch to that instead. The `PredictionSource = None` case noted there is unchanged and can be a separate follow-up.

The second commit is a drive-by in the same area: #3583 lowered `PredictionListView.MinWindowHeight` from 15 to 5 and updated the mirrored `MinWindowWidth` in the tests, but left `MinWindowHeight` at 15, despite the comment above it asking for the two to stay in sync. Happy to drop that commit to keep this PR to one thing.

## Verification

`./build.ps1 -Configuration Release` then `./build.ps1 -Test -Configuration Release`, both with 0 errors and 0 warnings:

| test pass | total | passed | failed | skipped |
| --- | --- | --- | --- | --- |
| en-US | 293 | 291 | 0 | 2 |
| screen-reader | 293 | 10 | 0 | 283 |

Restoring the removed line makes the new test fail with `Assert.Empty() Failure: Collection was not empty`.

The built module loaded into a 49x20 console:

| | conhost.exe | Windows Terminal |
| --- | --- | --- |
| `Set-PSReadLineOption -PredictionViewStyle ListView` | 1 warning | 1 warning |
| `Get-PSReadLineOption` | none | none |

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
        - The warning is not documented: neither `Get-PSReadLineOption`, the `-PredictionViewStyle` description on `Set-PSReadLineOption`, nor `about_PSReadLine` mentions it or the minimum window size.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/5206)